### PR TITLE
sharp dependency upgrade 0.32.6

### DIFF
--- a/plugins/image/service/package.json
+++ b/plugins/image/service/package.json
@@ -31,7 +31,7 @@
     "async": "^3.1.1",
     "fs-extra": "^8.1.0",
     "gm": "1.23.1",
-    "sharp": "^0.30.7"
+    "sharp": "^0.32.6"
   },
   "peerDependencies": {
     "@ngageoint/mage.service": "^6.2.0, ~6.2.10-beta",


### PR DESCRIPTION
Address High Severity Vulnerability: (GHSA-54xq-cgqr-rpm3)  in a Sharp library's dependency, libwebp, affecting versions prior to 0.32.6. This updates Sharp from version 0.30.7 to 0.32.6, which patches libwebp version 1.3.2. This update is supposed to mitigates the risks of processing untrusted WebP images.  