### PR TITLE
1390 - SFTP Plugin Password Encryption

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     environment:
       MAGE_MONGO_URL: mongodb://mage-db:27017/magedb
       MAGE_TOKEN_EXPIRATION: "28800"
+      # NOTE: default INSECURE salt value, recommend generate new UUID before deployment, **NOT** after deployment
+      SFTP_PLUGIN_CONFIG_SALT: "A0E6D3B4-25BD-4DD6-BBC9-B367931966AB"
 
   # Uncomment the following block to enable the TLS reverse proxy.  You will
   # also need to generate the key and certificate as the README describes.

--- a/plugins/sftp/config/sftpConfig.ts
+++ b/plugins/sftp/config/sftpConfig.ts
@@ -1,0 +1,20 @@
+export const eKey: Promise<CryptoKey> = window.crypto.subtle.generateKey(
+  {
+      name: "AES-GCM",
+      length: 256, //can be  128, 192, or 256
+  },
+  true, //whether the key is extractable (i.e. can be used in exportKey)
+  ["encrypt", "decrypt"] //can "encrypt", "decrypt", "wrapKey", or "unwrapKey"
+)
+
+export function arrayBufferToString(buffer: ArrayBuffer, encoding = 'utf-8'): string {
+  const decoder = new TextDecoder(encoding);
+  const view = new Uint8Array(buffer);
+  return decoder.decode(view);
+}
+
+export function stringToArrayBuffer(str: string): ArrayBuffer {
+  let enc = new TextEncoder();
+  var encoded = enc.encode(str);
+  return encoded;
+}

--- a/plugins/sftp/service/package-lock.json
+++ b/plugins/sftp/service/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "archiver": "^6.0.1",
+        "crypto-js": "^4.1.1",
         "ssh2-sftp-client": "^9.1.0"
       },
       "devDependencies": {
         "@types/archiver": "^6.0.2",
         "@types/bson": "^1.0.11",
+        "@types/crypto-js": "^4.2.2",
         "@types/express": "4.17.21",
         "@types/express-serve-static-core": "4.17.29",
         "@types/geojson": "^7946.0.7",
@@ -15639,6 +15641,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "4.17.21",
       "dev": true,
@@ -17043,6 +17052,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "license": "MIT"
     },
     "node_modules/cssom": {
       "version": "0.4.4",

--- a/plugins/sftp/service/package.json
+++ b/plugins/sftp/service/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/archiver": "^6.0.2",
     "@types/bson": "^1.0.11",
+    "@types/crypto-js": "^4.2.2",
     "@types/express": "4.17.21",
     "@types/express-serve-static-core": "4.17.29",
     "@types/geojson": "^7946.0.7",
@@ -51,6 +52,7 @@
   },
   "dependencies": {
     "archiver": "^6.0.1",
+    "crypto-js": "^4.1.1",
     "ssh2-sftp-client": "^9.1.0"
   }
 }

--- a/plugins/sftp/service/src/configuration/SFTPPluginConfig.ts
+++ b/plugins/sftp/service/src/configuration/SFTPPluginConfig.ts
@@ -1,5 +1,6 @@
 import { MageEventId } from '@ngageoint/mage.service/lib/entities/events/entities.events';
 import { ArchiveFormat, CompletionAction, TriggerRule } from '../format/entities.format';
+import * as CryptoJS from 'crypto-js';
 
 /**
  * Contains various configuration values used by the plugin.
@@ -74,54 +75,18 @@ export const defaultSFTPPluginConfig = Object.freeze<SFTPPluginConfig>({
   }
 })
 
-export function arrayBufferToString(buffer: ArrayBuffer): string {
-  const decoder = new TextDecoder();
-  return decoder.decode(buffer);
-}
-
-export function stringToArrayBuffer(str: string): ArrayBuffer {
-  let enc = new TextEncoder();
-  return enc.encode(str);
-}
+const salt = 'A0E6D3B4-25BD-4DD6-BBC9-B367931966AB';
 
 export async function encryptDecrypt(config: SFTPPluginConfig, isEncrypt: boolean): Promise<SFTPPluginConfig> {
-  let tempConfig = config;
-  // const encodedPassword = stringToArrayBuffer(config.sftpClient.password)
-  // const salt = 'db17cd34-d1fd-4ffc-a83c-e30a59c0fe81' // ***NOTE: This is the environment variable***
-  const algoName = 'AES-GCM'
-  const rawKey = new Uint8Array([
-    109,151,76,33,232,253,176,90,94,40,146,227,139,208,245,139,69,215,55,197,43,122,160,178,228,104,4,115,138,159,119,49,
-  ]);
-  const importedKey = await crypto.subtle.importKey(
-    'raw',
-    rawKey,
-    { name: algoName, length: 256 },
-    true,
-    ['decrypt', 'encrypt']
-  );
-  console.log(`importedKey:${JSON.stringify(importedKey)}`)
   try {
-    if (isEncrypt) {
-      console.log(`pass before encrypt: ${config.sftpClient.password}`)
-      const encryptedPassword = await crypto.subtle.encrypt(
-        { name: algoName, iv: rawKey }, // algorithm
-        importedKey, // CryptoKey
-        stringToArrayBuffer(config.sftpClient.password), // BufferSource
-      );
-      console.log(`encryptedPassword:${encryptedPassword}`)
-      tempConfig.sftpClient.password = arrayBufferToString(encryptedPassword);
-    } else {
-      console.log(`pass before decrypt: ${config.sftpClient.password}`)
-      const decryptedPassword = await crypto.subtle.decrypt(
-        { name: algoName, iv: rawKey }, // algorithm
-        importedKey, // CryptoKey
-        stringToArrayBuffer(config.sftpClient.password), // BufferSource
-      );
-      console.log(`decryptedPassword:${decryptedPassword}`)
-      tempConfig.sftpClient.password = arrayBufferToString(decryptedPassword);
-    }
+    let tempConfig = config;
+    const encryptedPass = isEncrypt ?
+      CryptoJS.AES.encrypt(config.sftpClient.password, salt).toString() :
+      CryptoJS.AES.decrypt(config.sftpClient.password, salt).toString();
+    tempConfig.sftpClient.password = encryptedPass;
+    return tempConfig;
   } catch (e) {
-    console.log(`ERROR: encrypt/decrypt: ${e}`);
+    console.log(e);
+    return config;
   }
-  return tempConfig;
 }

--- a/plugins/sftp/service/src/configuration/SFTPPluginConfig.ts
+++ b/plugins/sftp/service/src/configuration/SFTPPluginConfig.ts
@@ -1,6 +1,7 @@
 import { MageEventId } from '@ngageoint/mage.service/lib/entities/events/entities.events';
 import { ArchiveFormat, CompletionAction, TriggerRule } from '../format/entities.format';
 import * as CryptoJS from 'crypto-js';
+import { error } from 'console';
 
 /**
  * Contains various configuration values used by the plugin.
@@ -75,18 +76,19 @@ export const defaultSFTPPluginConfig = Object.freeze<SFTPPluginConfig>({
   }
 })
 
-const salt = 'A0E6D3B4-25BD-4DD6-BBC9-B367931966AB';
+// NOTE: default INSECURE salt value, recommend generate new UUID before deployment, **NOT** after deployment
+const salt = process.env.SFTP_PLUGIN_CONFIG_SALT;
 
 export async function encryptDecrypt(config: SFTPPluginConfig, isEncrypt: boolean): Promise<SFTPPluginConfig> {
   try {
     let tempConfig = config;
+    if(salt === undefined) { throw new Error("No salt value found, update docker-compose value...") }
     const encryptedPass = isEncrypt ?
       CryptoJS.AES.encrypt(config.sftpClient.password, salt).toString() :
       CryptoJS.AES.decrypt(config.sftpClient.password, salt).toString();
     tempConfig.sftpClient.password = encryptedPass;
     return tempConfig;
-  } catch (e) {
-    console.log(e);
-    return config;
+  } catch (err) {
+    throw err;
   }
 }

--- a/plugins/sftp/service/src/configuration/SFTPPluginConfig.ts
+++ b/plugins/sftp/service/src/configuration/SFTPPluginConfig.ts
@@ -73,3 +73,55 @@ export const defaultSFTPPluginConfig = Object.freeze<SFTPPluginConfig>({
     password: ''
   }
 })
+
+export function arrayBufferToString(buffer: ArrayBuffer): string {
+  const decoder = new TextDecoder();
+  return decoder.decode(buffer);
+}
+
+export function stringToArrayBuffer(str: string): ArrayBuffer {
+  let enc = new TextEncoder();
+  return enc.encode(str);
+}
+
+export async function encryptDecrypt(config: SFTPPluginConfig, isEncrypt: boolean): Promise<SFTPPluginConfig> {
+  let tempConfig = config;
+  // const encodedPassword = stringToArrayBuffer(config.sftpClient.password)
+  // const salt = 'db17cd34-d1fd-4ffc-a83c-e30a59c0fe81' // ***NOTE: This is the environment variable***
+  const algoName = 'AES-GCM'
+  const rawKey = new Uint8Array([
+    109,151,76,33,232,253,176,90,94,40,146,227,139,208,245,139,69,215,55,197,43,122,160,178,228,104,4,115,138,159,119,49,
+  ]);
+  const importedKey = await crypto.subtle.importKey(
+    'raw',
+    rawKey,
+    { name: algoName, length: 256 },
+    true,
+    ['decrypt', 'encrypt']
+  );
+  console.log(`importedKey:${JSON.stringify(importedKey)}`)
+  try {
+    if (isEncrypt) {
+      console.log(`pass before encrypt: ${config.sftpClient.password}`)
+      const encryptedPassword = await crypto.subtle.encrypt(
+        { name: algoName, iv: rawKey }, // algorithm
+        importedKey, // CryptoKey
+        stringToArrayBuffer(config.sftpClient.password), // BufferSource
+      );
+      console.log(`encryptedPassword:${encryptedPassword}`)
+      tempConfig.sftpClient.password = arrayBufferToString(encryptedPassword);
+    } else {
+      console.log(`pass before decrypt: ${config.sftpClient.password}`)
+      const decryptedPassword = await crypto.subtle.decrypt(
+        { name: algoName, iv: rawKey }, // algorithm
+        importedKey, // CryptoKey
+        stringToArrayBuffer(config.sftpClient.password), // BufferSource
+      );
+      console.log(`decryptedPassword:${decryptedPassword}`)
+      tempConfig.sftpClient.password = arrayBufferToString(decryptedPassword);
+    }
+  } catch (e) {
+    console.log(`ERROR: encrypt/decrypt: ${e}`);
+  }
+  return tempConfig;
+}

--- a/plugins/sftp/service/src/controller/controller.ts
+++ b/plugins/sftp/service/src/controller/controller.ts
@@ -7,7 +7,6 @@ import { PassThrough } from 'stream';
 import { SFTPPluginConfig, defaultSFTPPluginConfig, encryptDecrypt } from '../configuration/SFTPPluginConfig';
 import { ArchiveFormat, ArchiveStatus, ArchiverFactory, ArchiveResult, TriggerRule } from '../format/entities.format';
 import { SftpAttrs, SftpObservationRepository, SftpStatus } from '../adapters/adapters.sftp.mongoose';
-import { enc } from 'crypto-js';
 
 /**
  * Class used to process observations for SFTP
@@ -109,7 +108,8 @@ export class SftpController {
    */
   public async updateConfiguration(configuration: SFTPPluginConfig) {
     try {
-      await this.stateRepository.put(await encryptDecrypt(configuration, true))
+      let config = await encryptDecrypt(configuration, true);
+      await this.stateRepository.put(config)
     } catch (err) {
       this.console.log(`ERROR: updateConfiguration: ${err}`)
     }

--- a/plugins/sftp/service/src/controller/controller.ts
+++ b/plugins/sftp/service/src/controller/controller.ts
@@ -7,6 +7,7 @@ import { PassThrough } from 'stream';
 import { SFTPPluginConfig, defaultSFTPPluginConfig, encryptDecrypt } from '../configuration/SFTPPluginConfig';
 import { ArchiveFormat, ArchiveStatus, ArchiverFactory, ArchiveResult, TriggerRule } from '../format/entities.format';
 import { SftpAttrs, SftpObservationRepository, SftpStatus } from '../adapters/adapters.sftp.mongoose';
+import { enc } from 'crypto-js';
 
 /**
  * Class used to process observations for SFTP

--- a/plugins/sftp/service/src/index.ts
+++ b/plugins/sftp/service/src/index.ts
@@ -108,7 +108,7 @@ const sftpPluginHooks: InitPluginHook<typeof InjectedServices> = {
 
               await controller.start()
 
-              res.status(200).json(configuration)
+              res.status(200) //.json(configuration)
             })
 
           return routes


### PR DESCRIPTION
# Mage -> Admin -> SFTP plugin:
- when a user is adding credentials for connecting to their SFTP server we are now encrypting the password.
- we use a library named: `crypto-js`
- uses a *salt* UUID that is stored in `docker-compose` file
- it gets encrypted when updating, then stored in Mongo
- it gets decrypted when getting from Mongo
<img width="350" alt="Mage_SFTP_Plugin_Password_Encryption" src="https://github.com/user-attachments/assets/120807a1-1647-49b2-a9df-2bd59602709e" />
