### PR TITLE
Jsm/fips fix

### DIFF
--- a/api/form.js
+++ b/api/form.js
@@ -124,7 +124,7 @@ Form.prototype.export = function(formId, callback) {
 Form.prototype.validate = function(file, callback) {
   var err;
 
-  if (file.extension !== 'zip') {
+  if (!/\.zip$/.test(file.originalname)) {
     err = new Error('Form import attachment must be of type "zip"');
     err.status = 400;
     return callback(err);

--- a/api/icon.js
+++ b/api/icon.js
@@ -117,7 +117,7 @@ Icon.prototype.saveDefaultIconToEventForm = function(callback) {
 };
 
 Icon.prototype.create = function(icon, callback) {
-  var relativePath = createIconPath(this, icon.name);
+  var relativePath = createIconPath(this, icon.originalname);
   var newIcon = {
     eventId: this._eventId,
     formId: this._formId,

--- a/api/icon.js
+++ b/api/icon.js
@@ -130,7 +130,7 @@ Icon.prototype.create = function(icon, callback) {
   fs.mkdirp(path.dirname(iconPath), function(err) {
     if (err) return callback(err);
 
-    fs.rename(icon.path, iconPath, function(err) {
+    fs.move(icon.path, iconPath, {overwrite: true}, function(err) {
       if (err) return callback(err);
 
       IconModel.create(newIcon, function(err, oldIcon) {

--- a/environment/env.js
+++ b/environment/env.js
@@ -67,6 +67,7 @@ const environment = {
   iconBaseDirectory: path.resolve(process.env.MAGE_ICON_DIR || '/var/lib/mage/icons'),
   attachmentBaseDirectory: path.resolve(process.env.MAGE_ATTACHMENT_DIR || '/var/lib/mage/attachments'),
   layerBaseDirectory: path.resolve(process.env.MAGE_LAYER_DIR || '/var/lib/mage/layers'),
+  tempDirectory: path.resolve(process.env.MAGE_TEMP_DIR || '/tmp'),
   tokenExpiration: parseInt(process.env.MAGE_TOKEN_EXPIRATION) || 28800,
   cookies: {
     secure: process.env.MAGE_SESSION_COOKIE_SECURE !== 'false'

--- a/environment/magerc.sh
+++ b/environment/magerc.sh
@@ -14,6 +14,8 @@ export MAGE_ICON_DIR=/var/lib/mage/icons
 export MAGE_ATTACHEMENT_DIR=/var/lib/mage/attachments
 # directory where mage stores layers
 export MAGE_LAYER_DIR=/var/lib/mage/layers
+# directory where mage stores temporary files
+export MAGE_TEMP_DIR=/tmp
 # number of seconds an authentication token is valid; default 28800 (8 hours)
 export MAGE_TOKEN_EXPIRATION=28800
 # the URL that specifies MAGE's connection to mongodb

--- a/express.js
+++ b/express.js
@@ -1,4 +1,6 @@
 var express = require("express")
+  , crypto = require('crypto')
+  , multer = require('multer')
   , cookieSession = require('cookie-session')
   , passport = require('passport')
   , path = require('path')
@@ -33,7 +35,7 @@ app.use(function(req, res, next) {
   return next();
 });
 
-const secret = require('crypto').randomBytes(64).toString('hex');
+const secret = crypto.randomBytes(64).toString('hex');
 app.use(cookieSession({
   secret: secret,
   name: 'mage-session',
@@ -56,7 +58,19 @@ app.use(require('body-parser')({
   limit: '16mb',
   keepExtensions: true
 }));
-app.use(require('multer')());
+app.use(multer({
+  storage: multer.diskStorage({
+    destination: '/tmp',
+    filename: function(req, file, cb) {
+      // multer does not save the temp file w/the file extension which causes issues when processing e.g. geopackages
+      crypto.pseudoRandomBytes(16, function(err, raw) {
+        if (err) return cb(err);
+
+        cb(null, raw.toString('hex') + path.extname(file.originalname));
+      })
+    }
+  })
+}).any());
 app.use(passport.initialize());
 app.use(passport.session());
 app.use(express.static(path.join(__dirname, 'public/dist')));

--- a/express.js
+++ b/express.js
@@ -60,7 +60,7 @@ app.use(require('body-parser')({
 }));
 app.use(multer({
   storage: multer.diskStorage({
-    destination: '/tmp',
+    destination: env.tempDirectory,
     filename: function(req, file, cb) {
       // multer does not save the temp file w/the file extension which causes issues when processing e.g. geopackages
       crypto.pseudoRandomBytes(16, function(err, raw) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,7 +228,7 @@
         "proj4": "2.4.3",
         "pureimage": "0.1.6",
         "reproject": "^1.1.1",
-        "sql.js": "git+https://github.com/kripken/sql.js.git#be04bc157f8c6d0ad34b2c62474c3a560cae575b",
+        "sql.js": "git+https://github.com/kripken/sql.js.git",
         "sqlite3": "4.0.0",
         "stream-to-array": "^2.3.0",
         "wkx": "0.4.4"
@@ -260,7 +260,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -274,7 +274,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -714,7 +714,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "optional": true
     },
@@ -734,6 +734,11 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+    },
     "append-transform": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
@@ -745,7 +750,7 @@
     },
     "archiver": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "requires": {
         "archiver-utils": "^1.3.0",
@@ -945,7 +950,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -959,7 +964,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -973,7 +978,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -1115,7 +1120,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1209,7 +1214,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "optional": true,
       "requires": {
@@ -1668,7 +1673,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1692,7 +1697,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
@@ -2023,7 +2028,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "optional": true,
       "requires": {
@@ -2618,7 +2623,7 @@
     },
     "inquirer": {
       "version": "1.2.3",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
       "optional": true,
       "requires": {
@@ -3771,48 +3776,18 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multer": {
-      "version": "0.1.8",
-      "resolved": "http://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
-      "integrity": "sha1-VRuKYBUJNwG8rMlkkWsa4GV483s=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
+      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
       "requires": {
-        "busboy": "~0.2.9",
-        "mkdirp": "~0.3.5",
-        "qs": "~1.2.2",
-        "type-is": "~1.5.2"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.12.0",
-          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
-        },
-        "mime-types": {
-          "version": "2.0.14",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "requires": {
-            "mime-db": "~1.12.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-        },
-        "qs": {
-          "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-          "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
-        },
-        "type-is": {
-          "version": "1.5.7",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
-          "integrity": "sha1-uTaKWTzG730GReeLL0xky+zQXpA=",
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "~2.0.9"
-          }
-        }
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
       }
     },
     "muri": {
@@ -3828,7 +3803,7 @@
     },
     "nan": {
       "version": "2.9.2",
-      "resolved": "http://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
       "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
       "optional": true
     },
@@ -4270,7 +4245,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "optional": true
     },
@@ -4291,7 +4266,7 @@
     },
     "opentype.js": {
       "version": "0.4.11",
-      "resolved": "http://registry.npmjs.org/opentype.js/-/opentype.js-0.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.4.11.tgz",
       "integrity": "sha1-KBojkGOcwVkxyVXY1jwUp8d3K0E="
     },
     "optimist": {
@@ -4337,7 +4312,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "optional": true
     },
@@ -4613,7 +4588,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -5440,7 +5415,7 @@
     },
     "sqlite3": {
       "version": "4.0.0",
-      "resolved": "http://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
       "integrity": "sha512-6OlcAQNGaRSBLK1CuaRbKwlMFBb9DEhzmZyQP+fltNRF6XcIMpVIfXCBEcXPe1d4v9LnhkQUYkknDbA5JReqJg==",
       "optional": true,
       "requires": {
@@ -5455,7 +5430,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5473,11 +5449,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5490,15 +5468,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5598,7 +5579,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5608,6 +5590,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5620,17 +5603,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "yallist": "^3.0.0"
           }
@@ -5646,6 +5632,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5718,7 +5705,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5728,6 +5716,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5803,7 +5792,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
@@ -5828,6 +5818,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5845,6 +5836,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5882,11 +5874,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -5918,7 +5912,7 @@
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -5960,7 +5954,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -6159,7 +6153,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6173,7 +6167,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -6208,7 +6202,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mongodb-migrations": "0.8.5",
     "mongoose": "4.13.14",
     "mongoose-beautiful-unique-validation": "7.1.1",
-    "multer": "0.1.x",
+    "multer": "^1.4.2",
     "openid-client": "2.2.1",
     "passport": "0.4.0",
     "passport-anonymous": "1.0.1",

--- a/plugins/mage-image/process.js
+++ b/plugins/mage-image/process.js
@@ -67,7 +67,7 @@ function orient(event, observationId, attachment, callback) {
 
     var end = new Date().valueOf();
     log.info("orientation of attachment " + attachment.name + " complete in " + (end - start)/1000 + " seconds");
-    fs.rename(outputFile, file, function(err) {
+    fs.move(outputFile, file, {overwrite: true}, function(err) {
       if (err) return callback(err);
 
       gm(file).size(function(err, size) {

--- a/public/package-lock.json
+++ b/public/package-lock.json
@@ -34,6 +34,7 @@
         "proj4": "2.4.3",
         "pureimage": "0.1.6",
         "reproject": "^1.1.1",
+        "sql.js": "git+https://github.com/kripken/sql.js.git",
         "sqlite3": "4.0.0",
         "stream-to-array": "^2.3.0",
         "wkx": "0.4.4"
@@ -45,8 +46,8 @@
           "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
         },
         "sql.js": {
-          "version": "git+https://github.com/kripken/sql.js.git#fbe8427c32d5077be06bb808283c2efb22a84c97",
-          "from": "git+https://github.com/kripken/sql.js.git#fbe8427c32d5077be06bb808283c2efb22a84c97"
+          "version": "git+https://github.com/kripken/sql.js.git#3e73897177c408d5be17e1efd0c7aaf215b0ae2b",
+          "from": "git+https://github.com/kripken/sql.js.git"
         }
       }
     },
@@ -740,7 +741,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "optional": true
     },
@@ -2126,7 +2127,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
@@ -2484,7 +2485,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "optional": true,
       "requires": {
@@ -2613,7 +2614,7 @@
     },
     "file-type": {
       "version": "7.6.0",
-      "resolved": "http://registry.npmjs.org/file-type/-/file-type-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.6.0.tgz",
       "integrity": "sha512-EAogdjMKf0PEU26Wk+N/Qkg8JXpMRo9t70dg7+t9QvcYUZb/XfA66Hdt15g4xRdam4wgiQsg/qycKUIuZQDJog=="
     },
     "fill-range": {
@@ -2795,7 +2796,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2816,12 +2818,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2836,17 +2840,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2963,7 +2970,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2975,6 +2983,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2989,6 +2998,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2996,12 +3006,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3020,6 +3032,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3100,7 +3113,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3112,6 +3126,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3197,7 +3212,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3233,6 +3249,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3252,6 +3269,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3295,12 +3313,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3912,7 +3932,7 @@
     },
     "inquirer": {
       "version": "1.2.3",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
       "optional": true,
       "requires": {
@@ -4356,7 +4376,7 @@
         "pbf": "^3.0.2",
         "topojson-client": "^2.1.0",
         "vector-tile": "^1.3.0",
-        "whatwg-fetch": "git+https://github.com/github/fetch.git#3674c98df696d45573750aa7873814887d25689a"
+        "whatwg-fetch": "git+https://github.com/github/fetch.git"
       }
     },
     "loader-runner": {
@@ -4637,7 +4657,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
@@ -4998,13 +5018,13 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "optional": true
     },
     "opentype.js": {
       "version": "0.4.11",
-      "resolved": "http://registry.npmjs.org/opentype.js/-/opentype.js-0.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.4.11.tgz",
       "integrity": "sha1-KBojkGOcwVkxyVXY1jwUp8d3K0E="
     },
     "opn": {
@@ -5050,7 +5070,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "optional": true
     },
@@ -5202,7 +5222,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -6853,7 +6873,7 @@
     },
     "sqlite3": {
       "version": "4.0.0",
-      "resolved": "http://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
       "integrity": "sha512-6OlcAQNGaRSBLK1CuaRbKwlMFBb9DEhzmZyQP+fltNRF6XcIMpVIfXCBEcXPe1d4v9LnhkQUYkknDbA5JReqJg==",
       "optional": true,
       "requires": {
@@ -6868,7 +6888,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6886,11 +6907,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6903,15 +6926,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7011,7 +7037,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7021,6 +7048,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7033,17 +7061,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "yallist": "^3.0.0"
           }
@@ -7059,6 +7090,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7131,7 +7163,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7141,6 +7174,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7216,7 +7250,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
@@ -7241,6 +7276,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7258,6 +7294,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7295,11 +7332,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7351,7 +7390,7 @@
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -8380,7 +8419,7 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "git+https://github.com/github/fetch.git#3674c98df696d45573750aa7873814887d25689a",
+      "version": "git+https://github.com/github/fetch.git#37d10362687492868548c4d70c5c12e4a671771e",
       "from": "git+https://github.com/github/fetch.git"
     },
     "whet.extend": {

--- a/routes/events.js
+++ b/routes/events.js
@@ -286,7 +286,8 @@ module.exports = function(app, security) {
       if (!req.is('multipart/form-data')) return next();
 
       function validateForm(callback) {
-        new api.Form().validate(req.files.form, callback);
+        var form = req.files.find(o => o.fieldname === "form");
+        new api.Form().validate(form, callback);
       }
 
       function updateEvent(form, callback) {
@@ -298,7 +299,8 @@ module.exports = function(app, security) {
       }
 
       function importIcons(form, callback) {
-        new api.Form(req.event).importIcons(req.files.form, form, function(err) {
+        var icon = req.files.find(o => o.fieldname === "form");
+        new api.Form(req.event).importIcons(icon, form, function(err) {
           callback(err, form);
         });
       }
@@ -530,7 +532,8 @@ module.exports = function(app, security) {
     passport.authenticate('bearer'),
     authorizeAccess('UPDATE_EVENT', 'update'),
     function(req, res, next) {
-      new api.Icon(req.event._id, req.params.formId, req.params.primary, req.params.variant).create(req.files.icon, function(err, icon) {
+      var icon = req.files.find(o => o.fieldname === "icon");
+      new api.Icon(req.event._id, req.params.formId, req.params.primary, req.params.variant).create(icon, function(err, icon) {
         if (err) return next(err);
 
         return res.json(icon);

--- a/routes/events.js
+++ b/routes/events.js
@@ -286,7 +286,7 @@ module.exports = function(app, security) {
       if (!req.is('multipart/form-data')) return next();
 
       function validateForm(callback) {
-        var form = req.files.find(o => o.fieldname === "form");
+        var form = req.files && req.files.find(o => o.fieldname === "form");
         new api.Form().validate(form, callback);
       }
 
@@ -299,7 +299,7 @@ module.exports = function(app, security) {
       }
 
       function importIcons(form, callback) {
-        var icon = req.files.find(o => o.fieldname === "form");
+        var icon = req.files && req.files.find(o => o.fieldname === "form");
         new api.Form(req.event).importIcons(icon, form, function(err) {
           callback(err, form);
         });
@@ -532,7 +532,7 @@ module.exports = function(app, security) {
     passport.authenticate('bearer'),
     authorizeAccess('UPDATE_EVENT', 'update'),
     function(req, res, next) {
-      var icon = req.files.find(o => o.fieldname === "icon");
+      var icon = req.files && req.files.find(o => o.fieldname === "icon");
       new api.Icon(req.event._id, req.params.formId, req.params.primary, req.params.variant).create(icon, function(err, icon) {
         if (err) return next(err);
 

--- a/routes/imports.js
+++ b/routes/imports.js
@@ -17,7 +17,7 @@ module.exports = function(app, security) {
   function readImportFile(req, res, next) {
     // TODO at some point open file and determine type (KML, shapefile, geojson, csv)
 
-    var file = req.files.find(o => o.fieldname === "file");
+    var file = req.files && req.files.find(o => o.fieldname === "file");
     fs.readFile(file.path, 'utf8', function(err, data) {
       req.importData = data;
       return next(err);
@@ -34,7 +34,7 @@ module.exports = function(app, security) {
       var features = toGeoJson.kml(req.importData);
       new api.Feature(req.layer).createFeatures(features)
         .then(newFeatures => {
-          var file = req.files.find(o => o.fieldname === "file");
+          var file = req.files && req.files.find(o => o.fieldname === "file");
           var response = {
             files: [{
               name: file.originalname,

--- a/routes/imports.js
+++ b/routes/imports.js
@@ -17,7 +17,8 @@ module.exports = function(app, security) {
   function readImportFile(req, res, next) {
     // TODO at some point open file and determine type (KML, shapefile, geojson, csv)
 
-    fs.readFile(req.files.file.path, 'utf8', function(err, data) {
+    var file = req.files.find(o => o.fieldname === "file");
+    fs.readFile(file.path, 'utf8', function(err, data) {
       req.importData = data;
       return next(err);
     });
@@ -33,10 +34,11 @@ module.exports = function(app, security) {
       var features = toGeoJson.kml(req.importData);
       new api.Feature(req.layer).createFeatures(features)
         .then(newFeatures => {
+          var file = req.files.find(o => o.fieldname === "file");
           var response = {
             files: [{
-              name: req.files.file.originalname,
-              size: req.files.file.size,
+              name: file.originalname,
+              size: file.size,
               features: newFeatures.length
             }]
           };

--- a/routes/layers.js
+++ b/routes/layers.js
@@ -35,7 +35,7 @@ module.exports = function(app, security) {
       return next();
     }
 
-    var file = req.files.find(o => o.fieldname === "geopackage");
+    var file = req.files && req.files.find(o => o.fieldname === "geopackage");
     if (!file) {
       return res.send(400, 'cannot create layer "geopackage" file not specified');
     }

--- a/routes/layers.js
+++ b/routes/layers.js
@@ -35,14 +35,15 @@ module.exports = function(app, security) {
       return next();
     }
 
-    if (!req.files.geopackage) {
+    var file = req.files.find(o => o.fieldname === "geopackage");
+    if (!file) {
       return res.send(400, 'cannot create layer "geopackage" file not specified');
     }
 
-    geopackage.validate(req.files.geopackage, (err, result) => {
+    geopackage.validate(file, (err, result) => {
       if (err) return res.status(400).send('cannot create layer, geopackage is not valid');
 
-      req.newLayer.geopackage = req.files.geopackage;
+      req.newLayer.geopackage = file;
       req.newLayer.tables = result.metadata.tables;
       next(err);
     });

--- a/routes/observations.js
+++ b/routes/observations.js
@@ -559,7 +559,7 @@ module.exports = function(app, security) {
     passport.authenticate('bearer'),
     access.authorize('CREATE_OBSERVATION'),
     function(req, res, next) {
-      var attachment = req.files.find(o => o.fieldname === "attachment");
+      var attachment = req.files && req.files.find(o => o.fieldname === "attachment");
       if (!attachment) return res.status(400).send("no attachment");
 
       new api.Attachment(req.event, req.observation).create(req.observationId, attachment, function(err, attachment) {
@@ -577,7 +577,7 @@ module.exports = function(app, security) {
     passport.authenticate('bearer'),
     validateObservationUpdateAccess,
     function(req, res, next) {
-      var attachment = req.files.find(o => o.fieldname === "attachment");
+      var attachment = req.files && req.files.find(o => o.fieldname === "attachment");
       new api.Attachment(req.event, req.observation).update(req.params.attachmentId, attachment, function(err, attachment) {
         if (err) return next(err);
 

--- a/routes/observations.js
+++ b/routes/observations.js
@@ -559,10 +559,10 @@ module.exports = function(app, security) {
     passport.authenticate('bearer'),
     access.authorize('CREATE_OBSERVATION'),
     function(req, res, next) {
-      var attachment = req.files.attachment;
+      var attachment = req.files.find(o => o.fieldname === "attachment");
       if (!attachment) return res.status(400).send("no attachment");
 
-      new api.Attachment(req.event, req.observation).create(req.observationId, req.files.attachment, function(err, attachment) {
+      new api.Attachment(req.event, req.observation).create(req.observationId, attachment, function(err, attachment) {
         if (err) return next(err);
 
         var observation = req.observation;
@@ -577,7 +577,8 @@ module.exports = function(app, security) {
     passport.authenticate('bearer'),
     validateObservationUpdateAccess,
     function(req, res, next) {
-      new api.Attachment(req.event, req.observation).update(req.params.attachmentId, req.files.attachment, function(err, attachment) {
+      var attachment = req.files.find(o => o.fieldname === "attachment");
+      new api.Attachment(req.event, req.observation).update(req.params.attachmentId, attachment, function(err, attachment) {
         if (err) return next(err);
 
         var observation = req.observation;

--- a/routes/users.js
+++ b/routes/users.js
@@ -41,7 +41,7 @@ module.exports = function(app, security) {
       iconMetadata = JSON.parse(iconMetadata);
     }
 
-    var icon = req.files.find(o => o.fieldname === "icon");
+    var icon = req.files && req.files.find(o => o.fieldname === "icon");
     if (icon) {
       // default type to upload
       if (!iconMetadata.type) iconMetadata.type = 'upload';
@@ -247,7 +247,7 @@ module.exports = function(app, security) {
         }];
       }
 
-      var avatar = req.files.find(o => o.fieldname === "avatar");
+      var avatar = req.files && req.files.find(o => o.fieldname === "avatar");
       new api.User().update(req.user, {avatar}, function(err, updatedUser) {
         if (err) return next(err);
 
@@ -323,8 +323,8 @@ module.exports = function(app, security) {
       // Authorized to update users, activate account by default
       req.newUser.active = true;
 
-      var avatar = req.files.find(o => o.fieldname === "avatar");
-      var icon = req.files.find(o => o.fieldname === "icon");
+      var avatar = req.files && req.files.find(o => o.fieldname === "avatar");
+      var icon = req.files && req.files.find(o => o.fieldname === "icon");
       new api.User().create(req.newUser, {avatar, icon}, function(err, newUser) {
         if (err) return next(err);
 
@@ -344,7 +344,7 @@ module.exports = function(app, security) {
       req.newUser.active = false;
       req.newUser.roleId = req.role._id;
 
-      var avatar = req.files.find(o => o.fieldname === "avatar");
+      var avatar = req.files && req.files.find(o => o.fieldname === "avatar");
       new api.User().create(req.newUser, {avatar}, function(err, newUser) {
         if (err) return next(err);
 
@@ -435,8 +435,8 @@ module.exports = function(app, security) {
         }
       }
 
-      var avatar = req.files.find(o => o.fieldname === "avatar");
-      var icon = req.files.find(o => o.fieldname === "icon");
+      var avatar = req.files && req.files.find(o => o.fieldname === "avatar");
+      var icon = req.files && req.files.find(o => o.fieldname === "icon");
       new api.User().update(user, {avatar, icon}, function(err, updatedUser) {
         if (err) return next(err);
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -41,7 +41,8 @@ module.exports = function(app, security) {
       iconMetadata = JSON.parse(iconMetadata);
     }
 
-    if (req.files.icon) {
+    var icon = req.files.find(o => o.fieldname === "icon");
+    if (icon) {
       // default type to upload
       if (!iconMetadata.type) iconMetadata.type = 'upload';
 
@@ -49,12 +50,12 @@ module.exports = function(app, security) {
         return res.status(400).send('invalid icon metadata');
       }
 
-      req.files.icon.type = iconMetadata.type;
-      req.files.icon.text = iconMetadata.text;
-      req.files.icon.color = iconMetadata.color;
+      icon.type = iconMetadata.type;
+      icon.text = iconMetadata.text;
+      icon.color = iconMetadata.color;
     } else {
       if (iconMetadata.type === 'none') {
-        req.files.icon = {
+        icon = {
           type: 'none'
         };
       }
@@ -246,7 +247,8 @@ module.exports = function(app, security) {
         }];
       }
 
-      new api.User().update(req.user, {avatar: req.files.avatar}, function(err, updatedUser) {
+      var avatar = req.files.find(o => o.fieldname === "avatar");
+      new api.User().update(req.user, {avatar}, function(err, updatedUser) {
         if (err) return next(err);
 
         updatedUser = userTransformer.transform(updatedUser, {path: req.getRoot()});
@@ -314,13 +316,16 @@ module.exports = function(app, security) {
       }
 
       var roleId = req.param('roleId');
+
       if (!roleId) return res.status(400).send('roleId is a required field');
       req.newUser.roleId = roleId;
 
       // Authorized to update users, activate account by default
       req.newUser.active = true;
 
-      new api.User().create(req.newUser, {avatar: req.files.avatar, icon: req.files.icon}, function(err, newUser) {
+      var avatar = req.files.find(o => o.fieldname === "avatar");
+      var icon = req.files.find(o => o.fieldname === "icon");
+      new api.User().create(req.newUser, {avatar, icon}, function(err, newUser) {
         if (err) return next(err);
 
         newUser = userTransformer.transform(newUser, {path: req.getRoot()});
@@ -339,7 +344,8 @@ module.exports = function(app, security) {
       req.newUser.active = false;
       req.newUser.roleId = req.role._id;
 
-      new api.User().create(req.newUser, {avatar: req.files.avatar}, function(err, newUser) {
+      var avatar = req.files.find(o => o.fieldname === "avatar");
+      new api.User().create(req.newUser, {avatar}, function(err, newUser) {
         if (err) return next(err);
 
         newUser = userTransformer.transform(newUser, {path: req.getRoot()});
@@ -429,7 +435,9 @@ module.exports = function(app, security) {
         }
       }
 
-      new api.User().update(user, {avatar: req.files.avatar, icon: req.files.icon}, function(err, updatedUser) {
+      var avatar = req.files.find(o => o.fieldname === "avatar");
+      var icon = req.files.find(o => o.fieldname === "icon");
+      new api.User().update(user, {avatar, icon}, function(err, updatedUser) {
         if (err) return next(err);
 
         updatedUser = userTransformer.transform(updatedUser, {path: req.getRoot()});


### PR DESCRIPTION
The version of multer currently in use uses MD5 to hash files. This does not work when running on a system that's in FIPS mode. Updated `multer` to the current version and updated the usage in `express.js` -- _this needs confirmation of correct usage_.

Changes made to support the current version of `multer`:

- added `MAGE_TEMP_DIR` env var
- updated `multer` configuration
  -  `multer` requires specific dir to be set
  - `multer` does not save temp files with their extension -- added code to save temp files with their extension as existing code checks the extension of the incoming file (when importing a form to an event)
- `extension` no longer exists on a file -- updated single occurrence to regex match the extension against the `originalname` field
- replaced occurrences of `name` with `originalname`
- `req.files` can be null now, so added protection in all usages (perhaps only from tests)
- `req.files` is an array now, not a map -- need to use `.find` to locate files by `fieldname`
- replaced occurrences of `fs.rename` with `fs.move`, duplicating changes in https://github.com/ngageoint/mage-server/pull/55
