### PR TITLE
Fixed filtered observation issue

### DIFF
--- a/web-app/src/app/observation/observation.service.ts
+++ b/web-app/src/app/observation/observation.service.ts
@@ -25,8 +25,11 @@ export class ObservationService {
 
   getObservationsForEvent(event: MageEvent, options: any): Observable<any> {
     const parameters: any = { eventId: event.id, states: 'active', populate: 'true' };
-    if (options.interval) {
+    if (options.interval.start) {
       parameters.observationStartDate = options.interval.start;
+    }
+
+    if (options.interval.end) {
       parameters.observationEndDate = options.interval.end;
     }
 


### PR DESCRIPTION
When the observation filter is set to "Last 24 hours," the `options.interval.end` time is undefined and string "undefined" is passed as a query parameter. This is then parsed by momentJS as an invalid DateTime and the mongoDB filter returns zero results. This fix only adds the `observationEndDate` parameter if it is defined.