### PR TITLE
use SHA1 instead of MD4 because it's not FIPS compliant

### DIFF
--- a/public/webpack.common.js
+++ b/public/webpack.common.js
@@ -12,7 +12,8 @@ module.exports = {
   },
   output: {
     path: __dirname + '/dist',
-    filename: '[name].js'
+    filename: '[name].js',
+    hashFunction: 'sha1'
   },
   module: {
     rules: [


### PR DESCRIPTION
Webpack build breaks on FIPS systems due to default usage of MD4 algorithm during compilation.

Note that the webpack-terser-plugin package also hard-codes MD4. I have a PR in for this fix as well (https://github.com/webpack-contrib/terser-webpack-plugin/pull/213).