### PR TITLE
Fix typo in attachmentDeleteTest.js from ../MockTest to ../mockTest

### DIFF
--- a/test/attachment/attachmentDeleteTest.js
+++ b/test/attachment/attachmentDeleteTest.js
@@ -1,7 +1,7 @@
 var request = require('supertest')
   , sinon = require('sinon')
   , mongoose = require('mongoose')
-  , MockToken = require('../MockToken')
+  , MockToken = require('../mockToken')
   , app = require('../../express')
   , TokenModel = mongoose.model('Token');
 


### PR DESCRIPTION
The typo otherwise causes "npm test" to fail.