### PR TITLE
Jsm/dont use scheme for model urls

### DIFF
--- a/express.js
+++ b/express.js
@@ -11,7 +11,7 @@ var express = require("express")
 var app = express();
 app.use(function(req, res, next) {
   req.getRoot = function() {
-    return req.protocol + "://" + req.get('host');
+    return "//" + req.get('host');
   };
 
   req.getPath = function() {

--- a/express.js
+++ b/express.js
@@ -26,13 +26,6 @@ app.enable('trust proxy');
 
 app.set('view engine', 'pug');
 
-app.use(function(req, res, next) {
-  req.getRoot = function() {
-    return req.protocol + "://" + req.get('host');
-  };
-  return next();
-});
-
 const secret = require('crypto').randomBytes(64).toString('hex');
 app.use(cookieSession({
   secret: secret,


### PR DESCRIPTION
For observation attachments and layers, the URL for a model is sent back from the API call, and is determined on the server. Existing code was using the server's request protocol which may not match that of the client side. This change does not use the server's request protocol and instead uses `//` which will match the browser's protocol. 

This is an issue if MAGE is used via HTTPS but proxied through to HTTP. The `observation.url` property, for example, would come back as `http://...` rather than `https://...`. This fixes that issue.

**Note:** this will work correctly in a browser but I'm not sure if other API callers will respect `//`. Another solution would be to add a configuration variable / env var e.g. `MAGE_CLIENT_URL_USE_HTTPS` which, when set to `true` would return `https` as the scheme/protocol rather than whatever is on the request. I leave that to the MAGE devs to determine which is the better fix.