### PR TITLE
Fixing misspelling of 'initial'

### DIFF
--- a/migrations/001-create-device.js
+++ b/migrations/001-create-device.js
@@ -12,7 +12,7 @@ var defaultDescription = 'Initial device for web console';
 exports.id = 'create-initial-device';
 
 exports.up = function(done) {
-  console.log('\nCreating intial device uid...');
+  console.log('\nCreating initial device uid...');
 
   async.series({
       uid: function(done) {


### PR DESCRIPTION
As per issue #6 'intial' is a misspelling.  This PR fixes the spelling.
