### PR TITLE
Event schema unique fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ MAGE adheres to [Semantic Versioning](http://semver.org/).
 - Support for Mongoose 6.x
 - Support for Webpack 5.x
 - Support for Angular 14.x
-- [mongodb-migrations](https://www.npmjs.com/package/@ngageoint/mongodb-migrations) support for Mongo 5.x.
+- [mongodb-migrations](https://www.npmjs.com/package/@ngageoint/mongodb-migrations) support for Mongo 6.x.
 - The `MAGE_MONGO_TLS_INSECURE` env var avoids issues with [self-signed certs](https://github.com/Automattic/mongoose/issues/9147).
 - [GARS](https://github.com/ngageoint/gars-js) grid overlay
 - [MGRS](https://github.com/ngageoint/mgrs-js) grid overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ MAGE adheres to [Semantic Versioning](http://semver.org/).
 - Support for Mongoose 6.x
 - Support for Webpack 5.x
 - Support for Angular 14.x
-- [mongodb-migrations](https://www.npmjs.com/package/@ngageoint/mongodb-migrations) support for Mongo 4.x.
+- [mongodb-migrations](https://www.npmjs.com/package/@ngageoint/mongodb-migrations) support for Mongo 5.x.
 - The `MAGE_MONGO_TLS_INSECURE` env var avoids issues with [self-signed certs](https://github.com/Automattic/mongoose/issues/9147).
 - [GARS](https://github.com/ngageoint/gars-js) grid overlay
 - [MGRS](https://github.com/ngageoint/mgrs-js) grid overlay

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ requires Node > 18.x.  Developers should use the latest LTS, 20.x at the time of
 ### Install MongoDB
 
 Before running a MAGE server, you'll need to install and start [MongoDB](https://www.mongodb.com/try/download/community).
-At the time of this writing, MAGE supports MongoDB version 4.x (4.4).
+At the time of this writing, MAGE supports MongoDB version 5.x (5.0.1).
 
 ### Install MAGE server packages
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ requires Node > 18.x.  Developers should use the latest LTS, 20.x at the time of
 ### Install MongoDB
 
 Before running a MAGE server, you'll need to install and start [MongoDB](https://www.mongodb.com/try/download/community).
-At the time of this writing, MAGE supports MongoDB version 5.x (5.0.1).
+At the time of this writing, MAGE supports MongoDB version 6.x (6.0).
 
 ### Install MAGE server packages
 

--- a/service/src/models/event.js
+++ b/service/src/models/event.js
@@ -74,7 +74,7 @@ const FormSchema = new Schema({
 
 const EventSchema = new Schema({
   _id: { type: Number, required: true },
-  name: { type: String, required: true, unique: 'Event with name "{VALUE}" already exists.' },
+  name: { type: String, required: true, unique: true },
   description: { type: String, required: false },
   complete: { type: Boolean },
   collectionName: { type: String, required: true },


### PR DESCRIPTION
When using mongo db > 5.0.1, there was an issue that occurred due to a schema constraint in the EventSchema. The unique value must be a boolean. Switching this allowed for successful use with mongoDB 5.0.1 and mongoDB 6.0