### PR TITLE
Create Contact Us Section on Info Page

### DIFF
--- a/web-app/angular.json
+++ b/web-app/angular.json
@@ -87,8 +87,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "12kb",
+                  "maximumError": "20kb"
                 }
               ]
             },
@@ -250,8 +250,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "12kb",
+                  "maximumError": "20kb"
                 }
               ]
             },
@@ -416,8 +416,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "12kb",
+                  "maximumError": "20kb"
                 }
               ]
             },

--- a/web-app/angular.json
+++ b/web-app/angular.json
@@ -87,8 +87,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "12kb",
-                  "maximumError": "20kb"
+                  "maximumWarning": "18kb",
+                  "maximumError": "30kb"
                 }
               ]
             },
@@ -250,8 +250,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "12kb",
-                  "maximumError": "20kb"
+                  "maximumWarning": "18kb",
+                  "maximumError": "30kb"
                 }
               ]
             },
@@ -416,8 +416,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "12kb",
-                  "maximumError": "20kb"
+                  "maximumWarning": "18kb",
+                  "maximumError": "30kb"
                 }
               ]
             },

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -15997,6 +15997,7 @@
     },
     "node_modules/tree-sitter-json": {
       "version": "0.20.2",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16005,6 +16006,7 @@
     },
     "node_modules/tree-sitter-yaml": {
       "version": "0.5.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/web-app/src/app/about/about.component.html
+++ b/web-app/src/app/about/about.component.html
@@ -3,14 +3,12 @@
     <button mat-icon-button (click)="onBack()">
       <mat-icon>arrow_back</mat-icon>
     </button>
-
-    <span class="title">About</span>
+    <span class="title">About MAGE</span>
   </div>
 </mat-toolbar>
 
 <div class="content">
   <div>
-    <div class="mat-h1">About</div>
     <p>
       Mage is a dynamic, secure, mobile situational awareness and field data collection platform that supports
       low-bandwidth and disconnected users. Mage can integrate with existing command centers and common operating
@@ -23,31 +21,43 @@
     </p>
 
     <div class="app-store">
-      <a href="https://itunes.apple.com/us/app/m.a.g.e./id1032815042?mt=8">
+      <a
+        class="center-content"
+        href="https://itunes.apple.com/us/app/m.a.g.e./id1032815042?mt=8"
+      >
         <img class="app-store-icon" src="/assets/images/ios_app_store_black.svg">
       </a>
-      <a href="https://play.google.com/store/apps/details?id=mil.nga.giat.mage&hl=en">
+      <a
+        class="center-content"
+        href="https://play.google.com/store/apps/details?id=mil.nga.giat.mage&hl=en"
+      >
         <img class="app-store-icon" src="/assets/images/google-play-badge.png">
       </a>
-    </div>
+    </div> 
   </div>
 
   <div>
-    <div class="mat-h1">API</div>
+    <h3>
+      <span>API</span>
+    </h3>
     <div>
       Browse and try the Mage API live with <a href="#/swagger">Swagger UI.</a> Swagger interactive documentation will modify Mage data via API calls; please be careful with <strong>POST/PUT/DELETE</strong> operations.
     </div>
   </div>
 
   <div>
-    <div class="mat-h1">System</div>
+    <h3>
+      <span>System</span>
+    </h3>
     <div>Server Version {{mageVersion?.major}}.{{mageVersion?.minor}}.{{mageVersion?.micro}}</div>
     <div>Node Version {{nodeVersion}}</div>
     <div>MongoDB Version {{mongoVersion}}</div>
   </div>
 
   <div>
-    <div class="mat-h1">Acknowledgements</div>
+    <h3>
+      <span>Acknowledgements</span>
+    </h3>
       <div>Mage is built with the MEAN stack
         <a href="https://www.mongodb.org/" target="_blank">MongoDB</a>, 
         <a href="https://expressjs.com/" target="_blank">Express</a>, 
@@ -63,5 +73,11 @@
         <a href="https://leafletjs.com/" target="_blank">Leaflet</a>
       </div>
   </div>
-
+  <div>
+    <h3>
+      <span>Contact Us</span>
+    </h3>
+    <p><i class="fa fa-phone"></i> +1-571-557-1121</p>
+    <p><i class="fa fa-envelope"></i><a href="mailto:magesuitesupport@nga.mil"> magesuitesupport@nga.mil</a></p>
+  </div>
 </div>

--- a/web-app/src/app/about/about.component.scss
+++ b/web-app/src/app/about/about.component.scss
@@ -10,10 +10,6 @@
   gap: 32px;
 }
 
-.mat-h1 {
-  color: mat.get-color-from-palette($app-primary);
-}
-
 .container {
   display: flex;
   flex-direction: row;

--- a/web-app/src/app/about/about.component.scss
+++ b/web-app/src/app/about/about.component.scss
@@ -1,6 +1,5 @@
 @use '@angular/material' as mat;
 @import "variables.scss";
-@import "font-awesome/css/font-awesome.min.css";
 
 .content {
   width: 75vw;

--- a/web-app/src/app/about/about.component.scss
+++ b/web-app/src/app/about/about.component.scss
@@ -1,8 +1,9 @@
 @use '@angular/material' as mat;
 @import "variables.scss";
+@import "font-awesome/css/font-awesome.min.css";
 
 .content {
-  width: 50vw;
+  width: 75vw;
   margin: 0 auto;
   padding: 32px 0;
   display: flex;
@@ -21,6 +22,20 @@
   justify-content: center;
 }
 
+h3 {
+  width:100%;
+  text-align:left;
+  border-bottom: 1px solid #000;
+  line-height:0.1em;
+  margin:10px 0 20px;
+  color: mat.get-color-from-palette($app-primary);
+} 
+h3 span {
+  background:#fff;
+  padding:0 10px;
+  border: none;
+}
+
 .title {
   margin-left: 16px;
 }
@@ -30,8 +45,13 @@
   flex-direction: row;
   gap: 16px;
   align-items: center;
+  margin-top: 20px;
 }
 
 .app-store-icon {
   height: 48px;
+}
+
+.center-content{
+  margin: 0 auto !important;
 }

--- a/web-app/src/app/about/about.component.ts
+++ b/web-app/src/app/about/about.component.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'about',
   templateUrl: './about.component.html',
-  styleUrls: ['./about.component.scss']
+  styleUrls: ['./about.component.scss', '../../../node_modules/font-awesome/css/font-awesome.min.css']
 })
 export class AboutComponent implements OnInit {
   mageVersion: {


### PR DESCRIPTION
A Contact Us Form is Needed to allow users to call or email for support. 
<img width="800" alt="image" src="https://github.com/user-attachments/assets/2a346198-5c7b-4f22-bf35-c7db38f44997" />

Testing instructions:

- Build Web App
- Run Mage Server Locally
- Navigate to `http://localhost:4242/#/about`
    - Alternatively for sanity checks navigate to `http://localhost:4242/` and click the information icon in the top menu
- Note the Layout Changes
- Note the New Contact Us Section
- Click on the e-mail address
    - Expected Result is email app is opened and `to:` field is populated with correct address