### PR TITLE
Generic SSO customization

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -67,6 +67,7 @@
     "jquery": "3.3.1",
     "jquery-file-download": "1.4.6",
     "jquery-minicolors": "2.1.10",
+    "js-cookie": "^2.2.0",
     "leaflet": "1.6.0",
     "leaflet-editable": "1.2.0",
     "leaflet-groupedlayercontrol": "https://github.com/newmanw/leaflet-groupedlayercontrol.git#master",

--- a/web-app/src/ng1/app.js
+++ b/web-app/src/ng1/app.js
@@ -7,6 +7,7 @@ import fileBrowser from './file-upload/file.browser.component';
 import uiRouter from "@uirouter/angularjs";
 import { SwaggerComponent } from "../app/swagger/swagger.component";
 import { downgradeComponent } from '@angular/upgrade/static';
+import cookies from 'js-cookie';
 
 import {
   MatIcon,
@@ -384,9 +385,9 @@ function config($httpProvider, $stateProvider, $urlRouterProvider, $urlServicePr
   });
 }
 
-run.$inject = ['$rootScope', '$uibModal', '$templateCache', '$state', 'Api'];
+run.$inject = ['$rootScope', '$uibModal', '$templateCache', '$state', 'Api', 'LocalStorageService', 'UserService'];
 
-function run($rootScope, $uibModal, $templateCache, $state, Api) {
+function run($rootScope, $uibModal, $templateCache, $state, Api, LocalStorageService, UserService) {
   $templateCache.put("observation/observation-important.html", require("./observation/observation-important.html"));
 
   $rootScope.$on('event:auth-loginRequired', function(e, response) {
@@ -429,6 +430,19 @@ function run($rootScope, $uibModal, $templateCache, $state, Api) {
       });
     }
   });
+
+  trySSO(LocalStorageService, UserService);
+}
+
+function trySSO(LocalStorageService, UserService) {
+  const ssoTokenCookie = cookies.get('mage-sso-token');
+
+  // if SSO token exists, set it in local storage and fetch current user
+  if (ssoTokenCookie) {
+    LocalStorageService.setToken(ssoTokenCookie);
+
+    return UserService.getMyself();
+  }
 }
 
 export default app;


### PR DESCRIPTION
Would you consider pulling this in? This is how we currently handle SSO, and is the only difference we keep maintaining as we upgrade MAGE. 

We essentially call a custom API during login which authenticates/syncs the user with MAGE, and then sets this `mage-sso-cookie`. When the user visits MAGE, during the `run` method, we check if the cookie exists, and if so we set the cookie and then attempt to fetch the current user. If the token in the cookie is valid and references an actual user, then the user would be logged in.