### PR TITLE
Bugfix: /api initial flag regression

### DIFF
--- a/service/src/app.impl/systemInfo/app.impl.systemInfo.ts
+++ b/service/src/app.impl/systemInfo/app.impl.systemInfo.ts
@@ -2,6 +2,7 @@ import { AppResponse } from '../../app.api/app.api.global';
 import * as api from '../../app.api/systemInfo/app.api.systemInfo';
 import { EnvironmentService } from '../../entities/systemInfo/entities.systemInfo';
 import * as Settings from '../../models/setting';
+import * as Users from '../../models/user';
 import * as AuthenticationConfiguration from '../../models/authenticationconfiguration';
 import AuthenticationConfigurationTransformer from '../../transformers/authenticationconfiguration';
 import { ExoPrivilegedSystemInfo, ExoRedactedSystemInfo, ExoSystemInfo, SystemInfoPermissionService } from '../../app.api/systemInfo/app.api.systemInfo';
@@ -54,9 +55,18 @@ export function CreateReadSystemInfo(
   ): Promise<api.ReadSystemInfoResponse> {
     const isAuthenticated = req.context.requestingPrincipal() != null;
 
+	// FIXME: Replace this with Robert's first-run secret implementation when available
+	const legacyUsers = Users as any;   
+    const userCount = await new Promise(resolve => {
+      legacyUsers.count({}, (err:any, count:any) => {
+	    resolve(count)
+	  });
+    });
+    
     // Initialize with base system info
-    let systemInfoResponse: ExoRedactedSystemInfo = {
-      version: versionInfo,
+    let systemInfoResponse: ExoRedactedSystemInfo = {	  
+      version: versionInfo,	  
+	  initial: userCount == 0,
       disclaimer: (await settingsModule.getSetting('disclaimer')) || {},
       contactInfo: (await settingsModule.getSetting('contactInfo')) || {}
     };

--- a/service/src/entities/systemInfo/entities.systemInfo.ts
+++ b/service/src/entities/systemInfo/entities.systemInfo.ts
@@ -23,6 +23,7 @@ export interface SystemInfo {
    * Package version string straight from package.json
    */
   environment: EnvironmentInfo
+  initial: boolean // is in initial setup with no users
   disclaimer: any // mongoose Document type
   contactInfo: any
 }

--- a/service/test/adapters/systemInfo/adapters.systemInfo.controllers.web.test.ts
+++ b/service/test/adapters/systemInfo/adapters.systemInfo.controllers.web.test.ts
@@ -60,6 +60,7 @@ describe('SystemInfo web controller', () => {
           nodeVersion: 'test',
           mongodbVersion: 'test'
         },
+		initial: true,
         disclaimer: {},
         contactInfo: {},
         version: {


### PR DESCRIPTION
Fixed regression introduced on the *develop* branch's TS migration blocking initial admin user setup on first run.

We had missed the initial property on the **/api** endpoint's response which was being checked in Angular to see if zero users exist on the server, at which point we should route the user to the create an admin user flow instead of prompting them to login (as it currently works on *master*). This change replaces it, though it's leveraging the legacy JS user model for the moment for simplicity's sake.

Talking to Robert, there's an upcoming plan to migrate this behavior to a secret-based approach so we don't race to create the first admin user after installing and launching the server for the first time. But this unblocks the situation for now on wholly new installs until that lands.

Feel free to advise on any stylistic changes to fit how things *ought to work* as I haven't had a lot of mileage on TS in general and our mage-server stack in particular yet. :)