### PR TITLE
Only Admin users should view plugins

### DIFF
--- a/web-app/admin/src/ng1/admin/admin.tab.component.js
+++ b/web-app/admin/src/ng1/admin/admin.tab.component.js
@@ -5,6 +5,7 @@ class AdminTabController {
     this.$state = $state;
     this.UserService = UserService;
     this.token = LocalStorageService.getToken()
+    this.isAdmin = this.UserService.myself.role.name === 'ADMIN_ROLE';
   }
 
   hasPermission(permission) {

--- a/web-app/admin/src/ng1/admin/admin.tab.component.js
+++ b/web-app/admin/src/ng1/admin/admin.tab.component.js
@@ -4,8 +4,7 @@ class AdminTabController {
   constructor($state, UserService, LocalStorageService) {
     this.$state = $state;
     this.UserService = UserService;
-    this.token = LocalStorageService.getToken()
-    this.isAdmin = this.UserService.myself.role.name === 'ADMIN_ROLE';
+    this.token = LocalStorageService.getToken();
   }
 
   hasPermission(permission) {

--- a/web-app/admin/src/ng1/admin/admin.tab.html
+++ b/web-app/admin/src/ng1/admin/admin.tab.html
@@ -86,7 +86,7 @@
       <div>Settings</div>
     </div>
 
-    <div class="admin-action" ng-if="$ctrl.isAdmin" ng-repeat="pluginTab in $ctrl.pluginTabs"
+    <div class="admin-action" ng-if="$ctrl.hasPermission('UPDATE_SETTINGS')" ng-repeat="pluginTab in $ctrl.pluginTabs"
       ng-class="{'admin-action-selected': $ctrl.stateName === pluginTab.state}"
       ng-click="$ctrl.tabChanged(pluginTab.state)">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === pluginTab.state}"></div>

--- a/web-app/admin/src/ng1/admin/admin.tab.html
+++ b/web-app/admin/src/ng1/admin/admin.tab.html
@@ -1,79 +1,98 @@
 <div class="admin-actions">
   <div class="admin-actions-content">
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.dashboard'}" ng-click="$ctrl.tabChanged('admin.dashboard')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.dashboard'}"
+      ng-click="$ctrl.tabChanged('admin.dashboard')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.dashboard'}"></div>
       <div class="admin-badge">
         <i class="fa fa-dashboard"></i>
-        <span ng-if="$ctrl.inactiveUsers.length || $ctrl.unregisteredDevices.length" class="badge badge-notif badge-accent">{{$ctrl.inactiveUsers.length + $ctrl.unregisteredDevices.length}}</span>
+        <span ng-if="$ctrl.inactiveUsers.length || $ctrl.unregisteredDevices.length"
+          class="badge badge-notif badge-accent">{{$ctrl.inactiveUsers.length +
+          $ctrl.unregisteredDevices.length}}</span>
       </div>
       <div>Dashboard</div>
     </div>
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.users'}" ng-click="$ctrl.tabChanged('admin.users')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.users'}"
+      ng-click="$ctrl.tabChanged('admin.users')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.users'}"></div>
       <div class="admin-badge">
         <i class="fa fa-user"></i>
-        <span ng-if="$ctrl.inactiveUsers.length" class="badge badge-notif badge-accent">{{$ctrl.inactiveUsers.length}}</span>
+        <span ng-if="$ctrl.inactiveUsers.length"
+          class="badge badge-notif badge-accent">{{$ctrl.inactiveUsers.length}}</span>
       </div>
       <div>Users</div>
     </div>
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.teams'}" ng-click="$ctrl.tabChanged('admin.teams')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.teams'}"
+      ng-click="$ctrl.tabChanged('admin.teams')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.teams'}"></div>
       <i class="fa fa-users"></i>
       <div>Teams</div>
     </div>
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.events'}" ng-click="$ctrl.tabChanged('admin.events')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.events'}"
+      ng-click="$ctrl.tabChanged('admin.events')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.events'}"></div>
       <i class="fa fa-calendar"></i>
       <div>Events</div>
     </div>
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'maindevices'}" ng-click="$ctrl.tabChanged('admin.devices')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'maindevices'}"
+      ng-click="$ctrl.tabChanged('admin.devices')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.devices'}"></div>
       <div class="admin-badge">
         <i class="fa fa-mobile-phone"></i>
-        <span ng-if="$ctrl.unregisteredDevices.length" class="badge badge-notif badge-accent">{{$ctrl.unregisteredDevices.length}}</span>
+        <span ng-if="$ctrl.unregisteredDevices.length"
+          class="badge badge-notif badge-accent">{{$ctrl.unregisteredDevices.length}}</span>
       </div>
       <div>Devices</div>
     </div>
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.layers'}" ng-click="$ctrl.tabChanged('admin.layers')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.layers'}"
+      ng-click="$ctrl.tabChanged('admin.layers')">
       <div ng-class="{'admin-action-arrow-left':$ctrl.stateName === 'admin.layers'}"></div>
       <i class="fa fa-map"></i>
       <div>Layers</div>
     </div>
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.feeds'}" ng-click="$ctrl.tabChanged('admin.feeds')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.feeds'}"
+      ng-click="$ctrl.tabChanged('admin.feeds')">
       <div ng-class="{'admin-action-arrow-left':$ctrl.stateName === 'admin.feeds'}"></div>
       <i class="fa fa-rss"></i>
       <div>Feeds</div>
     </div>
 
-    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.map'}" ng-click="$ctrl.tabChanged('admin.map')">
+    <div class="admin-action" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.map'}"
+      ng-click="$ctrl.tabChanged('admin.map')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.map'}"></div>
       <i class="fa fa-globe"></i>
       <div>Map</div>
     </div>
 
-    <div class="admin-action" ng-if="$ctrl.hasPermission('UPDATE_SETTINGS')" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.security'}" ng-click="$ctrl.tabChanged('admin.security')">
+    <div class="admin-action" ng-if="$ctrl.hasPermission('UPDATE_SETTINGS')"
+      ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.security'}"
+      ng-click="$ctrl.tabChanged('admin.security')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.security'}"></div>
       <i class="fa fa-shield"></i>
       <div>Security</div>
     </div>
 
-    <div class="admin-action" ng-if="$ctrl.hasPermission('UPDATE_SETTINGS')" ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.settings'}" ng-click="$ctrl.tabChanged('admin.settings')">
+    <div class="admin-action" ng-if="$ctrl.hasPermission('UPDATE_SETTINGS')"
+      ng-class="{'admin-action-selected': $ctrl.stateName === 'admin.settings'}"
+      ng-click="$ctrl.tabChanged('admin.settings')">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === 'admin.settings'}"></div>
       <i class="fa fa-wrench"></i>
       <div>Settings</div>
     </div>
 
-    <div class="admin-action" ng-repeat="pluginTab in $ctrl.pluginTabs" ng-class="{'admin-action-selected': $ctrl.stateName === pluginTab.state}" ng-click="$ctrl.tabChanged(pluginTab.state)">
+    <div class="admin-action" ng-if="$ctrl.isAdmin" ng-repeat="pluginTab in $ctrl.pluginTabs"
+      ng-class="{'admin-action-selected': $ctrl.stateName === pluginTab.state}"
+      ng-click="$ctrl.tabChanged(pluginTab.state)">
       <div ng-class="{'admin-action-arrow-left': $ctrl.stateName === pluginTab.state}"></div>
       <div ng-if="pluginTab.icon.path">
-        <img class="admin-plugin-icon" ng-src="/ui_plugins/{{pluginTab.id}}/{{pluginTab.icon.path}}?access_token={{$ctrl.token}}">
+        <img class="admin-plugin-icon"
+          ng-src="/ui_plugins/{{pluginTab.id}}/{{pluginTab.icon.path}}?access_token={{$ctrl.token}}">
       </div>
       <i ng-if="pluginTab.icon.className" class="{{pluginTab.icon.className}}"></i>
       <i ng-if="!pluginTab.icon.path && !pluginTab.icon.className" class="fa fa-plug"></i>

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -69,7 +69,7 @@
         "ngx-color": "8.0.3",
         "ngx-mat-select-search": "5.0.0",
         "papaparse": "4.1.4",
-        "rxjs": "7.6.0",
+        "rxjs": "7.8.2",
         "select2": "4.0.7",
         "semver": "7.6.2",
         "swagger-ui": "3.52.4",
@@ -14420,8 +14420,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -120,7 +120,7 @@
     "ngx-color": "8.0.3",
     "ngx-mat-select-search": "5.0.0",
     "papaparse": "4.1.4",
-    "rxjs": "7.6.0",
+    "rxjs": "7.8.2",
     "select2": "4.0.7",
     "semver": "7.6.2",
     "swagger-ui": "3.52.4",


### PR DESCRIPTION
This PR fixes an issue where Event managers where able to view the plugins on the admin page.

Admin View:
<img width="123" alt="Screenshot 2025-05-07 at 9 49 35 AM" src="https://github.com/user-attachments/assets/e6774956-907d-4817-8d75-d40388c2dd6a" />

Event manager view:
<img width="129" alt="Screenshot 2025-05-07 at 9 50 08 AM" src="https://github.com/user-attachments/assets/6c104c31-1ce8-4c3c-8663-65bd23d41f6a" />
