### PR TITLE
ArcGIS plugin would crash if authentication fails

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,30 @@
         "<node_internals>/**"
       ],
       "cwd": "${workspaceFolder}/service"
+    },
+    {
+      "name": "mage server instance",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "start:dev"
+      ],
+      "trace": true,
+      "env": {
+        "NODE_PATH": "${workspaceFolder}/instance/node_modules",
+        "MAGE_MONGO_URL": "mongodb://127.0.0.1/magedb"
+      },
+      "cwd": "${workspaceFolder}/instance",
+      "console": "integratedTerminal",
+      "preLaunchTask": "service:build",
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceFolder}/service/lib/**/*.js",
+        "${workspaceFolder}/plugins/sftp/service/lib/**/*.js",
+        "${workspaceFolder}/plugins/arcgis/service/lib/**/*.js"
+      ]
     }
   ],
   "compounds": [


### PR DESCRIPTION
This PR fixes an issue where the ArcGIS plugin would crash on startup if one of the feature services fails to authenticate on signin. This is just a small pr that encases the logic inside a try/catch. 

This also adds back a launch json config to allow debugging just the mage server.