### PR TITLE
About page version number removed ,replaced with Mage Server

### DIFF
--- a/web-app/src/ng1/about/about.html
+++ b/web-app/src/ng1/about/about.html
@@ -1,5 +1,5 @@
 <div class="content-flex about-content">
-  <h2>About {{$ctrl.name}} {{$ctrl.serverVersion.major}}.{{$ctrl.serverVersion.minor}}.{{$ctrl.serverVersion.micro}}</h2>
+  <h2>About Mage Server</h2>
   <p>
       MAGE is a dynamic, secure, mobile situational awareness and field data collection platform that supports
       low-bandwidth and disconnected users. MAGE can integrate with existing command centers and common operating


### PR DESCRIPTION
Retitled the nga/geoint version number section on About page to "Mage Server".