### PR TITLE
initialize event search with empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ npm run build
 After building the core packages, install them as dependencies in the `instance` package.
 ```bash
 cd instance
-npm i --omit dev ../service ../web-app ../plugins/nga-msi
+npm i --omit dev ../service ../web-app/dist/app ../plugins/nga-msi
 ```
 The project's root [`package.json`](./package.json) provides some convenience script entries to install, build, and run
 the MAGE server components, however, those are deprecated and will likely go away after migrating to NPM 7+'s

--- a/web-app/src/ng1/admin/events/events.component.js
+++ b/web-app/src/ng1/admin/events/events.component.js
@@ -12,6 +12,7 @@ class AdminEventsController {
     this.filter = 'active'; // possible values all, active, complete
     this.page = 0;
     this.itemsPerPage = 10;
+    this.eventSearch = '';
 
     this.projection = {
       name: true,


### PR DESCRIPTION
eventSearch was uninitialized, causing the event filter to malfunction on page load.  Initialize the eventSearch string to ''.