### PR TITLE
for uploaded geopackage, use originalname, not name

### DIFF
--- a/api/layer.js
+++ b/api/layer.js
@@ -72,7 +72,7 @@ function createGeoPackageLayer(id, layer) {
     name: layer.geopackage.originalname,
     contentType: layer.geopackage.mimetype,
     size: layer.geopackage.size,
-    relativePath: path.join(id.toString(), layer.geopackage.name)
+    relativePath: path.join(id.toString(), layer.geopackage.originalname)
   };
 
   const targetPath = path.join(environment.layerBaseDirectory, layer.file.relativePath);


### PR DESCRIPTION
After upgrade to newer multer, missed this. Anywhere else `name` is used from an uploaded file should be changed to `originalname`.