### PR TITLE
1420 - Event Layer Description

### DIFF
--- a/web-app/admin/src/ng1/admin/events/event.html
+++ b/web-app/admin/src/ng1/admin/events/event.html
@@ -363,7 +363,7 @@ on-form-create-close="$ctrl.onFormCreateClose(form)" event="$ctrl.event"></admin
                           <div class="strong right-gap">
                             <span class="right-gap">{{layer.name}}</span>
                           </div>
-                          <div class="muted">{{layer.description}}</div>
+                          <div class="muted trunc">{{layer.description}}</div>
                         </div>
                         <a class="btn btn-xs btn-success" ng-click="$ctrl.addLayer($event, layer)">Add Layer</a>
                       </div>

--- a/web-app/admin/src/ng1/css/admin/team/team.scss
+++ b/web-app/admin/src/ng1/css/admin/team/team.scss
@@ -9,6 +9,12 @@
 
   &user-detail {
     flex: 1;
+    min-width: 0;
+    .trunc {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   &table {


### PR DESCRIPTION
# 1420 - Layer description bug
- Layers descriptions that are long cause a weird display issue on the *events* page.

## Before
<img width="700" alt="mage_event_layer_description_after" src="https://github.com/user-attachments/assets/c9ae54d6-58af-478f-b636-071fc5de3392" />

## After
<img width="700" alt="mage_event_layer_description_after" src="https://github.com/user-attachments/assets/0a02d04b-0cb3-415c-b2c7-cdb3fe0bc1fc" />

