### PR TITLE
1429 - Console Errors

### DIFF
--- a/web-app/admin/src/app/user/user-avatar/user-avatar.component.ts
+++ b/web-app/admin/src/app/user/user-avatar/user-avatar.component.ts
@@ -25,9 +25,19 @@ export class UserAvatarComponent implements OnChanges {
   }
 
   fetchAvatar(): void {
-    const url = `/api/users/${this.user.id}/avatar`
-    this.httpClient.get(url, { responseType: 'blob' }).subscribe(blob => {
-      this.url = this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(blob));
+    const url = `/api/users/${this.user.id}/avatar`;
+    this.httpClient.get(url, { responseType: 'blob' }).subscribe({
+      next: (blob) => {
+        this.url = this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(blob));
+      },
+      error: (err) => {
+        if(err.status === 404){
+          console.warn('Avatar not found (404). Using fallback.');
+        } else {
+          console.error('Error fetching avatar:', err);
+        }
+        this.url = '/assets/images/baseline-account_circle-24px.svg'; // fallback image
+      }
     });
   }
 }

--- a/web-app/src/app/ingress/ingress.component.ts
+++ b/web-app/src/app/ingress/ingress.component.ts
@@ -128,7 +128,8 @@ export class IngressComponent implements OnChanges {
   }
 
   onAuthenticated($event: { user: User, token: string }) {
-    this.userService.authorize($event.token, null).subscribe({
+    // NOTE: using null causes a 500, instead using any non-empty string forces the code to be re-entered
+    this.userService.authorize($event.token, 'refresh').subscribe({
       next: (response) => {
         this.authorized(response.token)
       },

--- a/web-app/src/app/user/user-avatar/user-avatar.component.ts
+++ b/web-app/src/app/user/user-avatar/user-avatar.component.ts
@@ -38,9 +38,19 @@ export class UserAvatarComponent implements OnChanges {
   }
 
   fetchAvatar(): void {
-    const url = `/api/users/${this.user.id}/avatar`
-    this.httpClient.get(url, { responseType: 'blob' }).subscribe(blob => {
-      this.url = this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(blob));
+    const url = `/api/users/${this.user.id}/avatar`;
+    this.httpClient.get(url, { responseType: 'blob' }).subscribe({
+      next: (blob) => {
+        this.url = this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(blob));
+      },
+      error: (err) => {
+        if(err.status === 404){
+          console.warn('Avatar not found (404). Using fallback.');
+        } else {
+          console.error('Error fetching avatar:', err);
+        }
+        this.url = '/assets/images/baseline-account_circle-24px.svg'; // fallback image
+      }
     });
   }
 }


### PR DESCRIPTION
- **Error 1** - When going to the about page, an error is thrown: ERROR TypeError: Cannot read properties of undefined (reading 'nodeVersion'). There are currently versions listed under the 'System section'. Both Node and MongoDB version appear blank.
  + **Solution:** This error seems to have already been fixed, it does not occur.
- **Error 2** - As a user, as I navigate around the mage application if I do not have an avatar picture I see the following error: GET https://abcdemo.mage.geointapps.com/api/users/68127b109cf25890fe279780/avatar 404 (Not Found)
  + **Solution:** Added a more descriptive warning.
- **Error 3** - When logging in, an error shows up: https://abcdemo.mage.geointapps.com/auth/token?createDevice=false 500 internal server error.
  + **Solution:** Replaced the `null` that produced the 500 with a non-empty string to instead produce a 403 which still forces the user to re-enter the pass code.