### PR TITLE
Make MAGE ready for CloudFoundry (PaaS) deployment

### DIFF
--- a/api/attachment.js
+++ b/api/attachment.js
@@ -10,7 +10,7 @@ var ObservationModel = require('../models/observation')
   , geometryFormat = require('../format/geoJsonFormat');
 
 var attachmentConfig = config.server.attachment;
-var attachmentBase = attachmentConfig.baseDirectory;
+var attachmentBase = path.resolve(attachmentConfig.baseDirectory);
 
 var createAttachmentPath = function(event) {
   var now = new Date();

--- a/api/form.js
+++ b/api/form.js
@@ -12,7 +12,7 @@ var Event = require('../models/event')
   , access = require('../access')
   , config = require('../config.js');
 
-var iconBase = config.server.iconBaseDirectory;
+var iconBase = path.resolve(config.server.iconBaseDirectory);
 
 function Form(event) {
   this._event = event;

--- a/api/icon.js
+++ b/api/icon.js
@@ -9,7 +9,7 @@ var IconModel = require('../models/icon')
   , config = require('../config.js');
 
 var appRoot = path.dirname(require.main.filename);
-var iconBase = config.server.iconBaseDirectory;
+var iconBase = path.resolve(config.server.iconBaseDirectory);
 
 function Icon(eventId, type, variant) {
   this._eventId = eventId || null;

--- a/api/observation.js
+++ b/api/observation.js
@@ -5,7 +5,7 @@ var ObservationModel = require('../models/observation')
   , async = require('async')
   , config = require('../config.js');
 
-var attachmentBase = config.server.attachment.baseDirectory;
+var attachmentBase = path.resolve(config.server.attachment.baseDirectory);
 
 function Observation(event) {
   this._event = event;

--- a/api/user.js
+++ b/api/user.js
@@ -9,7 +9,7 @@ var UserModel = require('../models/user')
   , async = require('async')
   , config = require('../config.js');
 
-var userBase = config.server.userBaseDirectory;
+var userBase = path.resolve(config.server.userBaseDirectory);
 
 function contentPath(id, user, content, type) {
   var relativePath = path.join(id.toString(), type + path.extname(content.path));

--- a/app.js
+++ b/app.js
@@ -6,10 +6,12 @@ var express = require("express")
   , mongoose = require('mongoose')
   , fs = require('fs-extra')
   , util = require('util')
+  , cfenv = require('cfenv')
   , config = require('./config.js')
   , log = require('./logger')
   , provision = require('./provision');
 
+var appEnv = cfenv.getAppEnv();
 var mongooseLogger = log.loggers.get('mongoose');
 
 mongoose.set('debug', function(collection, method, query, doc, options) {
@@ -23,14 +25,12 @@ log.info('Starting mage');
 var optimist = require("optimist")
   .usage("Usage: $0 --port [number] --address [string]")
   .describe('port', 'Port number that MAGE node server will run on.')
-  .describe('address', 'Address / network interface to listen on')
-  .default('port', 4242)
-  .default('address', '0.0.0.0');
+  .describe('address', 'Address / network interface to listen on');
 var argv = optimist.argv;
 if (argv.h || argv.help) return optimist.showHelp();
 
 // Create directory for storing SAGE media attachments
-var attachmentBase = config.server.attachment.baseDirectory;
+var attachmentBase = path.resolve(config.server.attachment.baseDirectory);
 fs.mkdirp(attachmentBase, function(err) {
   if (err) {
     log.error("Could not create directory to store MAGE media attachments. "  + err);
@@ -40,7 +40,7 @@ fs.mkdirp(attachmentBase, function(err) {
   }
 });
 
-var iconBase = config.server.iconBaseDirectory;
+var iconBase = path.resolve(config.server.iconBaseDirectory);
 fs.mkdirp(iconBase, function(err) {
   if (err) {
     log.error("Could not create directory to store MAGE icons. "  + err);
@@ -51,24 +51,41 @@ fs.mkdirp(iconBase, function(err) {
 
 // Configuration of the MAGE Express server
 var app = express();
-var mongodbConfig = config.server.mongodb;
 
-var mongoUri = "mongodb://" + mongodbConfig.host + "/" + mongodbConfig.db;
-mongoose.connect(mongoUri, {server: {poolSize: mongodbConfig.poolSize}}, function(err) {
-  if (err) {
-    log.error('Error connecting to mongo database, please make sure mongodb is running...');
-    throw err;
+var mongoConfig = appEnv.getServiceCreds('MongoInstance');
+//Did we get a mongo config from the cloud configuration?
+if( mongoConfig ) {
+  var mongoUri = mongoConfig.uri;
+} else {
+  //otherwise use defaults in config
+  var mongodbConfig = config.server.mongodb;
+  var mongoUri = mongodbConfig.scheme + '://' + mongodbConfig.host +  ':' + mongodbConfig.port + '/' + mongodbConfig.db;
+}
+
+log.info('using mongodb connection from: ' + mongoUri);
+mongoose.connect(mongoUri, {server: {poolSize: config.server.mongodb.poolSize}});
+mongoose.connection.on('error', function() {
+  log.error('Error connecting to mongo database, please make sure mongodb is running...');
+  throw err;
+});
+
+var setup = require('./setup');
+setup(function(status) {
+  if( !status ) {
+    log.info('Unable to run setup on mongodb. Quitting MAGE...');
+    process.exit(2);
   }
+  log.info('Completed initial setup');
 });
 
 app.use(function(req, res, next) {
   req.getRoot = function() {
     return req.protocol + "://" + req.get('host');
-  }
+  };
 
   req.getPath = function() {
     return req.getRoot() + req.path;
-  }
+  };
 
   return next();
 });
@@ -81,7 +98,7 @@ app.set('view engine', 'jade');
 app.use(function(req, res, next) {
   req.getRoot = function() {
     return req.protocol + "://" + req.get('host');
-  }
+  };
   return next();
 });
 app.use(require('body-parser')({ keepExtensions: true}));
@@ -107,10 +124,11 @@ var authentication = require('./authentication')(app, passport, provisioning, co
 require('./routes')(app, {authentication: authentication, provisioning: provisioning});
 
 // Launches the Node.js Express Server
-var port = argv.port;
-var address = argv.address;
-app.listen(port, address);
-log.info(util.format('MAGE Server: Started listening at address %s on port %s', address, port));
+var port = argv.port || appEnv.port;
+var address = argv.address || appEnv.bind;
+app.listen(port, address, function() {
+    log.info(util.format('MAGE Server: Started listening at address %s on port %s', address, port));
+});
 
 // install all plugins
 require('./plugins');

--- a/config.js
+++ b/config.js
@@ -30,12 +30,13 @@ module.exports = {
     }
   },
   server: {
-    "userBaseDirectory": "/var/lib/mage/users",
-    "iconBaseDirectory": "/var/lib/mage/icons",
+    "userBaseDirectory": "mage/users",
+    "iconBaseDirectory": "mage/icons",
     "token": {
       "expiration": 28800
     },
     "mongodb": {
+      "scheme": 'mongodb',
       "host": "localhost",
       "port": 27017,
       "db": "magedb",
@@ -46,7 +47,63 @@ module.exports = {
       "userCollectionLocationLimit": 100
     },
     "attachment": {
-      "baseDirectory": "/var/lib/mage/attachments"
+      "baseDirectory": "mage/attachments"
     }
+  },
+  defaults: {
+    device: {
+      name: null,
+      uid: '12345',
+      description: 'The default UID for admin user',
+      registered: true
+    },
+    roles: [
+      {
+        name: "USER_ROLE",
+        description: "User role, limited acces to MAGE API.",
+        permissions: [
+          'READ_DEVICE',
+          'READ_EVENT_USER',
+          'READ_TEAM',
+          'READ_LAYER_EVENT',
+          'READ_USER',
+          'READ_ROLE',
+          'CREATE_OBSERVATION', 'READ_OBSERVATION_EVENT', 'UPDATE_OBSERVATION_EVENT', 'DELETE_OBSERVATION',
+          'CREATE_LOCATION', 'READ_LOCATION_EVENT', 'UPDATE_LOCATION_EVENT', 'DELETE_LOCATION']
+      },
+      {
+        name: "ADMIN_ROLE",
+        description: "Administrative role, full acces to entire MAGE API.",
+        permissions: [
+          'READ_SETTINGS', 'UPDATE_SETTINGS',
+          'CREATE_DEVICE', 'READ_DEVICE', 'UPDATE_DEVICE', 'DELETE_DEVICE',
+          'CREATE_USER', 'READ_USER', 'UPDATE_USER', 'DELETE_USER',
+          'CREATE_ROLE', 'READ_ROLE', 'UPDATE_ROLE', 'DELETE_ROLE',
+          'CREATE_EVENT', 'READ_EVENT_ALL', 'UPDATE_EVENT', 'DELETE_EVENT',
+          'CREATE_LAYER', 'READ_LAYER_ALL', 'UPDATE_LAYER', 'DELETE_LAYER',
+          'CREATE_OBSERVATION', 'READ_OBSERVATION_ALL', 'UPDATE_OBSERVATION_ALL', 'DELETE_OBSERVATION',
+          'CREATE_LOCATION', 'READ_LOCATION_ALL', 'UPDATE_LOCATION_ALL', 'DELETE_LOCATION',
+          'CREATE_TEAM', 'READ_TEAM', 'UPDATE_TEAM', 'DELETE_TEAM']
+      }
+    ],
+    user: {
+      username: 'admin',
+      displayName: 'Admin',
+      roleId: "ROLE_ADMIN",
+      active: 'true',
+      authentication: {
+        type: 'local',
+        password: 'password'
+      }
+    },
+    layers: [
+      {
+        name: "Open Street Map",
+        type: "Imagery",
+        format: "XYZ",
+        base: true,
+        url: "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      }
+    ]
   }
-}
+};

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,13 @@
+---
+applications:
+ - name: MAGE
+   memory: 512M
+   instances: 1
+   domain: dev.geointservices.io
+   services:
+     - MongoInstance
+   env:
+     S3_MOUNTPOINT: mage
+     S3_BUCKET: 
+     S3_USER: 
+     S3_PASS: 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,21 @@
     "adm-zip": "0.4.7",
     "archiver": "0.14.3",
     "async": "0.2.x",
+    "bower": "^1.3.12",
     "body-parser": "1.2.x",
+    "cfenv": "^1.0.3",
     "dbf": "0.1.0",
     "express": "4.10.6",
     "fs-extra": "0.11.x",
     "gm": "1.17.x",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-concat": "^0.5.1",
+    "grunt-contrib-copy": "^0.8.0",
+    "grunt-contrib-cssmin": "^0.12.2",
+    "grunt-contrib-uglify": "^0.8.0",
+    "grunt-usemin": "^3.0.0",
     "jade": "^1.11.0",
     "json2csv": "^2.2.1",
     "json2csv-stream": "0.1.2",
@@ -55,16 +65,7 @@
   },
   "devDependencies": {
     "assert": "^1.3.0",
-    "bower": "^1.3.12",
     "chai": "^3.3.0",
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-concat": "^0.5.1",
-    "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-cssmin": "^0.12.2",
-    "grunt-contrib-uglify": "^0.8.0",
-    "grunt-usemin": "^3.0.0",
     "http": "0.0.0",
     "mocha": "^2.3.3",
     "nock": "^2.15.0",
@@ -75,9 +76,12 @@
   },
   "scripts": {
     "postinstall": "node_modules/.bin/bower install --config.cwd=public --config.interactive=false && node_modules/.bin/grunt build",
-    "test": "./node_modules/.bin/mocha --reporter spec"
+    "test": "./node_modules/.bin/mocha --reporter spec",
+    "prestart": "./s3ctrl.sh start",
+    "poststop": "./s3ctrl.sh stop",
+    "start": "node app.js"
   },
   "bundleDependencies": [],
   "private": true,
-  "main": "mage.js"
+  "main": "app.js"
 }

--- a/s3ctrl.sh
+++ b/s3ctrl.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+(( $# < 1 )) && { echo "Usage: $0 [start|stop]"; exit 2; }
+
+function starts3 {
+  if [[ -n $VCAP_APPLICATION ]]; then
+    [[ -z $S3_BUCKET || -z $S3_MOUNTPOINT || -z $S3_USER || -z $S3_PASS ]] && {
+      echo "Deploying to CloudFoundry requires an S3 bucket to store uploads" >&2
+      echo "Check your manifest for proper environment variables for:" >&2
+      echo "S3_BUCKET: $S3_BUCKET" >&2
+      echo "S3_MOUNTPOINT: $S3_MOUNTPOINT" >&2
+      echo "S3_USER: $S3_USER" >&2
+      [[ -n $S3_PASS ]] && p='****' || p='<empty>'
+      echo "S3_PASS: $p" >&2
+      exit 3
+    }
+
+    cat <<EOF > s3.passwd
+${S3_USER}:${S3_PASS}
+EOF
+    chmod 600 s3.passwd
+
+    mkdir -p $S3_MOUNTPOINT
+    pgrep -lf s3fs
+    if ! pgrep s3fs > /dev/null; then
+      ./s3fs $S3_BUCKET $S3_MOUNTPOINT -o passwd_file=s3.passwd -o use_sse=1 || {
+        echo "Unable to mount S3 filesystem" >&2
+        exit 1
+      }
+    fi
+  fi
+  return 0
+}
+
+function stops3 {
+  pkill s3fs
+}
+
+case "$1" in
+  start)
+    starts3
+    ;;
+  stop)
+    stops3
+    ;;
+  *)
+    echo "Unknown command: '$1'"
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,82 @@
+'use strict;';
+
+var async  = require('async'),
+    util   = require('util'),
+    config = require('./config'),
+    Device = require('./models/device'),
+    Role   = require('./models/role'),
+    User   = require('./models/user'),
+    Layer  = require('./models/layer'),
+    log    = require('./logger');
+
+var setup = function() {
+  need_setup( function(err, result) {
+    console.log(util.inspect(result));
+    if( result ) {
+      log.info('Running initial setup');
+      async.series([
+        install_device(config.defaults.device),
+        install_roles(config.defaults.roles),
+        //install_user(config.defaults.user),
+        install_layer(config.defaults.layers),
+      ], function(err, results) {
+        if( err ) {
+          throw err;
+        }
+        return true;
+      });
+    } else {
+      return true;
+    }
+  });
+};
+
+var need_setup = function(callback) {
+  var _callback = ('function' === typeof callback) ? callback : function(){} ;
+
+  Device.count(function(err, devicecount) {
+    if( err ) {
+      log.info("Unable to detect database objects for setup");
+      _callback(err, false);
+    }
+    _callback({}, (devicecount > 0) ? false : true);
+    //return (devicecount > 0) ? false : true;
+  });
+};
+
+var install_device = function(device) {
+  Device.createDevice(device, function(){} );
+  log.info('Created default device ' + device.uid);
+};
+
+var install_roles = function(roles, callback) {
+  async.forEach(roles, Role.createRole, function() {
+    log.info('Created ' + roles.length + ' default roles');
+    install_user(config.defaults.user);
+  });
+};
+
+var install_user = function(user) {
+  Role.getRole('ADMIN_ROLE', function(err, adminrole){
+    if( err || !adminrole ) {
+      log.info(util.inspect(adminrole));
+      throw 'Unable to get ADMIN_ROLE to apply to default user \'' + user.username + '\'';
+    }
+
+    var _user = user;
+    _user.roleId = adminrole._id;
+    User.createUser(_user, function(err, newuser) {
+      log.info('Created default user: ' + newuser.username);
+    });
+  });
+};
+
+var install_layer = function(layers) {
+  layers.forEach( function(layer) {
+    Layer.create(layer, function(err, newlayer) {
+      log.info('Created new default layer: ' + newlayer.name);
+    });
+  });
+};
+
+module.exports = setup;


### PR DESCRIPTION
 - Add s3fs support for keeping attachments, users, icons in Amazon S3 storage
 - Add support for getting IP/Port from cloud foundry env variables
 - Add support for getting MongoDB connection from cloud foundry
 - Add manifest for deploying to CloudFoundry with "cf push"
 - Make MAGE set up required DB entries on app start instead of manual migration script