### PR TITLE
Improve the Mage Build and Run Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,47 +273,45 @@ and [`@ngageoint/mage.web-app`](./web-app/).  There are more optional packages i
 directory.  The [`instance`](./instance/) package is an example of assembling all the packages into a running MAGE
 server instance.
 
-First, build the `service` package.
-```bash
-cd service
-npm ci
-npm run build
-```
-Then build the `web-app` package.
-```bash
-cd web-app
-npm ci
-npm run build
-```
-Build optional plugin packages similarly.:
-```bash
-cd plugins/nga-msi
-npm ci
-npm link ../../service # **IMPORTANT** see below
-npm run build
-```
-After building the core packages, install them as dependencies in the `instance` package.
-```bash
-cd instance
-npm i 
-```
+The project's root [`package.json`](./package.json) provides convenience script entries to install, build, and run
+the MAGE server components.
 
-In the case that the dev dependencies need to be over ridden (eg nga-msi plugin)
-```bash
-cd instance
-npm i --omit dev ../service ../web-app/dist ../plugins/nga-msi
-```
+Download and install the dependencies:
 
-The project's root [`package.json`](./package.json) provides some convenience script entries to install, build, and run
-the MAGE server components, however, those are deprecated and will likely go away after migrating to NPM 7+'s
-[workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces) feature.
+    git clone git@github.com:ngageoint/mage-server.git
+    cd mage-server
+    npm install
+
+Build the app without plugins
+
+    npm run build
+
+Optional: Build the app with plugins (arcgis and sftp)
+
+    npm run build-all
+
+Run an instance of mongodb via Docker Desktop:
+
+    docker run -d -p 27017:27017 mongo:6.0.4
+
+Run the app with the `instance/config.ts` settings
+
+    npm start
+
+If the monogo database is up and running and everything is built, you should see a message like:
+
+    2025-05-13T20:12:36.120Z - info: MAGE Server listening at address 127.0.0.1 on port 4242
+
+Open a browser to: <http://127.0.0.1:4242>. If the ArcGIS and SFTP plug-ins were built, you'll see those tabs on the sidebar in Settings.
+
+As you make changes, you can either build the entire app `npm run build` in the root directory, or only the parts that you are working on (web-app, service, plugin, etc.).
 
 ## Running from source
 
 To run the Mage server directly from your _built_ source tree, build the `service`, `web-app`, and any plugin packages 
 you want to run as described in the above section.  Then, from the `instance` directory, run
 ```shell
-npm run start:dev
+npm run start
 ```
 That [NPM script](./instance/package.json) will run the `mage.service` script from your working tree using the 
 [configuration](./instance/config.js) from the instance directory.  You can modify that configuration to suit

--- a/instance/config.js
+++ b/instance/config.js
@@ -34,8 +34,6 @@ module.exports = {
     plugins: {
       servicePlugins: [
         '@ngageoint/mage.arcgis.service',
-        '@ngageoint/mage.nga-msi',
-        '@ngageoint/mage.random',
         '@ngageoint/mage.sftp.service'
       ],
       webUIPlugins: [

--- a/instance/package.json
+++ b/instance/package.json
@@ -26,9 +26,6 @@
   "dependencies": {
     "@ngageoint/mage.arcgis.service": "../plugins/arcgis/service",
     "@ngageoint/mage.arcgis.web-app": "../plugins/arcgis/web-app/dist/main",
-    "@ngageoint/mage.image.service": "../plugins/image/service",
-    "@ngageoint/mage.nga-msi": "../plugins/nga-msi",
-    "@ngageoint/mage.random": "../plugins/random",
     "@ngageoint/mage.sftp.web": "../plugins/sftp/web/dist/main",
     "@ngageoint/mage.sftp.service": "../plugins/sftp/service",
     "@ngageoint/mage.service": "../service",

--- a/instance/package.json
+++ b/instance/package.json
@@ -3,10 +3,9 @@
   "version": "6.3.0-beta.8",
   "description": "Assemble a MAGE Server deployment from the core service, the web-app, and selected plugins.  This is primarily a development tool because the dependencies point to relative directories instead of production packages.  This can however serve as a starting point to create a production MAGE instance package.json.",
   "scripts": {
-    "start": "npm run start:dev-env",
+    "start": "npm run start:dev",
     "start:dev": "NODE_PATH=./node_modules node ./node_modules/.bin/mage.service -C config.js",
-    "postinstall": "node ./init.js",
-    "start:dev-env": "NODE_PATH=./node_modules node ./node_modules/.bin/mage.service"
+    "postinstall": "node ./init.js"
   },
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ngageoint/mage.project",
-  "version": "6.3.0-beta.7",
+  "version": "6.3.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ngageoint/mage.project",
-      "version": "6.3.0-beta.7",
+      "version": "6.3.0-beta.8",
       "hasInstallScript": true,
       "devDependencies": {
         "npm-run-all": "4.1.5"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "version": "6.3.0-beta.8",
   "files": [],
   "scripts": {
-    "postinstall": "npm-run-all service:ci web-app:ci image.service:ci nga-msi:ci",
-    "install:resolve": "npm-run-all service:install web-app:install image.service:install nga-msi:install",
-    "build": "npm-run-all service:build web-app:build image.service:build nga-msi:build instance:build",
+    "postinstall": "npm-run-all service:ci web-app:ci arcgis:ci sftp:ci",
+    "install:resolve": "npm-run-all service:install web-app:install",
+    "build": "npm-run-all service:build web-app:build instance:build",
+    "build-all": "npm-run-all build arcgis:build sftp:build",
+
     "pack-all": "npm-run-all service:pack web-app:pack image.service:pack nga-msi:pack",
     "service:install": "npm install --prefix service",
     "service:ci": "npm ci --prefix service",
@@ -21,6 +23,22 @@
     "instance:build": "npm install --prefix instance",
     "instance:start-config": "npm run start:dev --prefix instance",
     "instance:start-env": "npm run start:dev-env --prefix instance",
+    "instance:start": "npm run start --prefix instance",
+    
+    "arcgis:ci": "npm-run-all arcgis.service:ci arcgis.web-app:ci",
+    "arcgis.web-app:ci": "npm ci --prefix plugins/arcgis/web-app",
+    "arcgis.service:ci": "cd plugins/arcgis/service && npm ci && npm link ../../../service",
+    "arcgis:build":"npm-run-all arcgis.service:build arcgis.web-app:build",
+    "arcgis.service:build": "npm run build --prefix plugins/arcgis/service",
+    "arcgis.web-app:build": "npm run build --prefix plugins/arcgis/web-app",
+
+    "sftp:ci": "npm-run-all sftp.service:ci sftp.web:ci",
+    "sftp.web:ci": "npm ci --prefix plugins/sftp/web",
+    "sftp.service:ci": "cd plugins/sftp/service && npm ci && npm link ../../../service",
+    "sftp:build": "npm-run-all sftp.service:build sftp.web:build",
+    "sftp.service:build": "npm run build --prefix plugins/sftp/service",
+    "sftp.web:build": "npm run build --prefix plugins/sftp/web",    
+
     "image.service:install": "npm install --prefix plugins/image/service",
     "image.service:ci": "npm ci --prefix plugins/image/service",
     "image.service:build": "npm run build --prefix plugins/image/service",
@@ -29,7 +47,8 @@
     "nga-msi:ci": "npm ci --prefix plugins/nga-msi",
     "nga-msi:build": "npm run build --prefix plugins/nga-msi",
     "nga-msi:pack": "npm pack ./plugins/nga-msi",
-    "start": "npm run instance:start-env",
+    
+    "start": "npm run instance:start",
     "start-web": "npm run web-app:debug"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated the `npm` scripts to install, build, and start the server. The current process requires a lot of manual steps

* Added new package.node scripts to simplify the build and launch process
* Updated the README.md build instructions
* Removed the unused `nga-msi` and `random` plugins from the `instance/config.js` to remove errors

## High Level Workflow

    git clone git@github.com:ngageoint/mage-server.git
    cd mage-server

    npm install
    npm run build
    npm start

## Build timing (M4 Pro)

    npm install # ~53s
    npm build # ~38s (without plug-ins)
    npm build-all # ~75s (with plug-ins)