### PR TITLE
MAGE-1395 -  Add Event Selection to ARCGis

### DIFF
--- a/plugins/arcgis/web-app/projects/main/src/lib/arc-event/ArcEventsModel.ts
+++ b/plugins/arcgis/web-app/projects/main/src/lib/arc-event/ArcEventsModel.ts
@@ -1,9 +1,11 @@
 import { ArcEvent } from "./ArcEvent";
 
 export class ArcEventsModel {
-    events: ArcEvent[];
+    allEvents: Array<ArcEvent>;
+    events: Array<ArcEvent>;
 
     constructor() {
+        this.allEvents =  new Array<ArcEvent>();
         this.events = new Array<ArcEvent>();
     }
 }

--- a/plugins/arcgis/web-app/projects/main/src/lib/arc-event/arc-event.component.html
+++ b/plugins/arcgis/web-app/projects/main/src/lib/arc-event/arc-event.component.html
@@ -1,11 +1,30 @@
 <div>
-    <mat-card appearance="outlined">
-      <mat-card-title>Events</mat-card-title>
-      <mat-card-subtitle>Change the ArcGIS layers each MAGE event sends its observations to.</mat-card-subtitle>
+    <mat-card appearance="outlined" class="d-flow-root">
+      <mat-card-title-group class="w-100">
+        <div class="arcEvent__info">
+          <mat-card-title>Events</mat-card-title>
+          <mat-card-subtitle>Change the ArcGIS layers each MAGE event sends its observations to.</mat-card-subtitle>
+        </div>
+        <mat-form-field class="select-event">
+          <mat-label>Select Events</mat-label>
+          <mat-select #matRef multiple [(value)]="selectedValues" placeholder="Select Events" (closed)="clearFilterValue()">
+            <input
+              type="text"
+              placeholder="Filter Events..."
+              [(ngModel)]="filterValue"
+              (click)="$event.stopPropagation()"
+              class="select-text-box"
+            />
+            <mat-option *ngFor="let item of model.allEvents" [style.display]="getVisibility(item)? '' : 'none'" [value]="item.id" (onSelectionChange)="onSelectionChange(item, $event)">
+              {{item.name}}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </mat-card-title-group>
     <mat-card-content>
-      <section class="arc-event-sync">
+      <section class="arc-event-sync event-card">
         <div *ngIf="!model.events.length">
-          There are no events synchronizing to ArcGIS layers.
+          There are currently no events synchronizing to ArcGIS layers.
           <mat-divider></mat-divider>
         </div>
 
@@ -16,10 +35,10 @@
                 <div>
                   {{ event.name }}
                 </div>
-                <div *ngIf="event.layers.length; else noLayers">
+                <div *ngIf="getSelectedLayers(event).length; else noLayers">
                   <div>
-                    <ng-container *ngFor="let featureLayer of event.layers; let i = index">
-                      {{ layerDisplay(featureLayer) }}<span *ngIf="i < event.layers.length - 1">, </span>
+                    <ng-container *ngFor="let featureLayer of getSelectedLayers(event); let i = index">
+                      {{ layerDisplay(featureLayer) }}<span *ngIf="i < getSelectedLayers(event).length - 1">, </span>
                     </ng-container>
                   </div>
                 </div>
@@ -35,11 +54,18 @@
                 <button mat-icon-button color="primary" (click)="onEditEvent(event)">
                   <mat-icon>edit</mat-icon>
                 </button>
+                <button mat-icon-button color="primary" (click)="onRemoveEvent(event)">
+                  <mat-icon>remove_circle</mat-icon>
+                </button>
               </div>
             </mat-list-item>
             <mat-divider *ngIf="!last"></mat-divider>
           </ng-container>
-        </mat-list>        
+        </mat-list>
+      </section>
+      <section>
+        <button mat-flat-button color="primary" matDialogClose
+          (click)="saveChanges()" class="save-button">SAVE</button>
       </section>
     </mat-card-content>
   </mat-card>
@@ -55,9 +81,7 @@
     </div>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button mat-button matDialogClose>CANCEL</button>
-    <button mat-flat-button color="primary" matDialogClose
-      (click)="saveChanges()">SAVE</button>
+    <button mat-button matDialogClose>CLOSE</button>
   </mat-dialog-actions>
 </ng-template>
 </div>

--- a/plugins/arcgis/web-app/projects/main/src/lib/arc-event/arc-event.component.scss
+++ b/plugins/arcgis/web-app/projects/main/src/lib/arc-event/arc-event.component.scss
@@ -1,8 +1,65 @@
 .arcEvent__info {
     flex-grow: 1;
+    max-width: 93%
+}
+
+.arcEvent__button{
+    width: 7%;
 }
 
 .mat-divider {
     margin-top: 12px;
     margin-bottom: 12px;
 }
+
+.select-event-overlay{
+    width: 50vw;
+}
+
+.w-100{
+    width: 100% !important;
+}
+
+.save-button{
+    float: inline-end;
+    margin-top: 15px;
+    margin-right: 19px;
+}
+
+.select-event {
+    margin-right: 10px;
+    width: 34%;
+    margin-top: 5px;
+}
+
+.select-text-box{
+    height: 45px;
+    width: 100%;
+}
+
+.d-flow-root {
+    display: flow-root !important;
+}
+
+.event-card {
+    max-height: 300px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+::ng-deep {
+    .mat-select-panel {
+        .mat-selected {
+            background-color: #1E88E5 !important;
+            color: #fff !important;
+        }
+        .mat-option {
+            border-bottom: 1px solid black;
+            border-left: 1px solid black;
+            border-right: 1px solid black;
+            .mat-pseudo-checkbox {
+                display: none !important;
+            }
+        }
+    }
+  }

--- a/plugins/arcgis/web-app/projects/main/src/lib/arc-event/arc-event.component.ts
+++ b/plugins/arcgis/web-app/projects/main/src/lib/arc-event/arc-event.component.ts
@@ -1,12 +1,24 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, TemplateRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  TemplateRef,
+  ViewChild
+} from '@angular/core';
 import { ArcGISPluginConfig, defaultArcGISPluginConfig } from '../ArcGISPluginConfig'
-import { FeatureServiceConfig } from "../ArcGISConfig"
+import { FeatureLayerConfig, FeatureServiceConfig } from "../ArcGISConfig"
 import { ArcService, MageEvent } from '../arc.service'
 import { MatDialog } from '@angular/material/dialog'
 import { ArcEventsModel } from './ArcEventsModel';
 import { ArcEvent } from './ArcEvent';
 import { ArcEventLayer } from './ArcEventLayer';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
+import { MatSelect } from '@angular/material/select';
+import { MatOption, MatOptionSelectionChange } from '@angular/material/core';
 
 @Component({
   selector: 'arc-event',
@@ -15,80 +27,156 @@ import { Observable, Subscription } from 'rxjs';
 })
 export class ArcEventComponent implements OnInit, OnChanges {
 
-  private eventsSubscription: Subscription;
-
   @Input('config') config: ArcGISPluginConfig = defaultArcGISPluginConfig;
   private configSet = false;
+  private _eventSet = false;
+  filterValue: string = "";
+
+  @Input()
+  set eventSet(value: boolean) {
+    this._eventSet = value;
+  }
+  get eventSet() {
+    return this._eventSet;
+  }
 
   @Input() configChangedNotifier: Observable<void>;
 
   @Output() configChanged = new EventEmitter<ArcGISPluginConfig>();
 
-  model: ArcEventsModel;
+  private _model: ArcEventsModel = new ArcEventsModel()
+
+  @Input()
+  set model(value: ArcEventsModel) {
+    this._model = value;
+  }
+  get model() {
+    return this._model;
+  }
+
+  selectedValues: number[] = [];
+  
   isLoading: boolean;
   currentEditingEvent: ArcEvent;
   layers: ArcEventLayer[];
-  private layersCount: Map<string, Map<string, Set<string>>>
 
   @ViewChild('editEventDialog', { static: true })
   private editEventTemplate: TemplateRef<unknown>
 
+  @ViewChild('selectEvents', { static: true })
+  private selectEventTemplate: TemplateRef<unknown>
+
+  @ViewChild('matRef') matSelect: MatSelect;
+
   constructor(private arcService: ArcService, private dialog: MatDialog) {
     this.config = defaultArcGISPluginConfig;
-    this.model = new ArcEventsModel();
-    this.layersCount = new Map();
+    this._model = new ArcEventsModel();
   }
 
-  ngOnInit(): void {
-    this.eventsSubscription = this.configChangedNotifier.subscribe(() => this.handleConfigChanged());
-  }
+  ngOnInit(): void {}
 
+  /// Activates On Every View Change, Is Configured to Set Initial State
+  /// As Soon As Data is Available, Then locks Changes to Not Activate Unless
+  /// A State Change is made that requires an update.
   ngOnChanges(changes: SimpleChanges): void {
-    if(!this.configSet) {
+    if(
+      !this.configSet &&
+      this.config.featureServices.length > 0 &&
+      this.model.allEvents.length === 0
+    ){
       this.configSet = true;
-      this.arcService.fetchEvents().subscribe(x => this.handleEventResults(x));
+      this.arcService.fetchEvents().subscribe(x => this.setAllEvents(x));
+    }
+    else if (!this.eventSet && this.configSet && this.model.allEvents.length > 0) {
+      this.eventSet = true;
+      this.LoadSelectedEvents();
     }
   }
 
-  handleConfigChanged() {
-    let eventResults = new Array<MageEvent>();
-    if (this.model.events.length > 0) {
-      for (const arcEvent of this.model.events) {
-        const result = new MageEvent();
-        result.name = arcEvent.name;
-        result.id = arcEvent.id;
-        eventResults.push(result);
-      }
-
-      this.model.events.splice(0, this.model.events.length);
-      this.handleEventResults(eventResults);
-    }
+  /// Returns a list of values that differ between two lists of ArcEvents
+  getDifferences(left: ArcEvent[], right: ArcEvent[]): ArcEvent[]{
+    return left.filter(l =>
+      !right.some(r => 
+        l.id === r.id));
   }
 
-  handleEventResults(x: MageEvent[]) {
-    let activeEventMessage = 'Active events: ';
-    this.updateLayersCount();
+  /// This Returns if Something should be shown when the Filter Text Box is used
+  getVisibility(item: ArcEvent) {
+    let isNotFiltered = this.model.allEvents.find((x) =>
+      x.name === item.name)?.name.toLocaleLowerCase().includes(this.filterValue);
+    return isNotFiltered
+  }
+
+  clearFilterValue() {
+    this.filterValue = "";
+  }
+
+  getSelections() {
+    return this._model.events.map((x) => x.id);
+  }
+
+  /// On Initial Load this will store all available events into model.allEvents
+  setAllEvents(x: MageEvent[]){
+    if (this.model.allEvents.map((aE) => aE.name).filter((eN) =>
+      x.map((mE) => mE.name).includes(eN)).length) return;
+    console.log("Loading All Available Events")
+    let temp = new ArcEventsModel();
     for (const event of x) {
-      activeEventMessage += event.name + ' ';
       let eventsLayers = this.eventLayers(event.name)
       const arcEvent = new ArcEvent(event.name, event.id, eventsLayers);
-      this.model.events.push(arcEvent);
+      temp.allEvents.push(arcEvent);
     }
-    console.log(activeEventMessage);
+    this.model = Object.assign({}, temp);
+    this.eventSet = false;
   }
 
+  /// On Initial Load, this checks the database loaded value for selected events
+  /// And Adds them to the list of select box selected values, which in turn adds them
+  /// to model.events
+  LoadSelectedEvents(){
+    console.log("Loading Previously Selected Events")
+    let events: (string | number)[] = [];
+    for (const fs of this.config.featureServices){
+      for (const l of fs.layers){
+        events.push(...<[]>l.events?.map(x => x))
+      }
+    }
+    if (!events) {
+      console.log("No Events Found!")
+      return;
+    }
+    else events = [...new Set(events)]; /// needs to be distinct.
+    let e = null;
+    for (const event of events) { 
+      if (typeof(event) == "string") {
+        e = this.model.allEvents.find((x) => x.name === event);
+      } else if (typeof(event) == "number") { 
+        e = this.model.allEvents.find((x) => x.id === event);
+      }
+      if (!e) {
+        console.log(`${event} not found!`)
+        continue;
+      }
+      let eventsLayers = this.eventLayers(e.name)
+      const arcEvent = new ArcEvent(e.name, e.id, eventsLayers);
+      this.selectedValues.push(arcEvent.id)
+    }
+  }
+
+  // Returns a list of all Layers possible for events, and sets selected status
   private eventLayers(event: string): ArcEventLayer[] {
     const eventsLayers = [];
     for (const featureService of this.config.featureServices) {
       const domain = this.domain(featureService);
       const service = this.service(featureService);
       for (const featureLayer of featureService.layers) {
-        if (featureLayer.events == null
-          || featureLayer.events.indexOf(event) >= 0) {
-          const layer = String(featureLayer.layer);
-          const eventLayer = new ArcEventLayer(domain, service, layer);
-          eventsLayers.push(eventLayer);
-        }
+        const layer = String(featureLayer.layer);
+        const eventLayer = new ArcEventLayer(domain, service, layer);
+        eventLayer.isSelected = (
+          featureLayer.events !== undefined &&
+          featureLayer.events?.indexOf(event) >= 0
+        );
+        eventsLayers.push(eventLayer);
       }
     }
     return eventsLayers
@@ -96,68 +184,42 @@ export class ArcEventComponent implements OnInit, OnChanges {
 
   onEditEvent(event: ArcEvent) {
     console.log('Editing event synchronization for event ' + event.name);
+    this.layers = event.layers;
     this.currentEditingEvent = event;
-    this.layers = [];
-    this.updateLayersCount();
-
-    for (const featureService of this.config.featureServices) {
-      const domain = this.domain(featureService);
-      const service = this.service(featureService);
-      for (const featureLayer of featureService.layers) {
-        const layer = String(featureLayer.layer);
-        const selectableLayer = new ArcEventLayer(domain, service, layer);
-        const index = event.layers.findIndex((element) => {
-          return element.name === layer && element.domain === domain && element.service === service;
-        })
-        selectableLayer.isSelected = index >= 0;
-        this.layers.push(selectableLayer);
-      }
-    }
-
     this.dialog.open<unknown, unknown, string>(this.editEventTemplate)
   }
 
-  private updateLayersCount() {
-    const counts = new Map();
-    for (const featureService of this.config.featureServices) {
-      const domain = this.domain(featureService);
-      const service = this.service(featureService);
-      for (const featureLayer of featureService.layers) {
-        const layer = String(featureLayer.layer);
-        let serviceMap = counts.get(layer);
-        if (serviceMap == null) {
-          serviceMap = new Map();
-          counts.set(layer, serviceMap);
-        }
-        let domainSet = serviceMap.get(service);
-        if (domainSet == null) {
-          domainSet = new Set();
-          serviceMap.set(service, domainSet)
-        }
-        domainSet.add(domain)
-      }
-    }
-    this.layersCount = counts
+  onSelectEvents() {
+    this.dialog.open<unknown, unknown, string>(this.selectEventTemplate);
+  }
+
+  onSelectionChange(arcEventModified: ArcEvent, e: MatOptionSelectionChange){
+    let option: MatOption = e.source;
+    if (!option) return
+    if (option.selected) this.onAddEvent(arcEventModified);
+    else this.onRemoveEvent(arcEventModified)
+  }
+
+  onAddEvent(event: ArcEvent){
+    console.log('Adding Event to List of Selected Events');
+    let temp: ArcEventsModel = {...this.model}
+    temp.events.push(event);
+    this.model = Object.assign({}, temp);
+  }
+
+  onRemoveEvent(event: ArcEvent){
+    console.log('Removing Event to List of Selected Events');
+    let temp: ArcEventsModel = {...this.model}
+    temp.events = temp.events.filter((e) => e != event);
+    this.model = Object.assign({}, temp);
+  }
+
+  getSelectedLayers(event: ArcEvent) {
+    return event.layers.filter((x) => x.isSelected)
   }
 
   layerDisplay(layer: ArcEventLayer): string {
     let displayName = layer.name
-    const serviceMap = this.layersCount.get(layer.name)
-    if (serviceMap != null) {
-      if (serviceMap.size > 1) {
-        displayName += " (" + layer.service
-        const domainSet = serviceMap.get(layer.service)
-        if (domainSet != null && domainSet.size > 1) {
-          displayName += ", " + layer.domain
-        }
-        displayName += ")"
-      } else if (serviceMap.size == 1) {
-        const domainSet = serviceMap.get(layer.service)
-        if (domainSet != null && domainSet.size > 1) {
-          displayName += " (" + layer.domain + ")"
-        }
-      }
-    }
     return displayName
   }
 
@@ -166,45 +228,30 @@ export class ArcEventComponent implements OnInit, OnChanges {
     layer.isSelected = !layer.isSelected;
   }
 
+  /// This translates model.events to database format, which allows them to ber easily saved
+  /// Directly from the stated value
+  getEventsInFeatureFormat(featureService: FeatureServiceConfig): FeatureLayerConfig[]{
+    let values :FeatureLayerConfig[] = [];
+    for (let l of featureService.layers) {
+      values.push({
+        layer: l.layer,
+        geometryType: l.geometryType,
+        events: [...this.model.events.filter((x) => x.layers.map((y) => { 
+          if (y.name === l.layer && y.isSelected) {
+            return y.name
+          } else return "" 
+        }).indexOf(l.layer as string) >= 0)
+          .map((z) => z.name)]
+      })
+    }
+    return values;
+  }
+
   saveChanges() {
     console.log('Saving changes to event sync');
     for (const featureService of this.config.featureServices) {
-      const domain = this.domain(featureService);
-      const service = this.service(featureService);
-      for (const featureLayer of featureService.layers) {
-
-        const index = this.layers.findIndex((element) => {
-          return element.name === featureLayer.layer && element.domain === domain && element.service === service;
-        })
-
-        if (index != -1) {
-          const layer = this.layers[index];
-          if (layer.isSelected) {
-            // Only add the event if layer events are specified and do not contain the event
-            if (featureLayer.events != null
-              && featureLayer.events.indexOf(this.currentEditingEvent.name) == -1) {
-                featureLayer.events.push(this.currentEditingEvent.name);
-            }
-          } else if (featureLayer.events != null) {
-            const indexOf = featureLayer.events.indexOf(this.currentEditingEvent.name);
-            if (indexOf >= 0) {
-              featureLayer.events.splice(indexOf, 1);
-            }
-          } else {
-            // Specify all other events to remove the event from the layer
-            featureLayer.events = []
-            for (const event of this.model.events) {
-              if (event.name != this.currentEditingEvent.name) {
-                featureLayer.events.push(event.name)
-              }
-            }
-          }
-
-        }
-      }
+      featureService.layers = this.getEventsInFeatureFormat(featureService);
     }
-    this.currentEditingEvent.layers = this.eventLayers(this.currentEditingEvent.name)
-
     this.configChanged.emit(this.config);
     this.arcService.putArcConfig(this.config);
   }

--- a/plugins/arcgis/web-app/projects/main/src/lib/mage-arc.module.ts
+++ b/plugins/arcgis/web-app/projects/main/src/lib/mage-arc.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { MatFormFieldModule } from '@angular/material/form-field'
@@ -47,11 +47,15 @@ import { ArcLayerDeleteDialogComponent } from './arc-layer/arc-layer-delete-dial
     MatTableModule,
     ReactiveFormsModule,
     MatProgressSpinnerModule,
+    MatSelectModule,
   ],
   exports: [
     ArcAdminComponent,
     ArcLayerComponent,
     ArcEventComponent
+  ],
+  schemas: [
+    CUSTOM_ELEMENTS_SCHEMA
   ]
 })
 export class MageArcModule { }


### PR DESCRIPTION
This ticket adds the ability to choose events to apply arcgis layers to. Currently the functionality is such that all events are selected and must be managed for all possible layers. This is replaced with a friendly drop down containing all events and allowing the user to select each one that should have layers individually then applying the layers. 

To Test this you will need a set of Feature Layers, either create your own or use mine `https://arcgis.geointnext.com/arcgis/rest/services/Hosted/Ryan_C_Layer_1/FeatureServer`

1. Log into Mage
2. Go to Admin Page
3. Go to Events Tab
4. Create a set of events (For my personal testing I used 5)
5. Go to ArcGis Tab
6. Add Feature Service Layer(s)
7.  Select Events from Drop Down
8. Add Layers to Selected Events
9. Save

![image](https://github.com/user-attachments/assets/fde150ab-aab6-4c6d-a562-53ada35ddcdb)
