### PR TITLE
Adding ability to pass listening address via command line argument

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ var express = require("express")
   , path = require('path')
   , mongoose = require('mongoose')
   , fs = require('fs-extra')
+  , util = require('util')
   , config = require('./config.json')
   , log = require('./logger')
   , provision = require('./provision');
@@ -109,7 +110,7 @@ require('./routes')(app, {authentication: authentication, provisioning: provisio
 var port = argv.port;
 var address = argv.address;
 app.listen(port, address);
-log.info('MAGE Server: Started listening on port ' + port);
+log.info(util.format('MAGE Server: Started listening at address %s on port %s', address, port));
 
 // install all plugins
 require('./plugins');

--- a/app.js
+++ b/app.js
@@ -20,9 +20,11 @@ mongoose.Error.messages.general.required = "{PATH} is required.";
 log.info('Starting mage');
 
 var optimist = require("optimist")
-  .usage("Usage: $0 --port [number]")
+  .usage("Usage: $0 --port [number] --address [string]")
   .describe('port', 'Port number that MAGE node server will run on.')
-  .default('port', 4242);
+  .describe('address', 'Address / network interface to listen on')
+  .default('port', 4242)
+  .default('address', '0.0.0.0');
 var argv = optimist.argv;
 if (argv.h || argv.help) return optimist.showHelp();
 
@@ -105,7 +107,8 @@ require('./routes')(app, {authentication: authentication, provisioning: provisio
 
 // Launches the Node.js Express Server
 var port = argv.port;
-app.listen(port);
+var address = argv.address;
+app.listen(port, address);
 log.info('MAGE Server: Started listening on port ' + port);
 
 // install all plugins


### PR DESCRIPTION
This is a proposed solution to issue #3 .  It allows the listening address to be passed as a command line argument to the `node app.js` command invocation.

Example:

```
node app.js --address 0.0.0.0
```

I set the default at `0.0.0.0`, thought we may want to consider `127.0.0.1` for security purposes.
