### PR TITLE
initial sftp workflows into main branch

### DIFF
--- a/.github/workflows/build_test.sftp.service.yaml
+++ b/.github/workflows/build_test.sftp.service.yaml
@@ -1,0 +1,68 @@
+name: test and package sftp service plugin
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    paths:
+      - .github/workflows/build_test.sftp.service.yaml
+      - .github/workflows/config.yaml
+      - plugins/sftp/service/**
+
+jobs:
+
+  config:
+    uses: ./.github/workflows/config.yaml
+
+  test:
+    name: test plugin sftp.service
+    needs: [ config ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ${{ fromJSON(needs.config.outputs.node_versions-all-json) }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: |
+            plugins/sftp/service/package-lock.json
+      - name: test with node ${{ matrix.node }}
+        run: |
+          cd plugins/sftp/service
+          npm ci
+          rm -rf node_modules/@ngageoint/mage.service/node_modules/mongoose
+          npm test
+
+  package:
+    name: package plugin sftp.service
+    needs: [ config, test ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ needs.config.outputs.node_versions-lts }}
+          cache: npm
+          cache-dependency-path: |
+            plugins/sftp/service/package-lock.json
+      - name: build
+        run: |
+          cd plugins/sftp/service
+          npm ci
+          rm -rf node_modules/@ngageoint/mage.service/node_modules/mongoose
+          npm run build
+      - name: pack
+        run: npm pack ./plugins/sftp/service
+      - name: upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: sftp.service-artifacts
+          path: |
+            ngageoint-mage.*.tgz

--- a/.github/workflows/build_test.sftp.web-app.yaml
+++ b/.github/workflows/build_test.sftp.web-app.yaml
@@ -1,0 +1,49 @@
+name: test and package sftp web plugin
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    paths:
+      - .github/workflows/build_test.sftp.web.yaml
+      - .github/workflows/config.yaml
+      - plugins/sftp/web/**
+
+jobs:
+
+  config:
+    uses: ./.github/workflows/config.yaml
+
+  build:
+    name: build plugin mage.sftp.web
+    needs: config
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ needs.config.outputs.node_versions-lts }}
+          cache: npm
+          cache-dependency-path: plugins/sftp/web/package-lock.json
+      - name: build
+        run: |
+          cd plugins/sftp/web
+          npm ci
+          npm run build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+      - name: test
+        run: |
+          cd plugins/sftp/web
+          npm run test-headless
+      - name: pack
+        run: |
+          npm pack ./plugins/sftp/web/dist/main
+      - name: upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: sftp.web-artifacts
+          path: |
+            ngageoint-mage.sftp.web-*.tgz

--- a/.github/workflows/release.sftp_plugin.yaml
+++ b/.github/workflows/release.sftp_plugin.yaml
@@ -1,0 +1,65 @@
+name: release sftp plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version you want to assign to the release
+        type: string
+        required: true
+
+jobs:
+
+  config:
+    uses: ./.github/workflows/config.yaml
+
+  check_release_version:
+    needs: [ config ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ needs.config.outputs.node_versions-lts }}
+      - name: install json util
+        run: npm i -g json
+      - name: check service
+        run: |
+          [[ $(json version < ./plugins/sftp/service/package.json) = ${{ inputs.version }} ]] || exit 1
+      - name: check web
+        run: |
+          [[ $(json version < ./plugins/sftp/web/package.json) = ${{ inputs.version }} ]] || exit 1
+  build_and_test-service:
+    needs: [ check_release_version ]
+    uses: ./.github/workflows/build_test.sftp.service.yaml
+
+  build_and_test-web:
+    needs: [ check_release_version ]
+    uses: ./.github/workflows/build_test.sftp.web.yaml
+
+  publish_packages:
+    name:  publish packages
+    needs: [ config, build_and_test-service ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ needs.config.outputs.node_versions-lts }}
+      - name: install json util
+        run: npm i -g json
+      - name: download service packages
+        uses: actions/download-artifact@v4
+        with:
+          name: sftp.service-artifacts
+      - name: download web packages
+        uses: actions/download-artifact@v4
+        with:
+          name: sftp.web-artifacts
+      - name: publish to package registry
+        run: |
+          npm config set -- '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
+          npm publish --access public $(ls -1 ngageoint-mage.sftp.service-*.tgz)
+          npm publish --access public $(ls -1 ngageoint-mage.sftp.web-*.tgz)


### PR DESCRIPTION
Due to how workflows are enabled in github, we need to put out initial sftp workflows so we can properly utilize them from the branch as we make updates.