### PR TITLE
Update and Fix Observation Filtering -  MAGE-1501

### DIFF
--- a/service/src/api/observation.js
+++ b/service/src/api/observation.js
@@ -1,9 +1,9 @@
-const async = require('async')
-  , log = require('winston')
-  , ObservationEvents = require('./events/observation.js')
-  , FieldFactory = require('./field')
-  , ObservationModel = require('../models/observation')
-  , Attachment = require('./attachment');
+const async = require("async"),
+  log = require("winston"),
+  ObservationEvents = require("./events/observation.js"),
+  FieldFactory = require("./field"),
+  ObservationModel = require("../models/observation"),
+  Attachment = require("./attachment");
 
 const fieldFactory = new FieldFactory();
 
@@ -16,26 +16,30 @@ function Observation(event, user, deviceId) {
 const EventEmitter = new ObservationEvents();
 Observation.on = EventEmitter;
 
-Observation.prototype.getAll = function(options, callback) {
+Observation.prototype.getAll = function (options, callback) {
   const event = this._event;
   const filter = options.filter;
   if (filter && filter.geometries) {
     let allObservations = [];
     async.each(
       filter.geometries,
-      function(geometry, done) {
+      function (geometry, done) {
         options.filter.geometry = geometry;
-        ObservationModel.getObservations(event, options, function (err, observations) {
-          if (err) return done(err);
+        ObservationModel.getObservations(
+          event,
+          options,
+          function (err, observations) {
+            if (err) return done(err);
 
-          if (observations) {
-            allObservations = allObservations.concat(observations);
+            if (observations) {
+              allObservations = allObservations.concat(observations);
+            }
+
+            done();
           }
-
-          done();
-        });
+        );
       },
-      function(err) {
+      function (err) {
         callback(err, allObservations);
       }
     );
@@ -44,44 +48,66 @@ Observation.prototype.getAll = function(options, callback) {
   }
 };
 
-Observation.prototype.getById = function(observationId, options, callback) {
-  if (typeof options === 'function') {
+Observation.prototype.getById = function (observationId, options, callback) {
+  if (typeof options === "function") {
     callback = options;
     options = {};
   }
 
-  ObservationModel.getObservationById(this._event, observationId, options, callback);
+  ObservationModel.getObservationById(
+    this._event,
+    observationId,
+    options,
+    callback
+  );
 };
 
-Observation.prototype.validate = function(observation) {
+Observation.prototype.validate = function (observation) {
   const errors = {};
-  let message = '';
+  let message = "";
 
-  if (observation.type !== 'Feature') {
-    errors.type = { error: 'required', message: observation.type ? 'type is required' :  'type must equal "Feature"' };
-    message += observation.type ? '\u2022 type is required\n' : '\u2022 type must equal "Feature"\n'
+  if (observation.type !== "Feature") {
+    errors.type = {
+      error: "required",
+      message: observation.type
+        ? "type is required"
+        : 'type must equal "Feature"',
+    };
+    message += observation.type
+      ? "\u2022 type is required\n"
+      : '\u2022 type must equal "Feature"\n';
   }
 
   // validate timestamp
   const properties = observation.properties || {};
-  const timestampError = fieldFactory.createField({
-    type: 'date',
-    required: true,
-    name: 'timestamp',
-    title: 'Date'
-  }, properties).validate();
+  const timestampError = fieldFactory
+    .createField(
+      {
+        type: "date",
+        required: true,
+        name: "timestamp",
+        title: "Date",
+      },
+      properties
+    )
+    .validate();
   if (timestampError) {
     errors.timestamp = timestampError;
     message += `\u2022 ${timestampError.message}\n`;
   }
 
   // validate geometry
-  const geometryError = fieldFactory.createField({
-    type: 'geometry',
-    required: true,
-    name: 'geometry',
-    title: 'Location'
-  }, observation).validate();
+  const geometryError = fieldFactory
+    .createField(
+      {
+        type: "geometry",
+        required: true,
+        name: "geometry",
+        title: "Location",
+      },
+      observation
+    )
+    .validate();
   if (geometryError) {
     errors.geometry = geometryError;
     message += `\u2022 ${geometryError.message}\n`;
@@ -91,17 +117,23 @@ Observation.prototype.validate = function(observation) {
   const formCount = formEntries.reduce((count, form) => {
     count[form.formId] = (count[form.formId] || 0) + 1;
     return count;
-  }, {})
+  }, {});
 
   const formDefinitions = {};
 
   // Validate total number of forms
-  if (this._event.minObservationForms != null && formEntries.length < this._event.minObservationForms) {
+  if (
+    this._event.minObservationForms != null &&
+    formEntries.length < this._event.minObservationForms
+  ) {
     errors.minObservationForms = new Error("Insufficient number of forms");
     message += `\u2022 Total number of forms in observation must be at least ${this._event.minObservationForms}\n`;
   }
 
-  if (this._event.maxObservationForms != null && formEntries.length > this._event.maxObservationForms) {
+  if (
+    this._event.maxObservationForms != null &&
+    formEntries.length > this._event.maxObservationForms
+  ) {
     errors.maxObservationForms = new Error("Exceeded maximum number of forms");
     message += `\u2022 Total number of forms in observation cannot be more than ${this._event.maxObservationForms}\n`;
   }
@@ -109,23 +141,23 @@ Observation.prototype.validate = function(observation) {
   // Validate forms min/max occurrences
   const formError = {};
   this._event.forms
-    .filter(form => !form.archived)
-    .forEach(formDefinition => {
+    .filter((form) => !form.archived)
+    .forEach((formDefinition) => {
       formDefinitions[formDefinition._id] = formDefinition;
 
       const count = formCount[formDefinition.id] || 0;
       if (formDefinition.min && count < formDefinition.min) {
         formError[formDefinition.id] = {
-          error: 'min',
-          message: `${formDefinition.name} form must be included in observation at least ${formDefinition.min} times`
-        }
+          error: "min",
+          message: `${formDefinition.name} form must be included in observation at least ${formDefinition.min} times`,
+        };
 
         message += `\u2022 ${formDefinition.name} form must be included in observation at least ${formDefinition.min} times\n`;
-      } else if  (formDefinition.max && (count > formDefinition.max)) {
+      } else if (formDefinition.max && count > formDefinition.max) {
         formError[formDefinition.id] = {
-          error: 'max',
-          message: `${formDefinition.name} form cannot be included in observation more than ${formDefinition.max} times`
-        }
+          error: "max",
+          message: `${formDefinition.name} form cannot be included in observation more than ${formDefinition.max} times`,
+        };
 
         message += `\u2022 ${formDefinition.name} form cannot be included in observation more than ${formDefinition.max} times\n`;
       }
@@ -140,14 +172,18 @@ Observation.prototype.validate = function(observation) {
   // Validate form fields
   const formErrors = [];
 
-  formEntries.forEach(formEntry => {
-    let fieldsMessage = '';
+  formEntries.forEach((formEntry) => {
+    let fieldsMessage = "";
     const fieldsError = {};
 
     formDefinitions[formEntry.formId].fields
-      .filter(fieldDefinition => !fieldDefinition.archived)
-      .forEach(fieldDefinition => {
-        const field = fieldFactory.createField(fieldDefinition, formEntry, observation);
+      .filter((fieldDefinition) => !fieldDefinition.archived)
+      .forEach((fieldDefinition) => {
+        const field = fieldFactory.createField(
+          fieldDefinition,
+          formEntry,
+          observation
+        );
         const fieldError = field.validate();
 
         if (fieldError) {
@@ -164,12 +200,12 @@ Observation.prototype.validate = function(observation) {
   });
 
   if (formErrors.length) {
-    errors.forms = formErrors
+    errors.forms = formErrors;
   }
 
   if (Object.keys(errors).length) {
-    const err = new Error('Invalid Observation');
-    err.name = 'ValidationError';
+    const err = new Error("Invalid Observation");
+    err.name = "ValidationError";
     err.status = 400;
     err.message = message;
     err.errors = errors;
@@ -177,12 +213,12 @@ Observation.prototype.validate = function(observation) {
   }
 };
 
-Observation.prototype.createObservationId = function(callback) {
+Observation.prototype.createObservationId = function (callback) {
   ObservationModel.createObservationId(callback);
 };
 
-Observation.prototype.validateObservationId = function(id, callback) {
-  ObservationModel.getObservationId(id, function(err, id) {
+Observation.prototype.validateObservationId = function (id, callback) {
+  ObservationModel.getObservationId(id, function (err, id) {
     if (err) return callback(err);
 
     if (!id) {
@@ -195,70 +231,112 @@ Observation.prototype.validateObservationId = function(id, callback) {
 };
 
 // TODO create is gone, do I need to figure out if this is an observation create?
-Observation.prototype.update = function(observationId, observation, callback) {
+Observation.prototype.update = function (observationId, observation, callback) {
   if (this._user) observation.userId = this._user._id;
   if (this._deviceId) observation.deviceId = this._deviceId;
 
   const err = this.validate(observation);
   if (err) return callback(err);
 
-  ObservationModel.updateObservation(this._event, observationId, observation, (err, updatedObservation) => {
-    if (updatedObservation) {
-      EventEmitter.emit(ObservationEvents.events.update, updatedObservation.toObject({event: this._event}), this._event, this._user);
+  ObservationModel.updateObservation(
+    this._event,
+    observationId,
+    observation,
+    (err, updatedObservation) => {
+      if (updatedObservation) {
+        EventEmitter.emit(
+          ObservationEvents.events.update,
+          updatedObservation.toObject({ event: this._event }),
+          this._event,
+          this._user
+        );
 
-      // Remove any deleted attachments from file system
-      /*
+        // Remove any deleted attachments from file system
+        /*
       TODO: this might not even work. observation form entries are not stored
       with field entry keys for attachment fields, so finding attachments based
       on matching form entry keys with form field names will not produce any
       results.
       */
-      const {forms: formEntries = []}  = observation.properties || {};
-      formEntries.forEach(formEntry => {
-        const formDefinition = this._event.forms.find(form => form._id === formEntry.formId);
-        Object.keys(formEntry).forEach(fieldName => {
-          const fieldDefinition = formDefinition.fields.find(field => field.name === fieldName);
-          if (fieldDefinition && fieldDefinition.type === 'attachment') {
-            const attachmentsField = formEntry[fieldName] || [];
-            attachmentsField.filter(attachmentField => attachmentField.action === 'delete').forEach(attachmentField => {
-              const attachment = observation.attachments.find(attachment => attachment._id.toString() === attachmentField.id);
-              if (attachment) {
-                console.info(`deleting attachment ${attachment.id} for field ${fieldName} on observation ${observation.id}`)
-                new Attachment(this._event, observation).delete(attachment._id, err => {
-                  log.warn('Error removing deleted attachment from file system', err);
+        const { forms: formEntries = [] } = observation.properties || {};
+        formEntries.forEach((formEntry) => {
+          const formDefinition = this._event.forms.find(
+            (form) => form._id === formEntry.formId
+          );
+          Object.keys(formEntry).forEach((fieldName) => {
+            const fieldDefinition = formDefinition.fields.find(
+              (field) => field.name === fieldName
+            );
+            if (fieldDefinition && fieldDefinition.type === "attachment") {
+              const attachmentsField = formEntry[fieldName] || [];
+              attachmentsField
+                .filter(
+                  (attachmentField) => attachmentField.action === "delete"
+                )
+                .forEach((attachmentField) => {
+                  const attachment = observation.attachments.find(
+                    (attachment) =>
+                      attachment._id.toString() === attachmentField.id
+                  );
+                  if (attachment) {
+                    console.info(
+                      `deleting attachment ${attachment.id} for field ${fieldName} on observation ${observation.id}`
+                    );
+                    new Attachment(this._event, observation).delete(
+                      attachment._id,
+                      (err) => {
+                        log.warn(
+                          "Error removing deleted attachment from file system",
+                          err
+                        );
+                      }
+                    );
+                  }
                 });
-              }
-            });
-          }
+            }
+          });
         });
-      });
-    }
+      }
 
-    callback(err, updatedObservation);
-  });
+      callback(err, updatedObservation);
+    }
+  );
 };
 
-Observation.prototype.addFavorite = function(observationId, user, callback) {
+Observation.prototype.addFavorite = function (observationId, user, callback) {
   ObservationModel.addFavorite(this._event, observationId, user, callback);
 };
 
-Observation.prototype.removeFavorite = function(observation, user, callback) {
+Observation.prototype.removeFavorite = function (observation, user, callback) {
   ObservationModel.removeFavorite(this._event, observation, user, callback);
 };
 
-Observation.prototype.addImportant = function(observationId, important, callback) {
-  ObservationModel.addImportant(this._event, observationId, important, callback);
+Observation.prototype.addImportant = function (
+  observationId,
+  important,
+  callback
+) {
+  ObservationModel.addImportant(
+    this._event,
+    observationId,
+    important,
+    callback
+  );
 };
 
-Observation.prototype.removeImportant = function(observation, callback) {
+Observation.prototype.removeImportant = function (observation, callback) {
   ObservationModel.removeImportant(this._event, observation, callback);
 };
 
-Observation.prototype.addState = function(observationId, state, callback) {
+Observation.prototype.addState = function (observationId, state, callback) {
   ObservationModel.addState(this._event, observationId, state, (err, state) => {
     if (!err) {
-      if (state.name === 'archive') {
-        EventEmitter.emit(ObservationEvents.events.remove, observationId, this._event);
+      if (state.name === "archive") {
+        EventEmitter.emit(
+          ObservationEvents.events.remove,
+          observationId,
+          this._event
+        );
       }
     }
     callback(err, state);

--- a/service/src/routes/observations.js
+++ b/service/src/routes/observations.js
@@ -1,40 +1,47 @@
-const { attachmentTypeIsValidForField } = require('../entities/events/entities.events.forms');
+const {
+  attachmentTypeIsValidForField,
+} = require("../entities/events/entities.events.forms");
 
 module.exports = function (app, security) {
-
-  const async = require('async')
-    , api = require('../api')
-    , log = require('winston')
-    , archiver = require('archiver')
-    , path = require('path')
-    , environment = require('../environment/env')
-    , fs = require('fs-extra')
-    , moment = require('moment')
-    , Team = require('../models/team')
-    , access = require('../access')
-    , { default: turfCentroid } = require('@turf/centroid')
-    , geometryFormat = require('../format/geoJsonFormat')
-    , observationXform = require('../transformers/observation')
-    , FileType = require('file-type')
-    , passport = security.authentication.passport
-    , { defaultEventPermissionsService: eventPermissions } = require('../permissions/permissions.events');
+  const async = require("async"),
+    api = require("../api"),
+    log = require("winston"),
+    archiver = require("archiver"),
+    path = require("path"),
+    environment = require("../environment/env"),
+    fs = require("fs-extra"),
+    moment = require("moment"),
+    Team = require("../models/team"),
+    access = require("../access"),
+    { default: turfCentroid } = require("@turf/centroid"),
+    geometryFormat = require("../format/geoJsonFormat"),
+    observationXform = require("../transformers/observation"),
+    FileType = require("file-type"),
+    passport = security.authentication.passport,
+    {
+      defaultEventPermissionsService: eventPermissions,
+    } = require("../permissions/permissions.events");
 
   const sortColumnWhitelist = ["lastModified"];
 
   function transformOptions(req) {
     return {
       event: req.event,
-      path: req.getPath().match(/(.*observations)/)[0]
+      path: req.getPath().match(/(.*observations)/)[0],
     };
   }
 
   async function validateObservationReadAccess(req, res, next) {
-    if (access.userHasPermission(req.user, 'READ_OBSERVATION_ALL')) {
+    if (access.userHasPermission(req.user, "READ_OBSERVATION_ALL")) {
       return next();
     }
-    if (access.userHasPermission(req.user, 'READ_OBSERVATION_EVENT')) {
+    if (access.userHasPermission(req.user, "READ_OBSERVATION_EVENT")) {
       // Make sure I am part of this event
-      const hasPermission = await eventPermissions.userHasEventPermission(req.event, req.user.id, 'read')
+      const hasPermission = await eventPermissions.userHasEventPermission(
+        req.event,
+        req.user.id,
+        "read"
+      );
       if (hasPermission) {
         return next();
       }
@@ -44,8 +51,7 @@ module.exports = function (app, security) {
 
   function validateObservationCreateAccess(validateObservationId) {
     return function (req, res, next) {
-
-      if (!access.userHasPermission(req.user, 'CREATE_OBSERVATION')) {
+      if (!access.userHasPermission(req.user, "CREATE_OBSERVATION")) {
         return res.sendStatus(403);
       }
 
@@ -57,7 +63,7 @@ module.exports = function (app, security) {
           validate the id from the url path instead? the path id is the one
           that is passed down to the update operation
           */
-          new api.Observation().validateObservationId(req.param('id'), done);
+          new api.Observation().validateObservationId(req.param("id"), done);
         });
       }
 
@@ -66,7 +72,11 @@ module.exports = function (app, security) {
           if (err) return next(err);
 
           if (teams.length === 0) {
-            return res.status(403).send('Cannot submit an observation for an event that you are not part of.');
+            return res
+              .status(403)
+              .send(
+                "Cannot submit an observation for an event that you are not part of."
+              );
           }
 
           done();
@@ -78,12 +88,16 @@ module.exports = function (app, security) {
   }
 
   async function validateObservationUpdateAccess(req, res, next) {
-    if (access.userHasPermission(req.user, 'UPDATE_OBSERVATION_ALL')) {
+    if (access.userHasPermission(req.user, "UPDATE_OBSERVATION_ALL")) {
       return next();
     }
-    if (access.userHasPermission(req.user, 'UPDATE_OBSERVATION_EVENT')) {
+    if (access.userHasPermission(req.user, "UPDATE_OBSERVATION_EVENT")) {
       // Make sure I am part of this event
-      const hasPermission = await eventPermissions.userHasEventPermission(req.event, req.user.id, 'read')
+      const hasPermission = await eventPermissions.userHasEventPermission(
+        req.event,
+        req.user.id,
+        "read"
+      );
       if (hasPermission) {
         return next();
       }
@@ -92,21 +106,40 @@ module.exports = function (app, security) {
   }
 
   function validateAttachmentFile(req, res, next) {
-    FileType.fromFile(req.file.path).then(fileType => {
-      const attachment = req.observation.attachments.find(attachment => attachment._id.toString() === req.params.attachmentId);
-      const observationForm = req.observation.properties.forms.find(observationForm => {
-        return observationForm._id.toString() === attachment.observationFormId.toString()
-      });
+    FileType.fromFile(req.file.path).then((fileType) => {
+      const attachment = req.observation.attachments.find(
+        (attachment) => attachment._id.toString() === req.params.attachmentId
+      );
+      const observationForm = req.observation.properties.forms.find(
+        (observationForm) => {
+          return (
+            observationForm._id.toString() ===
+            attachment.observationFormId.toString()
+          );
+        }
+      );
       if (!observationForm) {
-        return res.status(400).send('Attachment form not found');
+        return res.status(400).send("Attachment form not found");
       }
-      const formDefinition = req.event.forms.find(form => form._id === observationForm.formId);
-      const fieldDefinition = formDefinition.fields.find(field => field.name === attachment.fieldName);
+      const formDefinition = req.event.forms.find(
+        (form) => form._id === observationForm.formId
+      );
+      const fieldDefinition = formDefinition.fields.find(
+        (field) => field.name === attachment.fieldName
+      );
       if (!fieldDefinition) {
-        return res.status(400).send('Attachment field not found');
+        return res.status(400).send("Attachment field not found");
       }
       if (!attachmentTypeIsValidForField(fieldDefinition, fileType.mime)) {
-        return res.status(400).send(`Invalid attachment '${attachment.name}', type must be one of ${fieldDefinition.allowedAttachmentTypes.join(' or ')}`);
+        return res
+          .status(400)
+          .send(
+            `Invalid attachment '${
+              attachment.name
+            }', type must be one of ${fieldDefinition.allowedAttachmentTypes.join(
+              " or "
+            )}`
+          );
       }
       next();
     });
@@ -117,7 +150,11 @@ module.exports = function (app, security) {
       if (access.userHasPermission(req.user, collectionPermission)) {
         return next();
       }
-      const hasPermission = await eventPermissions.userHasEventPermission(req.event, req.user.id, aclPermission)
+      const hasPermission = await eventPermissions.userHasEventPermission(
+        req.event,
+        req.user.id,
+        aclPermission
+      );
       if (hasPermission) {
         return next();
       }
@@ -126,13 +163,17 @@ module.exports = function (app, security) {
   }
 
   async function authorizeDeleteAccess(req, res, next) {
-    if (access.userHasPermission(req.user, 'UPDATE_EVENT')) {
+    if (access.userHasPermission(req.user, "UPDATE_EVENT")) {
       return next();
     }
     if (req.user._id.toString() === req.observation.userId.toString()) {
       return next();
     }
-    const hasPermission = await eventPermissions.userHasEventPermission(req.event, req.user.id, 'update')
+    const hasPermission = await eventPermissions.userHasEventPermission(
+      req.event,
+      req.user.id,
+      "update"
+    );
     if (hasPermission) {
       return next();
     }
@@ -168,7 +209,10 @@ module.exports = function (app, security) {
       }
     }
 
-    new api.Icon(req.event._id, form._id, primary, secondary).getIcon(function (err, icon) {
+    new api.Icon(req.event._id, form._id, primary, secondary).getIcon(function (
+      err,
+      icon
+    ) {
       if (err) return next(err);
 
       req.observationIcon = icon;
@@ -179,8 +223,7 @@ module.exports = function (app, security) {
   function parseQueryParams(req, res, next) {
     // setup defaults
     const parameters = {
-      filter: {
-      }
+      filter: {},
     };
 
     const fields = req.query.fields;
@@ -200,35 +243,39 @@ module.exports = function (app, security) {
 
     const observationStartDate = req.query.observationStartDate;
     if (observationStartDate) {
-      parameters.filter.observationStartDate = moment(observationStartDate).utc().toDate();
+      parameters.filter.observationStartDate = moment(observationStartDate)
+        .utc()
+        .toDate();
     }
 
     const observationEndDate = req.query.observationEndDate;
     if (observationEndDate) {
-      parameters.filter.observationEndDate = moment(observationEndDate).utc().toDate();
+      parameters.filter.observationEndDate = moment(observationEndDate)
+        .utc()
+        .toDate();
     }
 
     const bbox = req.query.bbox;
     if (bbox) {
-      parameters.filter.geometries = geometryFormat.parse('bbox', bbox);
+      parameters.filter.geometries = geometryFormat.parse("bbox", bbox);
     }
 
     const geometry = req.query.geometry;
     if (geometry) {
-      parameters.filter.geometries = geometryFormat.parse('geometry', geometry);
+      parameters.filter.geometries = geometryFormat.parse("geometry", geometry);
     }
 
     const states = req.query.states;
     if (states) {
-      parameters.filter.states = states.split(',');
+      parameters.filter.states = states.split(",");
     }
 
     const sort = req.query.sort;
     if (sort) {
       const columns = {};
       let err = null;
-      sort.split(',').every(function (column) {
-        const sortParams = column.split('+');
+      sort.split(",").every(function (column) {
+        const sortParams = column.split("+");
         // Check sort column is in whitelist
         if (sortColumnWhitelist.indexOf(sortParams[0]) === -1) {
           err = `Cannot sort on column '${sortParams[0]}'`;
@@ -236,7 +283,7 @@ module.exports = function (app, security) {
         }
         // Order can be nothing (ASC by default) or ASC, DESC
         let direction = 1; // ASC
-        if (sortParams.length > 1 && sortParams[1] === 'DESC') {
+        if (sortParams.length > 1 && sortParams[1] === "DESC") {
           direction = -1; // DESC
         }
         columns[sortParams[0]] = direction;
@@ -247,7 +294,7 @@ module.exports = function (app, security) {
       parameters.sort = columns;
     }
 
-    parameters.populate = req.query.populate === 'true';
+    parameters.populate = req.query.populate === "true";
 
     req.parameters = parameters;
 
@@ -255,8 +302,8 @@ module.exports = function (app, security) {
   }
 
   app.get(
-    '/api/events/:eventId/observations/(:observationId).zip',
-    passport.authenticate('bearer'),
+    "/api/events/:eventId/observations/(:observationId).zip",
+    passport.authenticate("bearer"),
     validateObservationReadAccess,
     getUserForObservation,
     getIconForObservation,
@@ -272,59 +319,81 @@ module.exports = function (app, security) {
         formMap[form.id] = form;
       });
 
-      const archive = archiver('zip');
+      const archive = archiver("zip");
       archive.pipe(res);
 
-      res.render('observation', {
-        event: req.event,
-        formMap: formMap,
-        observation: req.observation,
-        center: turfCentroid(req.observation).geometry,
-        user: req.observationUser
-      }, function (err, html) {
-        if (!err) {
-          archive.append(html, { name: req.observation._id + '/index.html' });
+      res.render(
+        "observation",
+        {
+          event: req.event,
+          formMap: formMap,
+          observation: req.observation,
+          center: turfCentroid(req.observation).geometry,
+          user: req.observationUser,
+        },
+        function (err, html) {
+          if (!err) {
+            archive.append(html, { name: req.observation._id + "/index.html" });
 
-          if (req.observationIcon) {
-            const iconPath = path.join(environment.iconBaseDirectory, req.observationIcon.relativePath);
-            archive.file(iconPath, { name: req.observation._id + '/media/icon.png' });
+            if (req.observationIcon) {
+              const iconPath = path.join(
+                environment.iconBaseDirectory,
+                req.observationIcon.relativePath
+              );
+              archive.file(iconPath, {
+                name: req.observation._id + "/media/icon.png",
+              });
+            }
+
+            req.observation.attachments.forEach(function (attachment) {
+              archive.file(
+                path.join(
+                  environment.attachmentBaseDirectory,
+                  attachment.relativePath
+                ),
+                { name: req.observation._id + "/media/" + attachment.name }
+              );
+            });
+          } else {
+            log.warn(err);
           }
 
-          req.observation.attachments.forEach(function (attachment) {
-            archive.file(path.join(environment.attachmentBaseDirectory, attachment.relativePath), { name: req.observation._id + '/media/' + attachment.name });
-          });
-        } else {
-          log.warn(err);
+          archive.finalize();
         }
-
-        archive.finalize();
-      });
+      );
     }
   );
 
   app.get(
-    '/api/events/:eventId/observations/:observationIdInPath',
-    passport.authenticate('bearer'),
+    "/api/events/:eventId/observations/:observationIdInPath",
+    passport.authenticate("bearer"),
     validateObservationReadAccess,
     parseQueryParams,
     function (req, res, next) {
       const options = { fields: req.parameters.fields };
-      new api.Observation(req.event).getById(req.params.observationIdInPath, options, function (err, observation) {
-        if (err) {
-          return next(err);
+      new api.Observation(req.event).getById(
+        req.params.observationIdInPath,
+        options,
+        function (err, observation) {
+          if (err) {
+            return next(err);
+          }
+          if (!observation) {
+            return res.sendStatus(404);
+          }
+          const response = observationXform.transform(
+            observation,
+            transformOptions(req)
+          );
+          res.json(response);
         }
-        if (!observation) {
-          return res.sendStatus(404);
-        }
-        const response = observationXform.transform(observation, transformOptions(req));
-        res.json(response);
-      });
+      );
     }
   );
 
   app.get(
-    '/api/events/:eventId/observations',
-    passport.authenticate('bearer'),
+    "/api/events/:eventId/observations",
+    passport.authenticate("bearer"),
     validateObservationReadAccess,
     parseQueryParams,
     function (req, res, next) {
@@ -332,19 +401,24 @@ module.exports = function (app, security) {
         filter: req.parameters.filter,
         fields: req.parameters.fields,
         sort: req.parameters.sort,
-        populate: req.parameters.populate
+        populate: req.parameters.populate,
       };
 
-      new api.Observation(req.event).getAll(options, function (err, observations) {
-        if (err) return next(err);
-        res.json(observationXform.transform(observations, transformOptions(req)));
-      });
+      new api.Observation(req.event).getAll(
+        options,
+        function (err, observations) {
+          if (err) return next(err);
+          res.json(
+            observationXform.transform(observations, transformOptions(req))
+          );
+        }
+      );
     }
   );
 
   app.put(
-    '/api/events/:eventId/observations/:observationIdInPath/favorite',
-    passport.authenticate('bearer'),
+    "/api/events/:eventId/observations/:observationIdInPath/favorite",
+    passport.authenticate("bearer"),
     /*
     TODO: this is a strange permission check.  this is because the request
     modifies data, but there is a USER_NO_EDIT_ROLE role that has permission to
@@ -355,76 +429,118 @@ module.exports = function (app, security) {
     */
     validateObservationCreateAccess(false),
     function (req, res, next) {
-      new api.Observation(req.event).addFavorite(req.params.observationIdInPath, req.user, function (err, updatedObservation) {
-        if (err) {
-          return next(err);
+      new api.Observation(req.event).addFavorite(
+        req.params.observationIdInPath,
+        req.user,
+        function (err, updatedObservation) {
+          if (err) {
+            return next(err);
+          }
+          if (!updatedObservation) {
+            return res
+              .status(404)
+              .send(
+                `Observation with ID ${req.params.observationIdInPath} does not exist`
+              );
+          }
+          const response = observationXform.transform(
+            updatedObservation,
+            transformOptions(req)
+          );
+          res.json(response);
         }
-        if (!updatedObservation) {
-          return res.status(404).send(`Observation with ID ${req.params.observationIdInPath} does not exist`);
-        }
-        const response = observationXform.transform(updatedObservation, transformOptions(req));
-        res.json(response);
-      });
+      );
     }
   );
 
   app.delete(
-    '/api/events/:eventId/observations/:observationIdInPath/favorite',
-    passport.authenticate('bearer'),
+    "/api/events/:eventId/observations/:observationIdInPath/favorite",
+    passport.authenticate("bearer"),
     /* TODO: see above note on PUT favorite permission check */
     validateObservationCreateAccess(false),
     function (req, res, next) {
+      new api.Observation(req.event).removeFavorite(
+        req.params.observationIdInPath,
+        req.user,
+        function (err, updatedObservation) {
+          if (err) return next(err);
+          if (!updatedObservation)
+            return res
+              .status(404)
+              .send(
+                "Observation with id " +
+                  req.params.observationIdInPath +
+                  " does not exist"
+              );
 
-      new api.Observation(req.event).removeFavorite(req.params.observationIdInPath, req.user, function (err, updatedObservation) {
-        if (err) return next(err);
-        if (!updatedObservation) return res.status(404).send('Observation with id ' + req.params.observationIdInPath + " does not exist");
-
-        const response = observationXform.transform(updatedObservation, transformOptions(req));
-        res.json(response);
-      });
+          const response = observationXform.transform(
+            updatedObservation,
+            transformOptions(req)
+          );
+          res.json(response);
+        }
+      );
     }
   );
 
   app.put(
-    '/api/events/:eventId/observations/:observationId/important',
-    passport.authenticate('bearer'),
-    authorizeEventAccess('UPDATE_EVENT', 'update'),
+    "/api/events/:eventId/observations/:observationId/important",
+    passport.authenticate("bearer"),
+    authorizeEventAccess("UPDATE_EVENT", "update"),
     function (req, res, next) {
       const important = {
         userId: req.user._id,
         timestamp: new Date(),
-        description: req.body.description
+        description: req.body.description,
       };
 
-      new api.Observation(req.event).addImportant(req.observation._id, important, function (err, updatedObservation) {
-        if (err) return next(err);
-        if (!updatedObservation) return res.status(404).send('Observation with id ' + req.params.id + " does not exist");
+      new api.Observation(req.event).addImportant(
+        req.observation._id,
+        important,
+        function (err, updatedObservation) {
+          if (err) return next(err);
+          if (!updatedObservation)
+            return res
+              .status(404)
+              .send("Observation with id " + req.params.id + " does not exist");
 
-        const response = observationXform.transform(updatedObservation, transformOptions(req));
-        res.json(response);
-      });
+          const response = observationXform.transform(
+            updatedObservation,
+            transformOptions(req)
+          );
+          res.json(response);
+        }
+      );
     }
   );
 
   app.delete(
-    '/api/events/:eventId/observations/:observationId/important',
-    passport.authenticate('bearer'),
-    authorizeEventAccess('UPDATE_EVENT', 'update'),
+    "/api/events/:eventId/observations/:observationId/important",
+    passport.authenticate("bearer"),
+    authorizeEventAccess("UPDATE_EVENT", "update"),
     function (req, res, next) {
+      new api.Observation(req.event).removeImportant(
+        req.observation._id,
+        function (err, updatedObservation) {
+          if (err) return next(err);
+          if (!updatedObservation)
+            return res
+              .status(404)
+              .send("Observation with id " + req.params.id + " does not exist");
 
-      new api.Observation(req.event).removeImportant(req.observation._id, function (err, updatedObservation) {
-        if (err) return next(err);
-        if (!updatedObservation) return res.status(404).send('Observation with id ' + req.params.id + " does not exist");
-
-        const response = observationXform.transform(updatedObservation, transformOptions(req));
-        res.json(response);
-      });
+          const response = observationXform.transform(
+            updatedObservation,
+            transformOptions(req)
+          );
+          res.json(response);
+        }
+      );
     }
   );
 
   app.post(
-    '/api/events/:eventId/observations/:observationId/states',
-    passport.authenticate('bearer'),
+    "/api/events/:eventId/observations/:observationId/states",
+    passport.authenticate("bearer"),
     authorizeDeleteAccess,
     function (req, res) {
       let state = req.body;
@@ -432,21 +548,29 @@ module.exports = function (app, security) {
         return res.send(400);
       }
       if (!state.name) {
-        return res.status(400).send('name required');
+        return res.status(400).send("name required");
       }
-      if (state.name !== 'active' && state.name !== 'archive') {
-        return res.status(400).send("state name must be one of 'active', 'complete', 'archive'");
+      if (state.name !== "active" && state.name !== "archive") {
+        return res
+          .status(400)
+          .send("state name must be one of 'active', 'complete', 'archive'");
       }
       state = { name: state.name };
       if (req.user) {
         state.userId = req.user._id;
       }
-      new api.Observation(req.event).addState(req.observation._id, state, function (err, state) {
-        if (err) {
-          return res.status(400).send('state is already ' + "'" + state.name + "'");
+      new api.Observation(req.event).addState(
+        req.observation._id,
+        state,
+        function (err, state) {
+          if (err) {
+            return res
+              .status(400)
+              .send("state is already " + "'" + state.name + "'");
+          }
+          res.status(201).json(state);
         }
-        res.status(201).json(state);
-      });
+      );
     }
   );
 };

--- a/web-app/admin/src/app/observation/observation-edit/observation-edit.component.ts
+++ b/web-app/admin/src/app/observation/observation-edit/observation-edit.component.ts
@@ -1,97 +1,130 @@
-import { animate, style, transition, trigger } from '@angular/animations'
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop'
-import { DOCUMENT } from '@angular/common'
-import { Component, ElementRef, EventEmitter, Inject, Input, OnChanges, OnInit, Output, QueryList, SimpleChanges, ViewChild, ViewChildren } from '@angular/core'
-import { UntypedFormArray, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms'
-import { DomSanitizer } from '@angular/platform-browser'
-import { first } from 'rxjs/operators'
-import { EventService, FilterService, LocalStorageService, MapService, ObservationService, UserService } from '../../../app/upgrade/ajs-upgraded-providers'
-import { ObservationEditFormPickerComponent } from './observation-edit-form-picker.component'
-import * as moment from 'moment';
-import { ObservationEditDiscardComponent } from './observation-edit-discard/observation-edit-discard.component'
-import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar'
-import { MatIconRegistry } from '@angular/material/icon'
-import { MatDialog } from '@angular/material/dialog'
-import { MatBottomSheet } from '@angular/material/bottom-sheet'
-import { AttachmentService, AttachmentUploadEvent, AttachmentUploadStatus } from '../attachment/attachment.service'
-import { FileUpload } from '../attachment/attachment-upload/attachment-upload.component'
-import { AttachmentAction } from './observation-edit-attachment/observation-edit-attachment-action'
+import { animate, style, transition, trigger } from "@angular/animations";
+import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
+import { DOCUMENT } from "@angular/common";
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  QueryList,
+  SimpleChanges,
+  ViewChild,
+  ViewChildren,
+} from "@angular/core";
+import {
+  UntypedFormArray,
+  UntypedFormBuilder,
+  UntypedFormControl,
+  UntypedFormGroup,
+  Validators,
+} from "@angular/forms";
+import { DomSanitizer } from "@angular/platform-browser";
+import { first } from "rxjs/operators";
+import {
+  EventService,
+  FilterService,
+  LocalStorageService,
+  MapService,
+  ObservationService,
+  UserService,
+} from "../../../app/upgrade/ajs-upgraded-providers";
+import { ObservationEditFormPickerComponent } from "./observation-edit-form-picker.component";
+import * as moment from "moment";
+import { ObservationEditDiscardComponent } from "./observation-edit-discard/observation-edit-discard.component";
+import {
+  MatSnackBar,
+  MatSnackBarRef,
+  SimpleSnackBar,
+} from "@angular/material/snack-bar";
+import { MatIconRegistry } from "@angular/material/icon";
+import { MatDialog } from "@angular/material/dialog";
+import { MatBottomSheet } from "@angular/material/bottom-sheet";
+import {
+  AttachmentService,
+  AttachmentUploadEvent,
+  AttachmentUploadStatus,
+} from "../attachment/attachment.service";
+import { FileUpload } from "../attachment/attachment-upload/attachment-upload.component";
+import { AttachmentAction } from "./observation-edit-attachment/observation-edit-attachment-action";
+import { Observation } from "src/app/filter/filter.types";
 
-export type ObservationFormControl = UntypedFormControl & { definition: any }
+export type ObservationFormControl = UntypedFormControl & { definition: any };
 
 @Component({
-  selector: 'observation-edit',
-  templateUrl: './observation-edit.component.html',
-  styleUrls: ['./observation-edit.component.scss'],
+  selector: "observation-edit",
+  templateUrl: "./observation-edit.component.html",
+  styleUrls: ["./observation-edit.component.scss"],
   animations: [
-    trigger('error', [
-      transition(':enter', [
+    trigger("error", [
+      transition(":enter", [
         style({ height: 0, opacity: 0 }),
-        animate('250ms', style({ height: '*', opacity: 1 })),
+        animate("250ms", style({ height: "*", opacity: 1 })),
       ]),
-      transition(':leave', [
-        animate('250ms', style({ height: 0, opacity: 0 }))
-      ])
+      transition(":leave", [
+        animate("250ms", style({ height: 0, opacity: 0 })),
+      ]),
     ]),
-    trigger('mask', [
-      transition(':enter', [
+    trigger("mask", [
+      transition(":enter", [
         style({ opacity: 0 }),
-        animate('250ms', style({ opacity: .2 })),
+        animate("250ms", style({ opacity: 0.2 })),
       ]),
-      transition(':leave', [
-        animate('250ms', style({ opacity: 0 }))
-      ])
-    ])
-  ]
+      transition(":leave", [animate("250ms", style({ opacity: 0 }))]),
+    ]),
+  ],
 })
 export class ObservationEditComponent implements OnInit, OnChanges {
-  @Input() preview: boolean
-  @Input() observation: any
-  attachments =[]
+  @Input() preview: boolean;
+  @Input() observation: Observation;
+  attachments = [];
 
-  @Output() close = new EventEmitter<any>()
+  @Output() close = new EventEmitter<any>();
 
-  @ViewChild('editContent', { static: true }) editContent: ElementRef
-  @ViewChild('dragHandle', { static: true }) dragHandle: ElementRef
-  @ViewChildren('form') formElements: QueryList<ElementRef>
+  @ViewChild("editContent", { static: true }) editContent: ElementRef;
+  @ViewChild("dragHandle", { static: true }) dragHandle: ElementRef;
+  @ViewChildren("form") formElements: QueryList<ElementRef>;
 
-  event: any
-  formGroup: UntypedFormGroup
-  formDefinitions: any
+  event: Event;
+  formGroup: UntypedFormGroup;
+  formDefinitions: any;
   timestampDefinition = {
-    title: '',
-    type: 'date',
-    name: 'timestamp',
-    required: true
-  }
+    title: "",
+    type: "date",
+    name: "timestamp",
+    required: true,
+  };
   geometryDefinition = {
-    title: 'Location',
-    type: 'geometry',
-    name: 'geometry',
-    required: true
-  }
+    title: "Location",
+    type: "geometry",
+    name: "geometry",
+    required: true,
+  };
 
-  mask = false
-  saving = false
-  error: any
+  mask = false;
+  saving = false;
+  error: any;
 
-  uploads: FileUpload[] = []
-  attachmentUrl: string
+  uploads: FileUpload[] = [];
+  attachmentUrl: string;
 
-  isNewObservation: boolean
-  canDeleteObservation: boolean
-  observationForm = {}
-  formOptions = { expand: false }
+  isNewObservation: boolean;
+  canDeleteObservation: boolean;
+  observationForm = {};
+  formOptions = { expand: false };
 
-  initialObservation: any
-  geometryStyle: any
+  initialObservation: any;
+  geometryStyle: any;
 
-  primaryField: any
-  primaryFieldValue: string
-  secondaryField: any
-  secondaryFieldValue: string
+  primaryField: any;
+  primaryFieldValue: string;
+  secondaryField: any;
+  secondaryFieldValue: string;
 
-  formRemoveSnackbar: MatSnackBarRef<SimpleSnackBar>
+  formRemoveSnackbar: MatSnackBarRef<SimpleSnackBar>;
 
   constructor(
     sanitizer: DomSanitizer,
@@ -107,89 +140,113 @@ export class ObservationEditComponent implements OnInit, OnChanges {
     @Inject(FilterService) private filterService: any,
     @Inject(EventService) private eventService: any,
     @Inject(ObservationService) private observationService: any,
-    @Inject(LocalStorageService) private localStorageService: any) {
-
-    matIconRegistry.addSvgIcon('handle', sanitizer.bypassSecurityTrustResourceUrl('assets/images/handle-24px.svg'));
+    @Inject(LocalStorageService) private localStorageService: any
+  ) {
+    matIconRegistry.addSvgIcon(
+      "handle",
+      sanitizer.bypassSecurityTrustResourceUrl("assets/images/handle-24px.svg")
+    );
   }
 
   ngOnInit(): void {
-    if (this.observation.id === 'new') {
-      this.formOptions.expand = true
+    if (this.observation.id === "new") {
+      this.formOptions.expand = true;
     }
 
-    this.canDeleteObservation = this.observation.id !== 'new' &&
-      (this.hasEventUpdatePermission() || this.isCurrentUsersObservation() || this.hasUpdatePermissionsInEventAcl())
+    this.canDeleteObservation =
+      this.observation.id !== "new" &&
+      (this.hasEventUpdatePermission() ||
+        this.isCurrentUsersObservation() ||
+        this.hasUpdatePermissionsInEventAcl());
 
-    this.attachmentService.upload$.subscribe(event => this.onAttachmentUpload(event))
+    this.attachmentService.upload$.subscribe((event) =>
+      this.onAttachmentUpload(event)
+    );
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.observation  && changes.observation.currentValue) {
-      this.event = this.eventService.getEventById(this.observation.eventId)
-      this.formDefinitions = this.eventService.getFormsForEvent(this.event).reduce((map, form) => {
-        map[form.id] = form
-        return map
-      }, {})
+    if (changes.observation && changes.observation.currentValue) {
+      this.event = this.eventService.getEventById(this.observation.eventId);
+      this.formDefinitions = this.eventService
+        .getFormsForEvent(this.event)
+        .reduce((map, form) => {
+          map[form.id] = form;
+          return map;
+        }, {});
 
-      this.isNewObservation = this.observation.id === 'new'
-      this.initialObservation = JSON.parse(JSON.stringify(this.observation))
+      this.isNewObservation = this.observation.id === "new";
+      this.initialObservation = JSON.parse(JSON.stringify(this.observation));
 
       if (this.observation.style) {
-        this.geometryStyle = JSON.parse(JSON.stringify(this.observation.style))
+        this.geometryStyle = JSON.parse(JSON.stringify(this.observation.style));
       }
 
       if (this.isNewObservation) {
-        this.mapService.addFeaturesToLayer([this.observation], 'observations')
+        this.mapService.addFeaturesToLayer([this.observation], "observations");
       }
 
-      this.toFormGroup(this.observation)
-      this.updatePrimarySecondary()
+      this.toFormGroup(this.observation);
+      this.updatePrimarySecondary();
     }
   }
 
   hasEventUpdatePermission(): boolean {
-    return this.userService.myself.role.permissions.includes('DELETE_OBSERVATION')
+    return this.userService.myself.role.permissions.includes(
+      "DELETE_OBSERVATION"
+    );
   }
 
   isCurrentUsersObservation(): boolean {
-    return this.observation.userId === this.userService.myself.id
+    return this.observation.userId === this.userService.myself.id;
   }
 
   hasUpdatePermissionsInEventAcl(): boolean {
-    const myAccess = this.filterService.getEvent().acl[this.userService.myself.id] || {}
-    const aclPermissions = myAccess.permissions || []
-    return aclPermissions.includes('update')
+    const myAccess =
+      this.filterService.getEvent().acl[this.userService.myself.id] || {};
+    const aclPermissions = myAccess["permissions"] || [];
+    return aclPermissions.includes("update");
   }
 
   token(): string {
-    return this.localStorageService.getToken()
+    return this.localStorageService.getToken();
   }
 
   // TODO multi-form build out validators here as well for each form control
-  toFormGroup(observation: any): void {
-    const timestampControl = new UntypedFormControl(moment(observation.properties.timestamp).toDate(), Validators.required);
-    const geometryControl = new UntypedFormControl(observation.geometry, Validators.required);
+  toFormGroup(observation: Observation): void {
+    const timestampControl = new UntypedFormControl(
+      moment(observation.properties.timestamp).toDate(),
+      Validators.required
+    );
+    const geometryControl = new UntypedFormControl(
+      observation.geometry,
+      Validators.required
+    );
 
-    const formArray = new UntypedFormArray([])
-    const observationForms = observation.properties.forms || []
-    observationForms.forEach(observationForm => {
-      const formDefinition = this.formDefinitions[observationForm.formId]
+    const formArray = new UntypedFormArray([]);
+    const observationForms = observation.properties.forms || [];
+    observationForms.forEach((observationForm) => {
+      const formDefinition = this.formDefinitions[observationForm.formId];
       const fieldGroup = new UntypedFormGroup({
         id: new UntypedFormControl(observationForm.id),
-        formId: new UntypedFormControl(formDefinition.id)
-      })
+        formId: new UntypedFormControl(formDefinition.id),
+      });
 
       formDefinition.fields
-        .filter(field => !field.archived)
+        .filter((field) => !field.archived)
         .sort((a, b) => a.id - b.id)
-        .forEach(field => {
-          const value = this.isNewObservation ? field.value : observationForm[field.name]
-          const fieldControl = new UntypedFormControl(value, field.required ? Validators.required : null)
-          fieldGroup.addControl(field.name, fieldControl)
-        })
+        .forEach((field) => {
+          const value = this.isNewObservation
+            ? field.value
+            : observationForm[field.name];
+          const fieldControl = new UntypedFormControl(
+            value,
+            field.required ? Validators.required : null
+          );
+          fieldGroup.addControl(field.name, fieldControl);
+        });
 
-      formArray.push(fieldGroup)
-    })
+      formArray.push(fieldGroup);
+    });
 
     this.formGroup = this.formBuilder.group({
       id: observation.id,
@@ -198,248 +255,325 @@ export class ObservationEditComponent implements OnInit, OnChanges {
       geometry: geometryControl,
       properties: new UntypedFormGroup({
         timestamp: timestampControl,
-        forms: formArray
-      })
-    })
+        forms: formArray,
+      }),
+    });
 
-    if (observation.properties.forms.length === 0 && this.hasForms() && observation.id === 'new') {
-      this.pickForm()
+    if (
+      observation.properties.forms.length === 0 &&
+      this.hasForms() &&
+      observation.id === "new"
+    ) {
+      this.pickForm();
     }
   }
 
   updatePrimarySecondary(): void {
-    const forms = this.formGroup.get('properties').get('forms') as UntypedFormArray
+    const forms = this.formGroup
+      .get("properties")
+      .get("forms") as UntypedFormArray;
     if (forms.length) {
-      const primaryFormGroup = forms.at(0) as UntypedFormGroup
-      const definition = this.formDefinitions[primaryFormGroup.get('formId').value]
+      const primaryFormGroup = forms.at(0) as UntypedFormGroup;
+      const definition =
+        this.formDefinitions[primaryFormGroup.get("formId").value];
 
-      let primaryFieldValue
+      let primaryFieldValue;
       if (primaryFormGroup.contains(definition.primaryFeedField)) {
-        this.primaryField = definition.fields.find(field => field.name === definition.primaryFeedField)
-        primaryFieldValue = primaryFormGroup.get(definition.primaryFeedField).value
+        this.primaryField = definition.fields.find(
+          (field) => field.name === definition.primaryFeedField
+        );
+        primaryFieldValue = primaryFormGroup.get(
+          definition.primaryFeedField
+        ).value;
       }
 
-      let secondaryFieldValue
+      let secondaryFieldValue;
       if (primaryFormGroup.contains(definition.secondaryFeedField)) {
-        this.secondaryField = definition.fields.find(field => field.name === definition.secondaryFeedField)
-        secondaryFieldValue = primaryFormGroup.get(definition.secondaryFeedField).value
+        this.secondaryField = definition.fields.find(
+          (field) => field.name === definition.secondaryFeedField
+        );
+        secondaryFieldValue = primaryFormGroup.get(
+          definition.secondaryFeedField
+        ).value;
       }
 
-      if ((this.primaryField && primaryFieldValue !== this.primaryFieldValue) ||
-          ((this.secondaryField && secondaryFieldValue !== this.secondaryFieldValue))) {
-        this.primaryFieldValue = this.primaryField ? primaryFieldValue : null
-        this.secondaryFieldValue = this.secondaryField ? secondaryFieldValue : null
+      if (
+        (this.primaryField && primaryFieldValue !== this.primaryFieldValue) ||
+        (this.secondaryField &&
+          secondaryFieldValue !== this.secondaryFieldValue)
+      ) {
+        this.primaryFieldValue = this.primaryField ? primaryFieldValue : null;
+        this.secondaryFieldValue = this.secondaryField
+          ? secondaryFieldValue
+          : null;
 
-        const observation = this.formGroup.value
+        const observation = this.formGroup.value;
 
-        const style = this.observationService.getObservationStyleForForm(observation, this.event, definition)
-        observation.style = style
-        this.geometryStyle = style
+        const style = this.observationService.getObservationStyleForForm(
+          observation,
+          this.event,
+          definition
+        );
+        observation.style = style;
+        this.geometryStyle = style;
 
-        this.mapService.updateFeatureForLayer(observation, 'Observations')
+        this.mapService.updateFeatureForLayer(observation, "Observations");
       }
     }
   }
 
   save(): void {
     if (this.formRemoveSnackbar) {
-      this.formRemoveSnackbar.dismiss()
+      this.formRemoveSnackbar.dismiss();
     }
 
-    this.saving = true
-    this.uploads = []
+    this.saving = true;
+    this.uploads = [];
 
     // TODO look at this: this is a hack that will be corrected when we pull ids from the server
-    const form = this.formGroup.getRawValue()
+    const form = this.formGroup.getRawValue();
     const id = form.id;
-    if (form.id === 'new') {
-      delete form.id
+    if (form.id === "new") {
+      delete form.id;
     }
 
-    this.eventService.saveObservation(form).then(observation => {
-      // If this feature was added to the map as a new observation, remove it
-      // as the event service will add it back to the map based on it new id
-      // if it passes the current filter.
-      if (id === 'new') {
-        this.mapService.removeFeatureFromLayer({ id: id }, 'observations')
-      }
+    this.eventService.saveObservation(form).then(
+      (observation) => {
+        // If this feature was added to the map as a new observation, remove it
+        // as the event service will add it back to the map based on it new id
+        // if it passes the current filter.
+        if (id === "new") {
+          this.mapService.removeFeatureFromLayer({ id: id }, "observations");
+        }
 
-      this.error = null
-      this.observation = observation
-      this.formGroup.get('id').setValue(observation.id)
+        this.error = null;
+        this.observation = observation;
+        this.formGroup.get("id").setValue(observation.id);
 
-      form.properties.forms.forEach(form => {
-        const formDefinition = this.formDefinitions[form.formId];
-        Object.keys(form).forEach(fieldName => {
-          const fieldDefinition = formDefinition.fields.find(field => field.name === fieldName);
-          const value = form[fieldName];
-          if (fieldDefinition && fieldDefinition.type === 'attachment' && Array.isArray(value)) {
-            value.forEach(fieldAttachment => {
-              const attachment = observation.attachments.find(attachment => {
-                return !attachment.url &&
-                  attachment.name === fieldAttachment.name &&
-                  attachment.contentType == fieldAttachment.contentType
+        form.properties.forms.forEach((form) => {
+          const formDefinition = this.formDefinitions[form.formId];
+          Object.keys(form).forEach((fieldName) => {
+            const fieldDefinition = formDefinition.fields.find(
+              (field) => field.name === fieldName
+            );
+            const value = form[fieldName];
+            if (
+              fieldDefinition &&
+              fieldDefinition.type === "attachment" &&
+              Array.isArray(value)
+            ) {
+              value.forEach((fieldAttachment) => {
+                const attachment = observation.attachments.find(
+                  (attachment) => {
+                    return (
+                      !attachment.url &&
+                      attachment.name === fieldAttachment.name &&
+                      attachment.contentType == fieldAttachment.contentType
+                    );
+                  }
+                );
+
+                if (
+                  fieldAttachment.file &&
+                  fieldAttachment.action === AttachmentAction.ADD &&
+                  attachment
+                ) {
+                  fieldAttachment.attachmentId = attachment.id;
+                  this.uploads.push(attachment);
+                }
               });
+            }
+          });
+        });
 
-              if (fieldAttachment.file && fieldAttachment.action === AttachmentAction.ADD && attachment) {
-                fieldAttachment.attachmentId = attachment.id
-                this.uploads.push(attachment)
-              }
-            })
-          }
-        })
-      })
+        if (this.uploads.length) {
+          this.attachmentUrl = observation.url;
+        } else {
+          this.close.emit(this.observation);
+        }
+      },
+      (err) => {
+        this.formGroup.markAllAsTouched();
 
-      if (this.uploads.length) {
-        this.attachmentUrl = observation.url
-      } else {
-        this.close.emit(this.observation)
+        if (id === "new") {
+          this.observation.id = "new";
+        }
+
+        this.saving = false;
+        this.error = {
+          message: err.data.message,
+        };
       }
-    }, err => {
-      this.formGroup.markAllAsTouched()
-
-      if (id === 'new') {
-        this.observation.id = 'new'
-      }
-
-      this.saving = false;
-      this.error = {
-        message: err.data.message
-      }
-    })
+    );
   }
 
   cancel(): void {
     this.observation.geometry = this.initialObservation.geometry;
-    if (this.observation.id !== 'new') {
-      this.mapService.updateFeatureForLayer(this.observation, 'observations')
+    if (this.observation.id !== "new") {
+      this.mapService.updateFeatureForLayer(this.observation, "observations");
     } else {
-      this.mapService.removeFeatureFromLayer(this.observation, 'observations')
+      this.mapService.removeFeatureFromLayer(this.observation, "observations");
     }
 
     if (this.formRemoveSnackbar) {
-      this.formRemoveSnackbar.dismiss()
+      this.formRemoveSnackbar.dismiss();
     }
 
-    this.dialog.open(ObservationEditDiscardComponent, {
-      width: '300px',
-      autoFocus: false,
-      position: { left: '75px' }
-    }).afterClosed().subscribe(result => {
-      if (result === 'discard') {
-        this.close.emit()
-      }
-    })
+    this.dialog
+      .open(ObservationEditDiscardComponent, {
+        width: "300px",
+        autoFocus: false,
+        position: { left: "75px" },
+      })
+      .afterClosed()
+      .subscribe((result) => {
+        if (result === "discard") {
+          this.close.emit();
+        }
+      });
   }
 
   hasForms(): boolean {
-    const definitions = this.formDefinitions || {}
-    return Object.keys(definitions).length > 0
+    const definitions = this.formDefinitions || {};
+    return Object.keys(definitions).length > 0;
   }
 
   onGeometryEdit(event): void {
-    this.mask = event.action === 'edit';
+    this.mask = event.action === "edit";
 
     if (this.mask) {
       const elementBounds = event.source.nativeElement.getBoundingClientRect();
-      const parentBounds = this.editContent.nativeElement.getBoundingClientRect();
-      if (elementBounds.top < parentBounds.top || elementBounds.bottom > parentBounds.bottom) {
-        event.source.nativeElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      const parentBounds =
+        this.editContent.nativeElement.getBoundingClientRect();
+      if (
+        elementBounds.top < parentBounds.top ||
+        elementBounds.bottom > parentBounds.bottom
+      ) {
+        event.source.nativeElement.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
       }
     }
   }
 
   pickForm(): void {
-    this.formOptions.expand = true
-    this.bottomSheet.open(ObservationEditFormPickerComponent, {
-      panelClass: 'feed-panel'
-    }).afterDismissed().subscribe(form => {
-      if (!form) return
+    this.formOptions.expand = true;
+    this.bottomSheet
+      .open(ObservationEditFormPickerComponent, {
+        panelClass: "feed-panel",
+      })
+      .afterDismissed()
+      .subscribe((form) => {
+        if (!form) return;
 
-      const fieldsGroup = new UntypedFormGroup({
-        formId: new UntypedFormControl(form.id)
-      });
-
-      form.fields
-        .filter(field => !field.archived)
-        .sort((a, b) => a.id - b.id)
-        .forEach(field => {
-          const fieldControl = new UntypedFormControl(field.value, field.required ? Validators.required : null)
-          fieldsGroup.addControl(field.name, fieldControl)
+        const fieldsGroup = new UntypedFormGroup({
+          formId: new UntypedFormControl(form.id),
         });
 
-      (this.formGroup.get('properties').get('forms') as UntypedFormArray).push(fieldsGroup);
+        form.fields
+          .filter((field) => !field.archived)
+          .sort((a, b) => a.id - b.id)
+          .forEach((field) => {
+            const fieldControl = new UntypedFormControl(
+              field.value,
+              field.required ? Validators.required : null
+            );
+            fieldsGroup.addControl(field.name, fieldControl);
+          });
 
-      this.formElements.changes.pipe(first()).subscribe((queryList: QueryList<ElementRef>) => {
-        queryList.last.nativeElement.scrollIntoView({ behavior: 'smooth' })
-      })
-    })
+        (
+          this.formGroup.get("properties").get("forms") as UntypedFormArray
+        ).push(fieldsGroup);
+
+        this.formElements.changes
+          .pipe(first())
+          .subscribe((queryList: QueryList<ElementRef>) => {
+            queryList.last.nativeElement.scrollIntoView({ behavior: "smooth" });
+          });
+      });
   }
 
   removeForm(formGroup: UntypedFormGroup): void {
-    const formArray = this.formGroup.get('properties').get('forms') as UntypedFormArray
-    const index = formArray.controls.indexOf(formGroup)
-    formArray.removeAt(index)
+    const formArray = this.formGroup
+      .get("properties")
+      .get("forms") as UntypedFormArray;
+    const index = formArray.controls.indexOf(formGroup);
+    formArray.removeAt(index);
 
-    this.formRemoveSnackbar = this.snackBar.open('Form Deleted', 'UNDO', {
+    this.formRemoveSnackbar = this.snackBar.open("Form Deleted", "UNDO", {
       duration: 5000,
-      panelClass: 'form-remove-snackbar',
-    })
+      panelClass: "form-remove-snackbar",
+    });
 
     this.formRemoveSnackbar.onAction().subscribe(() => {
-      formArray.insert(index, formGroup)
-    })
+      formArray.insert(index, formGroup);
+    });
   }
 
   reorderForm(event: CdkDragDrop<any, any>): void {
-    if (event.currentIndex === event.previousIndex) return
+    if (event.currentIndex === event.previousIndex) return;
 
-    const forms = (this.formGroup.get('properties').get('forms') as UntypedFormArray).controls
-    moveItemInArray(forms, event.previousIndex, event.currentIndex)
+    const forms = (
+      this.formGroup.get("properties").get("forms") as UntypedFormArray
+    ).controls;
+    moveItemInArray(forms, event.previousIndex, event.currentIndex);
 
     // re-calculate primary/secondary based new first form
     if (event.currentIndex === 0 || event.previousIndex === 0) {
-      this.updatePrimarySecondary()
+      this.updatePrimarySecondary();
     }
   }
 
   dragStart(event: DragEvent): void {
-    this.document.body.classList.add('item-drag')
+    this.document.body.classList.add("item-drag");
   }
 
   dragEnd(event: DragEvent): void {
-    this.document.body.classList.remove('item-drag')
+    this.document.body.classList.remove("item-drag");
   }
 
   private onAttachmentUpload(event: AttachmentUploadEvent): void {
     switch (event.status) {
       case AttachmentUploadStatus.COMPLETE: {
-        this.eventService.addAttachmentToObservation(this.observation, event.response)
+        this.eventService.addAttachmentToObservation(
+          this.observation,
+          event.response
+        );
 
-        this.uploads = this.uploads.filter(attachment => attachment.id !== event.upload.attachmentId)
+        this.uploads = this.uploads.filter(
+          (attachment) => attachment.id !== event.upload.attachmentId
+        );
         if (this.uploads.length === 0) {
-          this.saving = false
-          this.close.emit(this.observation)
+          this.saving = false;
+          this.close.emit(this.observation);
         }
 
         break;
       }
       case AttachmentUploadStatus.ERROR: {
-        this.snackBar.open(event.response?.error, null, { duration: 4000 })
+        this.snackBar.open(event.response?.error, null, { duration: 4000 });
 
-        const formArray = this.formGroup.get('properties').get('forms') as UntypedFormArray
+        const formArray = this.formGroup
+          .get("properties")
+          .get("forms") as UntypedFormArray;
         formArray.controls.forEach((formGroup: UntypedFormGroup) => {
-          const formId = formGroup.get('formId').value
+          const formId = formGroup.get("formId").value;
           const formDefinition = this.formDefinitions[formId];
-          Object.keys(formGroup.controls).forEach(fieldName => {
-            const fieldDefinition = formDefinition.fields.find(field => field.name === fieldName);
-            if (fieldDefinition && fieldDefinition.type === 'attachment') {
-              let attachments = formGroup.get(fieldName).value || []
-              attachments = attachments.filter(attachment => attachment.attachmentId !== event.upload.attachmentId)
-              formGroup.get(fieldName).setValue(attachments)
+          Object.keys(formGroup.controls).forEach((fieldName) => {
+            const fieldDefinition = formDefinition.fields.find(
+              (field) => field.name === fieldName
+            );
+            if (fieldDefinition && fieldDefinition.type === "attachment") {
+              let attachments = formGroup.get(fieldName).value || [];
+              attachments = attachments.filter(
+                (attachment) =>
+                  attachment.attachmentId !== event.upload.attachmentId
+              );
+              formGroup.get(fieldName).setValue(attachments);
             }
-          })
-        })
+          });
+        });
 
         this.saving = false;
         break;

--- a/web-app/src/app/event/event.service.ts
+++ b/web-app/src/app/event/event.service.ts
@@ -1,5 +1,15 @@
 import { Injectable } from "@angular/core";
-import { Observable, catchError, combineLatest, finalize, map, of, tap } from "rxjs";
+import {
+  Observable,
+  Subject,
+  catchError,
+  combineLatest,
+  finalize,
+  map,
+  of,
+  take,
+  tap,
+} from "rxjs";
 import { FilterService } from "../filter/filter.service";
 import { PollingService } from "./polling.service";
 import { ObservationService } from "../observation/observation.service";
@@ -7,12 +17,23 @@ import { HttpClient, HttpParams } from "@angular/common/http";
 import { LayerService } from "../layer/layer.service";
 import { LocationService } from "../user/location/location.service";
 import { LocalStorageService } from "../http/local-storage.service";
-import * as _ from 'lodash'
-import * as moment from 'moment'
+import * as _ from "lodash";
+import * as moment from "moment";
 import { FeedService } from "@ngageoint/mage.web-core-lib/feed";
+import { User } from "@ngageoint/mage.web-core-lib/user";
+import { MemberPage, filterChanges } from "./event.types";
+import {
+  Attachment,
+  Event,
+  Form,
+  FormField,
+  Layer,
+  Observation,
+  Team,
+} from "../filter/filter.types";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root",
 })
 export class EventService {
   private observationsChangedListeners: any = [];
@@ -24,6 +45,7 @@ export class EventService {
   private pollingTimeout: any = null;
   private feedPollTimeout: any = null;
   private feedSyncStates: any = {};
+  private memberSubject = new Subject<User[]>();
 
   constructor(
     private pollingService: PollingService,
@@ -37,58 +59,62 @@ export class EventService {
   ) {}
 
   init() {
-    this.filterService.addListener(this)
-    this.pollingService.addListener(this)
+    this.filterService.addListener(this);
+    this.pollingService.addListener(this);
   }
 
   destroy() {
-    this.eventsById = {}
-    this.filterService.removeListener(this)
-    this.pollingService.removeListener(this)
+    this.eventsById = {};
+    this.filterService.removeListener(this);
+    this.pollingService.removeListener(this);
 
     if (this.pollingTimeout) {
-      clearTimeout(this.pollingTimeout)
+      clearTimeout(this.pollingTimeout);
     }
 
     if (this.feedPollTimeout) {
-      clearTimeout(this.feedPollTimeout)
+      clearTimeout(this.feedPollTimeout);
     }
+
+    this.memberSubject.unsubscribe();
   }
 
   query(options?: any): Observable<any> {
     options = options || {};
-    return this.httpClient.get<any>('/api/events/', options)
+    return this.httpClient.get<any>("/api/events/", options);
   }
 
   addFeed(eventId: string, feed: any): Observable<any> {
-    return this.httpClient.post<any>(`/api/events/${eventId}/feeds`, feed)
+    return this.httpClient.post<any>(`/api/events/${eventId}/feeds`, feed);
   }
 
   removeFeed(eventId: string, feedId: string): Observable<any> {
-    return this.httpClient.delete<any>(`/api/events/${eventId}/feeds/${feedId}`)
+    return this.httpClient.delete<any>(
+      `/api/events/${eventId}/feeds/${feedId}`
+    );
   }
 
-  onFilterChanged(filter: any) {
+  async onFilterChanged(filter: any) {
     if (filter.event) {
       this.onEventChanged(filter.event);
     }
-
-    if (filter.event?.added?.length || filter.timeInterval) { // requery server
-      this.fetch().subscribe()
-    } else if (filter.teams) { // filter in memory
-      this.onTeamsChanged()
+    if (filter.event?.added?.length || filter.timeInterval) {
+      // requery server
+      await this.fetch().subscribe();
     }
 
+    this.onFiltersChanged(filter);
+
     if (filter.actionFilter) {
-      this.onActionFilterChanged()
+      this.onActionFilterChanged();
     }
   }
 
-  onEventChanged(event: any) {
-    const { added = [], removed = [] } = event 
+  onEventChanged(event: filterChanges) {
+    const { added = [], removed = [] } = event;
     added.forEach((added: any) => {
       if (!this.eventsById[added.id]) {
-        this.eventsById[added.id] = (JSON.parse(JSON.stringify(added)));
+        this.eventsById[added.id] = JSON.parse(JSON.stringify(added));
 
         this.eventsById[added.id].filteredObservationsById = {};
         this.eventsById[added.id].observationsById = {};
@@ -98,37 +124,69 @@ export class EventService {
 
       this.fetchLayers(added);
       this.fetchFeeds(added);
-    })
+    });
 
     removed.forEach((removed: any) => {
-      this.observationsChanged({ removed: Object.values(this.eventsById[removed.id]?.filteredObservationsById || {}) });
-      this.usersChanged({ removed: Object.values(this.eventsById[removed.id]?.filteredUsersById || {}) });
-      this.layersChanged({ removed: Object.values(this.eventsById[removed.id]?.layersById || {}) }, removed);
-      this.feedItemsChanged({ removed: Object.values(this.eventsById[removed.id]?.feedsById || {}).map((feed: any) => ({ feed })) }, removed);
+      this.observationsChanged({
+        removed: Object.values(
+          this.eventsById[removed.id]?.filteredObservationsById || {}
+        ),
+      });
+      this.usersChanged({
+        removed: Object.values(
+          this.eventsById[removed.id]?.filteredUsersById || {}
+        ),
+      });
+      this.layersChanged(
+        {
+          removed: Object.values(this.eventsById[removed.id]?.layersById || {}),
+        },
+        removed
+      );
+      this.feedItemsChanged(
+        {
+          removed: Object.values(
+            this.eventsById[removed.id]?.feedsById || {}
+          ).map((feed: any) => ({ feed })),
+        },
+        removed
+      );
       delete this.eventsById[removed.id];
-    })
+    });
   }
 
-  onTeamsChanged() {
+  onFiltersChanged(filter: any): void {
     const event = this.filterService.getEvent();
     if (!event) return;
 
     const teamsEvent = this.eventsById[event.id];
     if (!teamsEvent) return;
 
-    // remove observations that are not part of filtered teams
+    // remove observations that are not made by filtered users
     const observationsRemoved = [];
-    Object.values(teamsEvent.filteredObservationsById).forEach((observation: any) => {
-      if (!this.filterService.isUserInTeamFilter(observation.userId)) {
-        delete teamsEvent.filteredObservationsById[observation.id];
-        observationsRemoved.push(observation);
+    Object.values(teamsEvent.filteredObservationsById).forEach(
+      (observation: Observation) => {
+        if (
+          (filter.users &&
+            !this.filterService.isUserInList(observation.userId)) ||
+          (filter.teams &&
+            !this.filterService.isUserInTeamFilter(observation.userId)) ||
+          (filter.forms &&
+            !this.filterService.hasFormInList(observation.properties.forms))
+        ) {
+          delete teamsEvent.filteredObservationsById[observation.id];
+          observationsRemoved.push(observation);
+        }
       }
-    });
+    );
 
     // remove users that are not part of filtered teams
     const usersRemoved = [];
-    Object.values(teamsEvent.filteredUsersById).forEach((user: any) => {
-      if (!this.filterService.isUserInTeamFilter(user.id)) {
+    Object.values(teamsEvent.filteredUsersById).forEach((user: User) => {
+      if (
+        (filter.users && !this.filterService.isUserInList(user.id)) ||
+        (filter.teams && !this.filterService.isUserInTeamFilter(user.id))
+      ) {
         delete teamsEvent.filteredUsersById[user.id];
         usersRemoved.push(user);
       }
@@ -136,23 +194,42 @@ export class EventService {
 
     // add any observations that are part of the filtered teams
     const observationsAdded = [];
-    Object.values(teamsEvent.observationsById).forEach((observation: any) => {
-      if (this.filterService.isUserInTeamFilter(observation.userId) && !teamsEvent.filteredObservationsById[observation.id]) {
-        observationsAdded.push(observation);
-        teamsEvent.filteredObservationsById[observation.id] = observation;
+    Object.values(teamsEvent.observationsById).forEach(
+      (observation: Observation) => {
+        if (
+          filter.users &&
+          this.filterService.isUserInList(observation.userId) &&
+          filter.teams &&
+          this.filterService.isUserInTeamFilter(observation.userId) &&
+          filter.forms &&
+          this.filterService.hasFormInList(observation.properties.forms) &&
+          !teamsEvent.filteredObservationsById[observation.id]
+        ) {
+          observationsAdded.push(observation);
+          teamsEvent.filteredObservationsById[observation.id] = observation;
+        }
       }
-    });
+    );
 
     // add any users that are part of the filtered teams
     const usersAdded = [];
-    Object.values(teamsEvent.usersById).forEach((user: any) => {
-      if (this.filterService.isUserInTeamFilter(user.id) && !teamsEvent.filteredUsersById[user.id]) {
+    Object.values(teamsEvent.usersById).forEach((user: User) => {
+      if (
+        filter.users &&
+        !this.filterService.isUserInList(user.id) &&
+        filter.teams &&
+        !this.filterService.isUserInTeamFilter(user.id) &&
+        !teamsEvent.filteredUsersById[user.id]
+      ) {
         usersAdded.push(user);
         teamsEvent.filteredUsersById[user.id] = user;
       }
     });
 
-    this.observationsChanged({ added: observationsAdded, removed: observationsRemoved });
+    this.observationsChanged({
+      added: observationsAdded,
+      removed: observationsRemoved,
+    });
     this.usersChanged({ added: usersAdded, removed: usersRemoved });
   }
 
@@ -163,56 +240,69 @@ export class EventService {
     const actionEvent = this.eventsById[event.id];
 
     const observationsRemoved = [];
-    Object.values(actionEvent.filteredObservationsById).forEach((observation: any) => {
-      if (!this.filterService.observationInFilter(observation)) {
-        delete actionEvent.filteredObservationsById[observation.id];
-        observationsRemoved.push(observation);
+    Object.values(actionEvent.filteredObservationsById).forEach(
+      (observation: Observation) => {
+        if (!this.filterService.observationInFilter(observation)) {
+          delete actionEvent.filteredObservationsById[observation.id];
+          observationsRemoved.push(observation);
+        }
       }
-    });
+    );
 
     const observationsAdded = [];
     // add any observations that are part of the filtered actions
-    Object.values(actionEvent.observationsById).forEach((observation: any) => {
-      if (!actionEvent.filteredObservationsById[observation.id] && this.filterService.observationInFilter(observation)) {
-        observationsAdded.push(observation);
-        actionEvent.filteredObservationsById[observation.id] = observation;
+    Object.values(actionEvent.observationsById).forEach(
+      (observation: Observation) => {
+        if (
+          !actionEvent.filteredObservationsById[observation.id] &&
+          this.filterService.observationInFilter(observation)
+        ) {
+          observationsAdded.push(observation);
+          actionEvent.filteredObservationsById[observation.id] = observation;
+        }
       }
-    });
+    );
 
-    this.observationsChanged({ added: observationsAdded, removed: observationsRemoved });
+    this.observationsChanged({
+      added: observationsAdded,
+      removed: observationsRemoved,
+    });
   }
 
   onPollingIntervalChanged(interval: any) {
     if (this.pollingTimeout) {
       // cancel previous poll
-      clearTimeout(this.pollingTimeout)
+      clearTimeout(this.pollingTimeout);
     }
 
     this.pollingTimeout = setTimeout(() => {
       this.poll(interval);
-    }, interval)
+    }, interval);
   }
 
   addObservationsChangedListener(listener: any) {
     this.observationsChangedListeners.push(listener);
 
-    if (typeof listener.onObservationsChanged === 'function') {
+    if (typeof listener.onObservationsChanged === "function") {
       Object.values(this.eventsById).forEach((event: any) => {
-        listener.onObservationsChanged({ added: Object.values(event.observationsById) });
+        listener.onObservationsChanged({
+          added: Object.values(event.observationsById),
+        });
       });
     }
   }
 
   removeObservationsChangedListener(listener) {
-    this.observationsChangedListeners = this.observationsChangedListeners.filter((l: any) => {
-      return listener !== l;
-    });
+    this.observationsChangedListeners =
+      this.observationsChangedListeners.filter((l: any) => {
+        return listener !== l;
+      });
   }
 
   addUsersChangedListener(listener) {
     this.usersChangedListeners.push(listener);
 
-    if (typeof listener.onUsersChanged === 'function') {
+    if (typeof listener.onUsersChanged === "function") {
       Object.values(this.eventsById).forEach((event: any) => {
         listener.onUsersChanged({ added: Object.values(event.usersById) });
       });
@@ -228,9 +318,12 @@ export class EventService {
   addLayersChangedListener(listener) {
     this.layersChangedListeners.push(listener);
 
-    if (typeof listener.onLayersChanged === 'function') {
+    if (typeof listener.onLayersChanged === "function") {
       Object.values(this.eventsById).forEach((event: any) => {
-        listener.onLayersChanged({ added: Object.values(event.layersById) }, event); // TODO this could be old layers, admin panel might have changed layers
+        listener.onLayersChanged(
+          { added: Object.values(event.layersById) },
+          event
+        ); // TODO this could be old layers, admin panel might have changed layers
       });
     }
   }
@@ -238,7 +331,7 @@ export class EventService {
   addFeedItemsChangedListener(listener) {
     this.feedItemsChangedListeners.push(listener);
 
-    if (typeof listener.onFeedItemsChanged === 'function') {
+    if (typeof listener.onFeedItemsChanged === "function") {
       Object.values(this.eventsById).forEach((event: any) => {
         // TODO what do I send here?
         // listener.onFeedItemsChanged({ added: _.values(event.feedsById) }, event);
@@ -257,128 +350,151 @@ export class EventService {
   }
 
   removeLayersChangedListener(listener) {
-    this.layersChangedListeners = this.layersChangedListeners.filter((l: any) => {
-      return listener !== l;
-    });
+    this.layersChangedListeners = this.layersChangedListeners.filter(
+      (l: any) => {
+        return listener !== l;
+      }
+    );
   }
 
   removeFeedItemsChangedListener(listener) {
-    this.feedItemsChangedListeners = this.feedItemsChangedListeners.filter((l: any) => {
-      return listener !== l;
-    });
+    this.feedItemsChangedListeners = this.feedItemsChangedListeners.filter(
+      (l: any) => {
+        return listener !== l;
+      }
+    );
   }
 
   getEventById(eventId) {
     return this.eventsById[eventId];
   }
 
-  saveObservation(observation: any) {
+  saveObservation(observation: Observation) {
     const event = this.eventsById[observation.eventId];
     const isNewObservation = !observation.id;
 
-    return this.observationService.saveObservationForEvent(event, observation)
+    return this.observationService
+      .saveObservationForEvent(event, observation)
       .pipe(
-        tap((update: any) => {
+        tap((update: Observation) => {
           event.observationsById[update.id] = update;
 
           // Check if this new observation passes the current filter
           if (this.filterService.observationInFilter(update)) {
             event.filteredObservationsById[update.id] = update;
-            isNewObservation ? this.observationsChanged({ added: [update] }) : this.observationsChanged({ updated: [update] });
+            isNewObservation
+              ? this.observationsChanged({ added: [update] })
+              : this.observationsChanged({ updated: [update] });
           }
         })
-      )
+      );
   }
 
   addObservationFavorite(observation) {
     var event = this.eventsById[observation.eventId];
-    return this.observationService.addObservationFavorite(event, observation)
+    return this.observationService
+      .addObservationFavorite(event, observation)
       .pipe(
-        tap((update: any) => {
+        tap((update: Observation) => {
           event.observationsById[update.id] = update;
           this.observationsChanged({ updated: [update] });
         })
-      )
+      );
   }
 
   removeObservationFavorite(observation) {
     var event = this.eventsById[observation.eventId];
-    return this.observationService.removeObservationFavorite(event, observation)
+    return this.observationService
+      .removeObservationFavorite(event, observation)
       .pipe(
-        tap((update: any) => {
+        tap((update: Observation) => {
           event.observationsById[update.id] = update;
           this.observationsChanged({ updated: [update] });
         })
-      )
+      );
   }
 
-  markObservationAsImportant(observation, important): Observable<any> {
+  markObservationAsImportant(
+    observation: Observation,
+    important
+  ): Observable<Observation> {
     var event = this.eventsById[observation.eventId];
-    return this.observationService.markObservationAsImportantForEvent(event, observation, important)
+    return this.observationService
+      .markObservationAsImportantForEvent(event, observation, important)
       .pipe(
-        tap((update: any) => {
+        tap((update: Observation) => {
           event.observationsById[update.id] = update;
           this.observationsChanged({ updated: [update] });
         })
-      )
+      );
   }
 
-  clearObservationAsImportant(observation): Observable<any> {
+  clearObservationAsImportant(
+    observation: Observation
+  ): Observable<Observation> {
     var event = this.eventsById[observation.eventId];
-    return this.observationService.clearObservationAsImportantForEvent(event, observation)
+    return this.observationService
+      .clearObservationAsImportantForEvent(event, observation)
       .pipe(
-        tap((update: any) => {
+        tap((update: Observation) => {
           event.observationsById[update.id] = update;
           this.observationsChanged({ updated: [update] });
         })
-      )
+      );
   }
 
-  archiveObservation(observation): Observable<any> {
-    var event = this.eventsById[observation.eventId]
-    return this.observationService.archiveObservationForEvent(event, observation)
+  archiveObservation(observation): Observable<Observation> {
+    var event = this.eventsById[observation.eventId];
+    return this.observationService
+      .archiveObservationForEvent(event, observation)
       .pipe(
-        tap((archived: any) => {
-          delete event.observationsById[archived.id]
-          this.observationsChanged({ removed: [archived] })
+        tap((archived: Observation) => {
+          delete event.observationsById[archived.id];
+          this.observationsChanged({ removed: [archived] });
         })
-      )
+      );
   }
 
-  addAttachmentToObservation(observation, attachment) {
+  addAttachmentToObservation(observation: Observation, attachment: Attachment) {
     const event = this.eventsById[observation.eventId];
-    this.observationService.addAttachmentToObservationForEvent(event, observation, attachment);
+    this.observationService.addAttachmentToObservationForEvent(
+      event,
+      observation,
+      attachment
+    );
     this.observationsChanged({ updated: [observation] });
   }
 
   deleteAttachmentForObservation(observation, attachment) {
     const event = this.eventsById[observation.eventId];
-    return this.observationService.deleteAttachmentInObservationForEvent(event, observation, attachment).subscribe((observation: any) => {
-      this.observationsChanged({ updated: [observation] });
-    });
+    return this.observationService
+      .deleteAttachmentInObservationForEvent(event, observation, attachment)
+      .subscribe((observation: Observation) => {
+        this.observationsChanged({ updated: [observation] });
+      });
   }
 
-  getFormField(form, fieldName) {
-    return form.fields.find((field: any) => field.name === fieldName);
+  getFormField(form: Form, fieldName: string) {
+    return form.fields.find((field: FormField) => field.name === fieldName);
   }
 
-  getForms(observation, options?: any) {
+  getForms(observation: Observation, options?: any) {
     var event = this.eventsById[observation.eventId];
     return this.getFormsForEvent(event, options);
   }
 
-  getFormsForEvent(event, options?: any) {
+  getFormsForEvent(event: Event, options?: any) {
     options = options || {};
     var forms = event.forms;
     if (options.archived === false) {
-      forms = forms.filter((form: any) => !form.archived);
+      forms = forms.filter((form: Form) => !form.archived);
     }
 
     return forms;
   }
 
-  createForm(observationForm, formDefinition, viewModel?: any) {
-    const form = (JSON.parse(JSON.stringify(formDefinition)));
+  createForm(observationForm: any, formDefinition: any, viewModel?: any) {
+    const form = JSON.parse(JSON.stringify(formDefinition));
 
     form.remoteId = observationForm.id;
 
@@ -387,7 +503,7 @@ export class EventService {
     for (const [key, value] of Object.entries(observationForm)) {
       const field = this.getFormField(form, key);
       if (field) {
-        if (field.type === 'date' && field.value) {
+        if (field.type === "date" && field.value) {
           field.value = moment(value).toDate();
         } else {
           field.value = value;
@@ -397,19 +513,30 @@ export class EventService {
     }
 
     if (viewModel) {
-      observationForm.fields = _.intersection(observationForm.fields, existingPropertyFields);
+      observationForm.fields = _.intersection(
+        observationForm.fields,
+        existingPropertyFields
+      );
     }
 
     return form;
   }
 
-  exportForm(event): Observable<any> {
-    return this.httpClient.get<any>(`/api/event/${event.id}/form.zip`)
+  exportForm(event): Observable<Form> {
+    return this.httpClient.get<Form>(`/api/event/${event.id}/form.zip`);
+  }
+
+  getMembers(event): Observable<User[]> {
+    let memberPage = this.httpClient.get<MemberPage>(
+      `/api/events/${event.id}/members`
+    );
+    memberPage.pipe(take(1)).subscribe((x) => this.memberSubject.next(x.items));
+    return this.memberSubject.asObservable();
   }
 
   isUserInEvent(user, event): boolean {
     if (!event) return false;
-    return event.teams.some((team: any) => team.userIds.includes(user.id));
+    return event.teams.some((team: Team) => team.userIds.includes(user.id));
   }
 
   usersChanged(changed) {
@@ -418,19 +545,19 @@ export class EventService {
       changed.updated = changed.updated || [];
       changed.removed = changed.removed || [];
 
-      if (typeof listener.onUsersChanged === 'function') {
+      if (typeof listener.onUsersChanged === "function") {
         listener.onUsersChanged(changed);
       }
     });
   }
 
-  observationsChanged(changed) {
+  observationsChanged(changed: filterChanges) {
     this.observationsChangedListeners.forEach((listener: any) => {
       changed.added = changed.added || [];
       changed.updated = changed.updated || [];
       changed.removed = changed.removed || [];
 
-      if (typeof listener.onObservationsChanged === 'function') {
+      if (typeof listener.onObservationsChanged === "function") {
         listener.onObservationsChanged(changed);
       }
     });
@@ -442,7 +569,7 @@ export class EventService {
       changed.updated = changed.updated || [];
       changed.removed = changed.removed || [];
 
-      if (typeof listener.onLayersChanged === 'function') {
+      if (typeof listener.onLayersChanged === "function") {
         listener.onLayersChanged(changed, event);
       }
     });
@@ -454,7 +581,7 @@ export class EventService {
       changed.updated = changed.updated || [];
       changed.removed = changed.removed || [];
 
-      if (typeof listener.onFeedItemsChanged === 'function') {
+      if (typeof listener.onFeedItemsChanged === "function") {
         listener.onFeedItemsChanged(changed, event);
       }
     });
@@ -462,7 +589,9 @@ export class EventService {
 
   fetch(): Observable<any> {
     const event = this.filterService.getEvent();
-    if (!event) { return of()}
+    if (!event) {
+      return of();
+    }
 
     const parameters: any = {};
     const interval = this.filterService.getInterval();
@@ -477,56 +606,70 @@ export class EventService {
         .pipe(map((locations: any) => this.parseLocations(event, locations))),
       this.observationService
         .getObservationsForEvent(event, parameters)
-        .pipe(map((observations: any) => this.parseObservations(event, observations)))
-    ])
+        .pipe(
+          map((observations: Observation[]) =>
+            this.parseObservations(event, observations)
+          )
+        ),
+    ]);
   }
 
   fetchLayers(event) {
-    return this.layerService.getLayersForEvent(event).subscribe((layers: any) => {
-      const added = layers.filter((l) => {
-        return !Object.keys(this.eventsById[event.id].layersById || {}).some((layerId: any) => l.id === layerId)
-      })
+    return this.layerService
+      .getLayersForEvent(event)
+      .subscribe((layers: Layer[]) => {
+        const added = layers.filter((l) => {
+          return !Object.keys(this.eventsById[event.id].layersById || {}).some(
+            (layerId: any) => l.id === layerId
+          );
+        });
 
-      const removed = Object.keys(this.eventsById[event.id].layersById || {}).filter((layerId: any) => {
-        return !layers.some((l: any) => l.id === layerId);
-      })
+        const removed = Object.keys(
+          this.eventsById[event.id].layersById || {}
+        ).filter((layerId: any) => {
+          return !layers.some((l: Layer) => l.id === layerId);
+        });
 
-      this.eventsById[event.id].layersById = _.keyBy(layers, 'id');
-      this.layersChanged({ added: added, removed: removed }, event);
-    });
+        this.eventsById[event.id].layersById = _.keyBy(layers, "id");
+        this.layersChanged({ added: added, removed: removed }, event);
+      });
   }
 
   fetchFeeds(event) {
-    this.feedService.fetchFeeds(event.id).subscribe(feeds => {
-      this.feedItemsChanged({
-        added: feeds.map(feed => {
-          return {
-            feed,
-            items: []
-          }
-        })
-      }, event);
+    this.feedService.fetchFeeds(event.id).subscribe((feeds) => {
+      this.feedItemsChanged(
+        {
+          added: feeds.map((feed) => {
+            return {
+              feed,
+              items: [],
+            };
+          }),
+        },
+        event
+      );
 
-      this.eventsById[event.id].feedsById = _.keyBy(feeds, 'id');
-      this.feedSyncStates = feeds.map(feed => {
+      this.eventsById[event.id].feedsById = _.keyBy(feeds, "id");
+      this.feedSyncStates = feeds.map((feed) => {
         return {
           id: feed.id,
-          lastSync: 0
-        }
+          lastSync: 0,
+        };
       });
 
       this.pollFeeds();
     });
   }
 
-  parseObservations(event: any, observations: any): void {
+  parseObservations(event: Event, observations: Observation[]): void {
     var added = [];
     var updated = [];
     var removed = [];
 
     var observationsById = {};
-    var filteredObservationsById = this.eventsById[event.id].filteredObservationsById;
-    observations.forEach((observation: any) => {
+    var filteredObservationsById =
+      this.eventsById[event.id].filteredObservationsById;
+    observations.forEach((observation: Observation) => {
       // Check if this observation passes the current filter
       if (this.filterService.observationInFilter(observation)) {
         // Check if we already have this observation, if so update, otherwise add
@@ -536,8 +679,16 @@ export class EventService {
             updated.push(observation);
           } else if (observation.attachments) {
             var some = _.some(observation.attachments, function (attachment) {
-              var localAttachment = _.find(localObservation.attachments, function (a) { return a.id === attachment.id; });
-              return !localAttachment || localAttachment.lastModified !== attachment.lastModified;
+              var localAttachment = _.find(
+                localObservation.attachments,
+                function (a) {
+                  return a.id === attachment.id;
+                }
+              );
+              return (
+                !localAttachment ||
+                localAttachment.lastModified !== attachment.lastModified
+              );
             });
 
             if (some) updated.push(observation);
@@ -557,13 +708,17 @@ export class EventService {
     // remaining elements were not pulled from the server, hence we should remove them
     removed = Object.values(filteredObservationsById);
 
-    this.eventsById[event.id].observationsById = _.keyBy(observations, 'id');
+    this.eventsById[event.id].observationsById = _.keyBy(observations, "id");
     this.eventsById[event.id].filteredObservationsById = observationsById;
 
-    this.observationsChanged({ added: added, updated: updated, removed: removed });
+    this.observationsChanged({
+      added: added,
+      updated: updated,
+      removed: removed,
+    });
   }
 
-  parseLocations(event, userLocations: any): void {
+  parseLocations(event: Event, userLocations: any): void {
     const added = [];
     const updated = [];
 
@@ -580,20 +735,25 @@ export class EventService {
 
       if (userLocation.user.iconUrl) {
         var params = new HttpParams();
-        params = params.append('access_token', this.localStorageService.getToken())
-        params = params.append('_dc', userLocation.user.lastUpdated)
+        params = params.append(
+          "access_token",
+          this.localStorageService.getToken()
+        );
+        params = params.append("_dc", userLocation.user.lastUpdated);
 
         location.style = {
-          iconUrl: `${userLocation.user.iconUrl}?${params.toString()}`
-        }
+          iconUrl: `${userLocation.user.iconUrl}?${params.toString()}`,
+        };
       }
 
       if (this.filterService.isUserInTeamFilter(userLocation.id)) {
         // Check if we already have this user, if so update, otherwise add
         const localUser = filteredUsersById[userLocation.id];
         if (localUser) {
-
-          if (userLocation.location.properties.timestamp !== localUser.location.properties.timestamp) {
+          if (
+            userLocation.location.properties.timestamp !==
+            localUser.location.properties.timestamp
+          ) {
             updated.push(userLocation);
           }
         } else {
@@ -611,7 +771,7 @@ export class EventService {
     // remaining elements were not pulled from the server, hence we should remove them
     const removed = _.values(filteredUsersById);
 
-    this.eventsById[event.id].usersById = _.keyBy(userLocations, 'id');
+    this.eventsById[event.id].usersById = _.keyBy(userLocations, "id");
     this.eventsById[event.id].filteredUsersById = usersById;
 
     this.usersChanged({ added: added, updated: updated, removed: removed });
@@ -623,36 +783,39 @@ export class EventService {
     }
     this.fetch().subscribe(() => {
       this.pollListeners.forEach((listener: any) => {
-        if (typeof listener.onPoll === 'function') {
+        if (typeof listener.onPoll === "function") {
           listener.onPoll();
         }
       });
 
       this.pollingTimeout = setTimeout(() => {
         this.poll(interval);
-      }, interval)
+      }, interval);
     });
   }
 
-  getNextFeed(event) {
+  getNextFeed(event: Event) {
     const now = Date.now();
-    const feedsInSyncPriorityOrder = _.sortBy(this.feedSyncStates, feed => { return feed.lastSync });
-    const nextFeed = feedsInSyncPriorityOrder.find(syncState => {
-      if (!syncState.lastSync) {
-        return true;
-      }
-      const feed = this.eventsById[event.id].feedsById[syncState.id];
-      if ((now - syncState.lastSync) > (feed.updateFrequencySeconds * 1000)) {
-        return true;
-      }
-    }) || {};
+    const feedsInSyncPriorityOrder = _.sortBy(this.feedSyncStates, (feed) => {
+      return feed.lastSync;
+    });
+    const nextFeed =
+      feedsInSyncPriorityOrder.find((syncState) => {
+        if (!syncState.lastSync) {
+          return true;
+        }
+        const feed = this.eventsById[event.id].feedsById[syncState.id];
+        if (now - syncState.lastSync > feed.updateFrequencySeconds * 1000) {
+          return true;
+        }
+      }) || {};
     return this.eventsById[event.id].feedsById[nextFeed.id];
   }
 
-  getFeedFetchDelay(event) {
+  getFeedFetchDelay(event: Event) {
     const now = Date.now();
-    const delays = this.feedSyncStates.map(syncState => {
-      const feed = this.eventsById[event.id].feedsById[syncState.id]
+    const delays = this.feedSyncStates.map((syncState) => {
+      const feed = this.eventsById[event.id].feedsById[syncState.id];
       if (!syncState.lastSync) {
         return 0;
       }
@@ -661,7 +824,7 @@ export class EventService {
       return frequencyMillis - elapsed;
     });
 
-    return delays.length > 0 ? Math.min(...delays) : 60 * 1000
+    return delays.length > 0 ? Math.min(...delays) : 60 * 1000;
   }
 
   pollFeeds() {
@@ -669,34 +832,43 @@ export class EventService {
     const feed = this.getNextFeed(event);
     const scheduleNextPoll = () => {
       const delayMillis = this.getFeedFetchDelay(event);
-      clearTimeout(this.feedPollTimeout)
+      clearTimeout(this.feedPollTimeout);
       this.feedPollTimeout = setTimeout(() => {
-        this.pollFeeds()
-      }, delayMillis)
+        this.pollFeeds();
+      }, delayMillis);
     };
 
     if (!feed) {
       return scheduleNextPoll();
     }
-    
-    this.feedService.fetchFeedItems(event, feed).pipe(
-      tap((content: any) => {
-        // TODO is this really created or updated, maybe just create as empty when,
-        // feeds come back
-        this.feedItemsChanged({
-          updated: [{ feed, items: content.items.features }]
-        }, event);
-      }),
-      catchError((err) => {
-        // TODO: add error handling
-        console.error(`error fetching feed content for feed ${feed.id}, ${feed.title}`, err);
-        return of();
-      }),
-      finalize(() => {
-        const state = this.feedSyncStates.find(f => f.id === feed.id);
-        state.lastSync = Date.now();
-        scheduleNextPoll();
-      })
-    ).subscribe();
+
+    this.feedService
+      .fetchFeedItems(event, feed)
+      .pipe(
+        tap((content: any) => {
+          // TODO is this really created or updated, maybe just create as empty when,
+          // feeds come back
+          this.feedItemsChanged(
+            {
+              updated: [{ feed, items: content.items.features }],
+            },
+            event
+          );
+        }),
+        catchError((err) => {
+          // TODO: add error handling
+          console.error(
+            `error fetching feed content for feed ${feed.id}, ${feed.title}`,
+            err
+          );
+          return of();
+        }),
+        finalize(() => {
+          const state = this.feedSyncStates.find((f) => f.id === feed.id);
+          state.lastSync = Date.now();
+          scheduleNextPoll();
+        })
+      )
+      .subscribe();
   }
 }

--- a/web-app/src/app/event/event.service.ts
+++ b/web-app/src/app/event/event.service.ts
@@ -25,6 +25,7 @@ import { MemberPage, filterChanges } from "./event.types";
 import {
   Attachment,
   Event,
+  Filter,
   Form,
   FormField,
   Layer,
@@ -155,7 +156,13 @@ export class EventService {
     });
   }
 
-  onFiltersChanged(filter: any): void {
+  /**
+   * Updates List of Observations and Users when Filter Changes
+   * @param  {Filter} filter Filter Parametes
+   * @return {void} No Return
+   */
+
+  onFiltersChanged(filter: Filter): void {
     const event = this.filterService.getEvent();
     if (!event) return;
 

--- a/web-app/src/app/event/event.types.ts
+++ b/web-app/src/app/event/event.types.ts
@@ -1,0 +1,13 @@
+import { User } from "@ngageoint/mage.web-core-lib/user";
+import { Event } from "../filter/filter.types";
+
+export type MemberPage = {
+    items: User[];
+    pageIndex: number;
+    pageSize: number;
+    totalCount: number;
+  };
+  
+export type filterChanges = { added?: any[]; updated?: any[]; removed?: any[] };
+
+export type EventById = Record<string, Event>;

--- a/web-app/src/app/filter/filter.component.html
+++ b/web-app/src/app/filter/filter.component.html
@@ -1,69 +1,96 @@
 <div class="content">
   <div>
-    <h2 mat-dialog-title>Filter</h2>
-    <div mat-dialog-content>
-      <div>
-        <mat-form-field appearance="fill">
-          <mat-label>Event</mat-label>
-          <input type="text" matInput [formControl]="eventControl" [matAutocomplete]="autoEvent">
-          <mat-autocomplete #autoEvent="matAutocomplete" [displayWith]="onDisplayEvent" (optionSelected)="onSelectEvent()">
-            <mat-option *ngFor="let event of filteredEvents | async" [value]="event">
-              <div class="option-text">{{event.name}}</div>
-              <div class="option-description">{{event.description}}</div>
-            </mat-option>
-          </mat-autocomplete>
-        </mat-form-field>
-      </div>
-    
-      <div>
-        <mat-form-field appearance="fill">
-          <mat-label>Teams</mat-label>
-          <mat-chip-list #chipList>
-            <mat-chip *ngFor="let team of selectedTeams" [removable]="true" (removed)="onRemoveTeam(team)">
-              {{team.name}}
-              <mat-icon matChipRemove>cancel</mat-icon>
-            </mat-chip>
-            <input [formControl]="teamControl" [matAutocomplete]="autoTeam" [matChipInputFor]="chipList"
-              [matChipInputSeparatorKeyCodes]="separatorKeysCodes" (matChipInputTokenEnd)="onSelectTeam($event)">
-          </mat-chip-list>
-          <mat-autocomplete #autoTeam="matAutocomplete" [displayWith]="onDisplayTeam"
-            (optionSelected)="onSelectTeam($event)">
-            <mat-option *ngFor="let team of filteredTeams | async" [value]="team">
-              <span>{{team.name}}</span>
-            </mat-option>
-          </mat-autocomplete>
-        </mat-form-field>
-      </div>
-    
-      <div>
-        <mat-form-field appearance="fill">
-          <mat-label>Time</mat-label>
-          <mat-select [(value)]="intervalChoice" [compareWith]="compareIntervalChoices">
-            <mat-option *ngFor="let choice of intervalChoices" [value]="choice">
-              <span>{{choice.label}}</span>
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <div class="datetime" *ngIf="intervalChoice.filter === 'custom'">
+      <h2 mat-dialog-title>Filter</h2>
+      <div mat-dialog-content>
           <div>
-            <datetime-picker title="Start" [datetime]="defaultStartDate" [timezone]="timeZone" (dateTimeChange)="onStartDate($event)"></datetime-picker>
-            <datetime-picker title="Start" [datetime]="defaultStartDate" [timezone]="timeZone" (dateTimeChange)="onStartDate($event)"></datetime-picker>
+              <mat-form-field appearance="fill">
+                  <mat-label>Event</mat-label>
+                  <input type="text" matInput [formControl]="eventControl" [matAutocomplete]="autoEvent" />
+                  <mat-autocomplete #autoEvent="matAutocomplete" [displayWith]="onDisplayEvent" (optionSelected)="onSelectEvent($event)">
+                      <mat-option *ngFor="let event of filteredEvents | async" [value]="event">
+                          <div class="option-text">{{event.name}}</div>
+                          <div class="option-description">{{event.description}}</div>
+                      </mat-option>
+                  </mat-autocomplete>
+              </mat-form-field>
           </div>
-          <div class="timezone">
-            <button mat-stroked-button class="timezone__button" (click)="onTimezone()">
-              <span *ngIf="timeZone === 'local'">Local ({{localOffset}})</span>
-              <span *ngIf="timeZone === 'gmt'">GMT (+00:00)</span>
-            </button>
+          <div>
+              <mat-form-field appearance="fill">
+                  <mat-label>Teams</mat-label>
+                  <mat-chip-list #chipListTeam>
+                      <mat-chip *ngFor="let team of selectedTeams" [removable]="true" (removed)="onRemoveTeam(team)">
+                          {{team.name}}
+                          <mat-icon matChipRemove>cancel</mat-icon>
+                      </mat-chip>
+                      <input [formControl]="teamControl" [matAutocomplete]="autoTeam" [matChipInputFor]="chipListTeam" [matChipInputSeparatorKeyCodes]="separatorKeysCodes" (matChipInputTokenEnd)="onSelectTeam($event)" />
+                  </mat-chip-list>
+                  <mat-autocomplete #autoTeam="matAutocomplete" [displayWith]="onDisplayTeam" (optionSelected)="onSelectTeam($event)">
+                      <mat-option *ngFor="let team of filteredTeams | async" [value]="team">
+                          <span>{{team.name}}</span>
+                      </mat-option>
+                  </mat-autocomplete>
+              </mat-form-field>
           </div>
-        </div>
+          <div>
+              <mat-form-field appearance="fill">
+                  <mat-label>Users</mat-label>
+                  <mat-chip-list #chipListUser>
+                      <mat-chip *ngFor="let user of selectedUsers" [removable]="true" (removed)="onRemoveUser(user)">
+                          {{user.displayName || user.username}}
+                          <mat-icon matChipRemove>cancel</mat-icon>
+                      </mat-chip>
+                      <input [formControl]="userControl" [matAutocomplete]="autoUser" [matChipInputFor]="chipListUser" [matChipInputSeparatorKeyCodes]="separatorKeysCodes" (matChipInputTokenEnd)="onSelectUser($event)" />
+                  </mat-chip-list>
+                  <mat-autocomplete #autoUser="matAutocomplete" [displayWith]="onDisplayUser" (optionSelected)="onSelectUser($event)">
+                      <mat-option *ngFor="let user of filteredUsers | async" [value]="user">
+                          <span>{{user.displayName || user.username}}</span>
+                      </mat-option>
+                  </mat-autocomplete>
+              </mat-form-field>
+          </div>
+          <div>
+              <mat-form-field appearance="fill">
+                  <mat-label>Forms</mat-label>
+                  <mat-chip-list #chipListForm>
+                      <mat-chip *ngFor="let form of selectedForms" [removable]="true" (removed)="onRemoveForm(form)">
+                          {{form.name}}
+                          <mat-icon matChipRemove>cancel</mat-icon>
+                      </mat-chip>
+                      <input [formControl]="formControl" [matAutocomplete]="autoForm" [matChipInputFor]="chipListForm" [matChipInputSeparatorKeyCodes]="separatorKeysCodes" (matChipInputTokenEnd)="onSelectForm($event)" />
+                  </mat-chip-list>
+                  <mat-autocomplete #autoForm="matAutocomplete" [displayWith]="onDisplayForm" (optionSelected)="onSelectForm($event)">
+                      <mat-option *ngFor="let form of filteredForms | async" [value]="form">
+                          <span>{{form.name}}</span>
+                      </mat-option>
+                  </mat-autocomplete>
+              </mat-form-field>
+          </div>
+          <div>
+              <mat-form-field appearance="fill">
+                  <mat-label>Time</mat-label>
+                  <mat-select [(value)]="intervalChoice" [compareWith]="compareIntervalChoices">
+                      <mat-option *ngFor="let choice of intervalChoices" [value]="choice">
+                          <span>{{choice.label}}</span>
+                      </mat-option>
+                  </mat-select>
+              </mat-form-field>
+              <div class="datetime" *ngIf="intervalChoice?.filter === 'custom'">
+                  <div>
+                      <datetime-picker title="Start" [datetime]="defaultStartDate" [timezone]="timeZone" (dateTimeChange)="onStartDate($event)"></datetime-picker>
+                      <datetime-picker title="End" [datetime]="defaultEndDate" [timezone]="timeZone" (dateTimeChange)="onEndDate($event)"></datetime-picker>
+                  </div>
+                  <div class="timezone">
+                      <button mat-stroked-button class="timezone__button" (click)="onTimezone()">
+                          <span *ngIf="timeZone === 'local'">Local ({{localOffset}})</span>
+                          <span *ngIf="timeZone === 'gmt'">GMT (+00:00)</span>
+                      </button>
+                  </div>
+              </div>
+          </div>
       </div>
-    </div>
   </div>
-
   <div mat-dialog-actions align="end">
-    <button mat-button (click)="onCancel()">Cancel</button>
-    <button mat-button color="primary" cdkFocusInitial (click)="onFilter()">Filter</button>
+      <button mat-button (click)="onCancel()">Cancel</button>
+      <button mat-button color="primary" cdkFocusInitial (click)="onFilter()">Filter</button>
   </div>
-
 </div>

--- a/web-app/src/app/filter/filter.component.ts
+++ b/web-app/src/app/filter/filter.component.ts
@@ -104,12 +104,26 @@ export class FilterComponent implements OnInit {
     });
   }
 
+  /**
+   * Fetches Users for Given Event
+   * @param  {Event} event Event to Get Users From
+   * @return {Promise<User[]>} Returns List of Users as an Async Promise
+   */
+
   async getUsers(event: Event): Promise<User[]> {
     const users = await firstValueFrom(this.eventService.getMembers(event));
     return users;
   }
 
-  setFilteredValues(events: Event[], eUsers: User[], eForms: Form[]) {
+  /**
+   * Resets Filter When Event is Selected
+   * @param  {Event[]} events List of Events
+   * @param  {User[]} eUsers Users in the Event
+   * @param  {Form[]} eForms Forms in the Event
+   * @return {void} No Return
+   */
+
+  setFilteredValues(events: Event[], eUsers: User[], eForms: Form[]): void {
     this.events = events;
 
     this.filteredEvents = this.eventControl.valueChanges.pipe(
@@ -189,6 +203,12 @@ export class FilterComponent implements OnInit {
       })
     );
   }
+
+  /**
+   * Resets Filter When Event is Selected
+   * @param  {MatAutocompleteSelectedEvent} event The Event from the Autocomplete SelectBox
+   * @return {Promise<void>} No Return
+   */
 
   async onSelectEvent(event: MatAutocompleteSelectedEvent): Promise<void> {
     this.selectedTeams = [];
@@ -285,6 +305,11 @@ export class FilterComponent implements OnInit {
   public compareIntervalChoices = function (option, value): boolean {
     return option.label === value.label;
   };
+
+  /**
+   * Filters Observation List using the FilterService
+   * @return {void} No Return
+   */
 
   onFilter(): void {
     var options: IntervalOptions = {};

--- a/web-app/src/app/filter/filter.component.ts
+++ b/web-app/src/app/filter/filter.component.ts
@@ -1,150 +1,297 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
-import { FilterService } from './filter.service';
-import { EventService } from '../event/event.service';
-import { FormControl } from '@angular/forms';
-import { Observable, map, startWith } from 'rxjs';
-import { COMMA, ENTER } from '@angular/cdk/keycodes';
-import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
-import { LocalStorageService } from '../http/local-storage.service';
-import * as moment from 'moment'
+import { Component, OnInit, ViewEncapsulation } from "@angular/core";
+import { MatDialogRef } from "@angular/material/dialog";
+import { FilterService } from "./filter.service";
+import { EventService } from "../event/event.service";
+import { FormControl } from "@angular/forms";
+import { Observable, firstValueFrom, map, startWith, take } from "rxjs";
+import { COMMA, ENTER } from "@angular/cdk/keycodes";
+import { MatAutocompleteSelectedEvent } from "@angular/material/autocomplete";
+import { LocalStorageService } from "../http/local-storage.service";
+import * as moment from "moment";
+import { User } from "@ngageoint/mage.web-core-lib/user";
+import {
+  Form,
+  Team,
+  Event,
+  FilterChoice,
+  Interval,
+  IntervalOptions,
+} from "./filter.types";
 
 @Component({
-  selector: 'filter',
-  templateUrl: './filter.component.html',
-  styleUrls: ['./filter.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  selector: "filter",
+  templateUrl: "./filter.component.html",
+  styleUrls: ["./filter.component.scss"],
+  encapsulation: ViewEncapsulation.None,
 })
 export class FilterComponent implements OnInit {
-  readonly separatorKeysCodes: number[] = [ENTER, COMMA]
+  readonly separatorKeysCodes: number[] = [ENTER, COMMA];
 
-  events: any[]
-  selectedTeams: any[] = []
+  events: Event[];
+  selectedTeams: Team[] = [];
 
-  eventControl = new FormControl()
-  teamControl = new FormControl()
+  eventUsers: User[] = [];
+  selectedUsers: User[] = [];
 
-  filteredEvents: Observable<any[]>
-  filteredTeams: Observable<any[]>
+  eventForms: Form[] = [];
+  selectedForms: Form[] = [];
 
-  timeZone: any
-  localOffset: string
-  interval: any
-  defaultStartDate: Date
-  startDate: Date
-  defaultEndDate: Date
-  endDate: Date
-  intervalChoice: any
-  intervalChoices: any
+  eventControl = new FormControl();
+  teamControl = new FormControl();
+  userControl = new FormControl();
+  formControl = new FormControl();
+
+  filteredEvents: Observable<Event[]>;
+  filteredTeams: Observable<Team[]>;
+  filteredUsers: Observable<User[]>;
+  filteredForms: Observable<Form[]>;
+
+  timeZone: string;
+  localOffset: string;
+  interval: Interval;
+  defaultStartDate: Date;
+  startDate: Date;
+  defaultEndDate: Date;
+  endDate: Date;
+  intervalChoice: FilterChoice;
+  intervalChoices: FilterChoice[];
 
   constructor(
     public dialogRef: MatDialogRef<FilterComponent>,
     private eventService: EventService,
     private filterService: FilterService,
     private localStorageService: LocalStorageService
-  ) { }
+  ) {}
 
-  ngOnInit() {
-    const event = this.filterService.getEvent()
-    this.eventControl.setValue(event)
+  async ngOnInit() {
+    const event: Event = this.filterService.getEvent();
+    this.eventControl.setValue(event);
     const teamIds = this.localStorageService.getTeams() || [];
-    this.selectedTeams = teamIds.map((teamId: string) => {
-      return event.teams.find((team: any) => team.id === teamId)
-    })
+    this.selectedTeams = teamIds.map((teamId: number) => {
+      return event.teams.find((team: Team) => team.id === teamId);
+    });
+    const users: User[] = this.localStorageService.getUsers() || [];
+    const forms: Form[] = this.localStorageService.getForms() || [];
+    this.selectedUsers = users;
+    this.selectedForms = forms;
+    if (!this.eventUsers.length) {
+      var eUsers = await this.getUsers(event);
+      this.eventUsers.push(...eUsers);
+    }
+    if (!this.eventForms.length && event.forms) this.eventForms = event.forms;
 
-    this.interval = this.filterService.getInterval()
-    this.timeZone = this.interval.options?.localTime === false ? 'gmt' : 'local'
-    this.intervalChoice = this.interval.choice
-    this.intervalChoices = this.filterService.intervalChoices
+    this.interval = this.filterService.getInterval();
+    this.timeZone =
+      this.interval.options?.localTime === false ? "gmt" : "local";
+    this.intervalChoice = this.interval.choice;
+    this.intervalChoices = this.filterService.intervalChoices;
     if (this.interval?.options && this.interval?.options?.startDate) {
       this.defaultStartDate = this.interval?.options?.startDate;
     } else {
-      this.defaultStartDate = moment().startOf('day').toDate();
+      this.defaultStartDate = moment().startOf("day").toDate();
     }
 
     if (this.interval?.options && this.interval?.options?.endDate) {
       this.defaultEndDate = this.interval.options.endDate;
     } else {
-      this.defaultEndDate = moment().endOf('day').toDate()
+      this.defaultEndDate = moment().endOf("day").toDate();
     }
 
-    this.localOffset = moment().format('Z')
+    this.localOffset = moment().format("Z");
 
-    this.eventService.query().subscribe((events: any) => {
-      this.events = events
+    this.eventService.query().subscribe((events: Event[]) => {
+      this.setFilteredValues(events, this.eventUsers, this.eventForms);
+    });
+  }
 
-      this.filteredEvents = this.eventControl.valueChanges.pipe(
-        startWith(''),
-        map(value => typeof value === 'string' ? value : value.name),
-        map(name => name ? this.filterEvent(name) : this.events.slice())
-      )
+  async getUsers(event: Event): Promise<User[]> {
+    const users = await firstValueFrom(this.eventService.getMembers(event));
+    return users;
+  }
 
-      this.filteredTeams = this.teamControl.valueChanges.pipe(
-        startWith(''),
-        map(value => typeof value === 'string' ? value : value.name),
-        map(name => {
-          if (this.eventControl.value) {
-            let teams = this.eventControl.value.teams.filter(team => this.selectedTeams.indexOf(team) < 0)
-            if (name) {
-              const filterValue = name.toLowerCase()
-              return teams.filter((team: any) => team.name.toLowerCase().indexOf(filterValue) === 0)
-            } else {
-              return teams.slice()
-            }
+  setFilteredValues(events: Event[], eUsers: User[], eForms: Form[]) {
+    this.events = events;
+
+    this.filteredEvents = this.eventControl.valueChanges.pipe(
+      startWith(""),
+      map((value) => (typeof value === "string" ? value : value.name)),
+      map((name) => (name ? this.filterEvent(name) : this.events.slice()))
+    );
+
+    this.filteredTeams = this.teamControl.valueChanges.pipe(
+      startWith(""),
+      map((value) => (typeof value === "string" ? value : value.name)),
+      map((name) => {
+        if (this.eventControl.value) {
+          let teams = this.eventControl.value.teams.filter(
+            (team) => this.selectedTeams.indexOf(team) < 0
+          );
+          if (name) {
+            const filterValue = name.toLowerCase();
+            return teams.filter(
+              (team: Team) => team.name.toLowerCase().indexOf(filterValue) === 0
+            );
           } else {
-            return []
+            return teams.slice();
           }
-        })
-      )
-    })
+        } else {
+          return [];
+        }
+      })
+    );
+
+    this.filteredUsers = this.userControl.valueChanges.pipe(
+      startWith(""),
+      map((value) =>
+        typeof value === "string" ? value : value.displayName || value.username
+      ),
+      map((name) => {
+        if (eUsers.length) {
+          let usersList = eUsers.filter(
+            (user) => this.selectedUsers.map((x) => x.id).indexOf(user.id) < 0
+          );
+          if (name) {
+            const filterValue = name.toLowerCase();
+            return usersList.filter(
+              (user: User) =>
+                (user.displayName || user.username)
+                  .toLowerCase()
+                  .indexOf(filterValue) === 0
+            );
+          } else {
+            return usersList.slice();
+          }
+        } else {
+          return [];
+        }
+      })
+    );
+
+    this.filteredForms = this.formControl.valueChanges.pipe(
+      startWith(""),
+      map((value) => (typeof value === "string" ? value : value.name)),
+      map((name) => {
+        let formsList = this.eventForms.filter(
+          (form) => this.selectedForms.map((x) => x.id).indexOf(form.id) < 0
+        );
+        if (eForms.length) {
+          if (name) {
+            const filterValue = name.toLowerCase();
+            return formsList.filter(
+              (form: Form) => form.name.toLowerCase().indexOf(filterValue) === 0
+            );
+          } else {
+            return formsList.slice();
+          }
+        } else {
+          return [];
+        }
+      })
+    );
   }
 
-  onSelectEvent(): void {
-    this.selectedTeams = []
-    this.teamControl.setValue('')
+  async onSelectEvent(event: MatAutocompleteSelectedEvent): Promise<void> {
+    this.selectedTeams = [];
+    this.selectedUsers = [];
+    this.selectedForms = [];
+    this.teamControl.setValue("");
+    this.userControl.setValue("");
+    this.formControl.setValue("");
+
+    var newEvent: Event = event.option.value;
+    var eUsers = await this.getUsers(newEvent);
+
+    this.eventUsers = eUsers;
+    this.eventForms = newEvent.forms;
+
+    this.eventService.query().subscribe(async (events: Event[]) => {
+      this.setFilteredValues(events, eUsers, newEvent.forms);
+    });
   }
 
-  onDisplayEvent(event: any): string {
-    return event && event.name ? event.name : '';
+  onDisplayEvent(event: Event): string {
+    return event && event.name ? event.name : "";
   }
 
-  private filterEvent(name: string): any[] {
+  private filterEvent(name: string): Event[] {
     const filterValue = name.toLowerCase();
-    return this.events.filter(option => option.name.toLowerCase().indexOf(filterValue) === 0);
+    return this.events.filter(
+      (option) => option.name.toLowerCase().indexOf(filterValue) === 0
+    );
   }
 
   onSelectTeam(event: MatAutocompleteSelectedEvent): void {
-    this.selectedTeams.push(event.option.value)
-    this.teamControl.setValue('')
+    this.selectedTeams.push(event.option.value);
+    this.teamControl.setValue("");
   }
 
-  onRemoveTeam(team: any): void {
-    this.selectedTeams = this.selectedTeams.filter((selectedTeam: any) => team.name !== selectedTeam.name)
-    this.teamControl.setValue('')
+  onSelectUser(event: MatAutocompleteSelectedEvent): void {
+    this.selectedUsers.push(event.option.value);
+    this.userControl.setValue("");
   }
 
-  onDisplayTeam(team: any): string {
-    return team && team.name ? team.name : '';
+  onSelectForm(event: MatAutocompleteSelectedEvent): void {
+    this.selectedForms.push(event.option.value);
+    this.formControl.setValue("");
+  }
+
+  onRemoveTeam(team: Team): void {
+    this.selectedTeams = this.selectedTeams.filter(
+      (selectedTeam: Team) => team.name !== selectedTeam.name
+    );
+    this.teamControl.setValue("");
+  }
+
+  onRemoveUser(user: User): void {
+    this.selectedUsers = this.selectedUsers.filter(
+      (selectedUser: User) =>
+        (user.displayName || user.username) !==
+        (selectedUser.displayName || selectedUser.username)
+    );
+    this.userControl.setValue("");
+  }
+
+  onRemoveForm(form: Form): void {
+    this.selectedForms = this.selectedForms.filter(
+      (selectedForm: Form) => form.name !== selectedForm.name
+    );
+    this.formControl.setValue("");
+  }
+
+  onDisplayTeam(team: Team): string {
+    return team && team.name ? team.name : "";
+  }
+
+  onDisplayUser(user: User): string {
+    return user && user.displayName ? user.displayName || user.username : "";
+  }
+
+  onDisplayForm(form: Form): string {
+    return form && form.name ? form.name : "";
   }
 
   onStartDate(date: Date): void {
     this.startDate = date;
   }
 
+  onEndDate(date: Date): void {
+    this.endDate = date;
+  }
+
   onTimezone(): void {
-    this.timeZone = this.timeZone === 'gmt' ? 'local' : 'gmt';
+    this.timeZone = this.timeZone === "gmt" ? "local" : "gmt";
   }
 
   public compareIntervalChoices = function (option, value): boolean {
     return option.label === value.label;
-  }
+  };
 
   onFilter(): void {
-    var options: any = {};
-    if (this.intervalChoice.filter === 'custom') {
-      options.startDate = this.startDate
-      options.endDate = this.endDate
-      options.localTime = this.timeZone === 'local'
+    var options: IntervalOptions = {};
+    if (this.intervalChoice.filter === "custom") {
+      options.startDate = this.startDate;
+      options.endDate = this.endDate;
+      options.localTime = this.timeZone === "local";
     }
 
     this.filterService.setFilter({
@@ -152,15 +299,16 @@ export class FilterComponent implements OnInit {
       teams: this.selectedTeams,
       timeInterval: {
         choice: this.intervalChoice,
-        options: options
-      }
+        options: options,
+      },
+      users: this.selectedUsers,
+      forms: this.selectedForms,
     });
 
-    this.dialogRef.close()
+    this.dialogRef.close();
   }
 
   onCancel(): void {
     this.dialogRef.close();
   }
-
 }

--- a/web-app/src/app/filter/filter.service.ts
+++ b/web-app/src/app/filter/filter.service.ts
@@ -15,11 +15,14 @@ import {
   Changes,
   Form,
   FormProperties,
+  SearchInterval,
 } from "./filter.types";
+import { filterChanges } from "../event/event.types";
 
 @Injectable({
   providedIn: "root",
 })
+
 export class FilterService {
   event: Event = null;
   teamsById: TeamById = {};
@@ -93,7 +96,13 @@ export class FilterService {
     this.listeners = this.listeners.filter((l: any) => l !== listener);
   }
 
-  setFilter(filter: Filter) {
+  /**
+   * Updates the Observation Filter With the Selected Items
+   * @param  {Filter} filter Contains the Selected Filter Values
+   * @return {void} No Return
+   */
+
+  setFilter(filter: Filter): void {
     var eventChanged = null;
     var teamsChanged = null;
     var usersChanged = null;
@@ -156,7 +165,13 @@ export class FilterService {
     this.filterChanged(changed);
   }
 
-  setEvent(newEvent: Event) {
+  /**
+   * Updates the Event Selected
+   * @param  {Event} newEvent the new Event Selection
+   * @return {filterChanges} a List of events added/removed from the list
+   */
+
+  setEvent(newEvent: Event): filterChanges {
     if (!newEvent && this.event) {
       this.event = null;
 
@@ -187,7 +202,13 @@ export class FilterService {
     return this.event;
   }
 
-  setUsers(newUsers: User[]) {
+  /**
+   * Updates the List of Users in the Selected Event
+   * @param  {User[]} newUser the new List of Users that are in the events
+   * @return {filterChanges} a List of users added and removed from the list
+   */
+
+  setUsers(newUsers: User[]): filterChanges {
     var added = [];
     var removed = [];
 
@@ -208,7 +229,13 @@ export class FilterService {
     };
   }
 
-  setForms(newForms: Form[]) {
+  /**
+   * Updates the List of Forms in the Selected Event
+   * @param  {Form[]} newForms the new List of Forms that are in the events
+   * @return {filterChanges} a List of forms added and removed from the list
+   */
+
+  setForms(newForms: Form[]): filterChanges {
     var added = [];
     var removed = [];
 
@@ -229,7 +256,13 @@ export class FilterService {
     };
   }
 
-  setTeams(newTeams: Team[]) {
+  /**
+   * Updates the List of Teams in the Selected Event
+   * @param  {Team[]} newTeams the new List of Teams that are in the events
+   * @return {filterChanges} a List of teams added and removed from the list
+   */
+
+  setTeams(newTeams: Team[]): filterChanges {
     var added = [];
     var removed = [];
 
@@ -279,7 +312,13 @@ export class FilterService {
     return this.interval;
   }
 
-  setTimeInterval(newInterval: Interval) {
+  /**
+   * Sets the Time Interval if a change was made
+   * @param  {Interval} newInterval Contains the Selected Interval Type and Custom Information
+   * @return {boolean} If a change was made, returns True, else False
+   */
+
+  setTimeInterval(newInterval: Interval): boolean {
     if (newInterval.choice.filter === "custom") {
       if (
         this.interval.options?.startDate &&
@@ -297,7 +336,13 @@ export class FilterService {
     return true;
   }
 
-  observationInFilter(o: Observation) {
+  /**
+   * Checks to see if the ID is within the list of filters Users
+   * @param  {Observation} o The Current Observation
+   * @return {boolean} Returns True if Observation is Allowed, or False if Not
+   */
+
+  observationInFilter(o: Observation): boolean {
     if (!this.isObservationInTimeFilter(o)) return false;
 
     if (!this.isUserInTeamFilter(o.userId)) return false;
@@ -322,12 +367,24 @@ export class FilterService {
     return true;
   }
 
-  isUserInList(observationUserId: string) {
+  /**
+   * Checks to see if the ID is within the list of filters Users
+   * @param  {string} observationUserId Observations User ID
+   * @return {boolean} Returns True if Observation is Allowed, or False if Not
+   */
+
+  isUserInList(observationUserId: string): boolean {
     if (this.users.length <= 0) return true;
     return this.users.findIndex((u) => u.id === observationUserId) >= 0;
   }
 
-  hasFormInList(observationForms: FormProperties[]) {
+  /**
+   * Checks Incoming Observation to see if it has Forms within the Filter List
+   * @param  {FormProperties[]} observationForms The Current Observations Forms
+   * @return {boolean} Returns True if Observation is Allowed, or False if Not
+   */
+
+  hasFormInList(observationForms: FormProperties[]): boolean {
     if (this.forms.length <= 0) return true;
     var intersection = this.forms
       .map((x) => x.id)
@@ -335,8 +392,14 @@ export class FilterService {
     return intersection.length > 0;
   }
 
-  isObservationInTimeFilter(o: Observation) {
-    var time = this.formatInterval(this.interval);
+  /**
+   * Checks Incoming Observation to Make Sure it is Within the Time Constraints
+   * @param  {Observation} o The Current Observation
+   * @return {boolean} Returns True if Observation is Allowed, or False if Not
+   */
+
+  isObservationInTimeFilter(o: Observation): boolean {
+    var time: SearchInterval = this.formatInterval(this.interval);
     if (time) {
       var properties = o.properties;
       if (time?.start && time?.end) {
@@ -350,14 +413,26 @@ export class FilterService {
     return true;
   }
 
-  isUserInTeamFilter(userId: string) {
+  /**
+   * Checks to see if the declared username is filtered Team selections
+   * @param  {string} userId the unique ID of the User who Created the Observation
+   * @return {boolean} Returns True if Observation is Allowed, or False if Not
+   */
+
+  isUserInTeamFilter(userId: string): boolean {
     if (Object.keys(this.teamsById).length === 0) return true;
     return Object.values(this.teamsById).some((team: Team) =>
       team.userIds.includes(userId)
     );
   }
 
-  formatInterval(interval: Interval) {
+  /**
+   * Calculates and Returns the Start and End Time for Selected Interval
+   * @param  {Interval} interval Contains the Selected Interval Type and Custom Information
+   * @return {SearchInterval} A Start and End Value to Compare DateTimes to
+   */
+
+  formatInterval(interval: Interval): SearchInterval  {
     if (!interval) return null;
     var choice = interval.choice;
     var options = interval.options;

--- a/web-app/src/app/filter/filter.service.ts
+++ b/web-app/src/app/filter/filter.service.ts
@@ -1,81 +1,114 @@
 import { Injectable } from "@angular/core";
 import { UserService } from "../user/user.service";
 import { LocalStorageService } from "../http/local-storage.service";
-import * as moment from 'moment';
-import * as _ from 'lodash'
+import * as moment from "moment";
+import * as _ from "lodash";
+import { User } from "@ngageoint/mage.web-core-lib/user";
+import {
+  Event,
+  Interval,
+  FilterChoice,
+  Team,
+  TeamById,
+  Observation,
+  Filter,
+  Changes,
+  Form,
+  FormProperties,
+} from "./filter.types";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root",
 })
 export class FilterService {
-
-  event: any = null;
-  teamsById: any = {};
+  event: Event = null;
+  teamsById: TeamById = {};
   listeners: any = [];
+  users: User[] = [];
+  forms: Form[] = [];
 
-  interval: any = {};
-  filterLocalOffset = moment().format('Z');
-  actionFilter: any = {};
+  interval: Interval = {};
+  filterLocalOffset = moment().format("Z");
+  actionFilter: string = "";
 
-  intervalChoices: any = [{
-    filter: 'all',
-    label: 'All'
-  }, {
-    filter: 'today',
-    label: 'Today (Local GMT ' + this.filterLocalOffset + ')'
-  }, {
-    filter: 86400,
-    label: 'Last 24 Hours'
-  }, {
-    filter: 43200,
-    label: 'Last 12 Hours'
-  }, {
-    filter: 21600,
-    label: 'Last 6 Hours'
-  }, {
-    filter: 3600,
-    label: 'Last Hour'
-  }, {
-    filter: 'custom',
-    label: 'Custom'
-  }];
+  intervalChoices: FilterChoice[] = [
+    {
+      filter: "all",
+      label: "All",
+    },
+    {
+      filter: "today",
+      label: "Today (Local GMT " + this.filterLocalOffset + ")",
+    },
+    {
+      filter: 86400,
+      label: "Last 24 Hours",
+    },
+    {
+      filter: 43200,
+      label: "Last 12 Hours",
+    },
+    {
+      filter: 21600,
+      label: "Last 6 Hours",
+    },
+    {
+      filter: 3600,
+      label: "Last Hour",
+    },
+    {
+      filter: "custom",
+      label: "Custom",
+    },
+  ];
 
   constructor(
     private userService: UserService,
     private localStorageService: LocalStorageService
   ) {
-    this.setTimeInterval(localStorageService.getTimeInterval() || { choice: this.intervalChoices[1] });
+    this.setTimeInterval(
+      localStorageService.getTimeInterval() || {
+        choice: this.intervalChoices[1],
+      }
+    );
     this.filterChanged({ intervalChoice: this.interval.choice });
   }
 
   addListener(listener: any) {
     this.listeners.push(listener);
 
-    if (typeof listener.onFilterChanged === 'function') {
+    if (typeof listener.onFilterChanged === "function") {
       listener.onFilterChanged({
         event: this.event,
         teams: Object.values(this.teamsById),
+        user: this.users,
         timeInterval: {
-          choice: this.interval.choice
-        }
+          choice: this.interval.choice,
+        },
       });
     }
   }
 
   removeListener(listener: any) {
-    this.listeners = this.listeners.filter((l: any) => l !== listener );
+    this.listeners = this.listeners.filter((l: any) => l !== listener);
   }
 
-  setFilter(filter: any) {
+  setFilter(filter: Filter) {
     var eventChanged = null;
     var teamsChanged = null;
+    var usersChanged = null;
+    var formsChanged = null;
     var timeIntervalChanged = null;
     var actionFilterChanged = null;
+
+    if (filter.users) usersChanged = this.setUsers(filter.users);
+
+    if (filter.forms) formsChanged = this.setForms(filter.forms);
 
     if (filter.teams) {
       teamsChanged = this.setTeams(filter.teams);
     }
-  
+
     if (filter.event) {
       eventChanged = this.setEvent(filter.event);
 
@@ -102,9 +135,11 @@ export class FilterService {
       timeIntervalChanged = filter.timeInterval;
     }
 
-    var changed: any = {};
+    var changed: Changes = {};
     if (eventChanged) changed.event = eventChanged;
     if (teamsChanged) changed.teams = teamsChanged;
+    if (usersChanged) changed.users = usersChanged;
+    if (formsChanged) changed.forms = formsChanged;
     if (actionFilterChanged) changed.actionFilter = actionFilterChanged;
     if (timeIntervalChanged) changed.timeInterval = timeIntervalChanged;
 
@@ -112,7 +147,7 @@ export class FilterService {
   }
 
   removeFilters() {
-    var changed: any = {};
+    var changed: Changes = {};
     if (this.event) {
       changed.event = { removed: [this.event] };
       this.event = null;
@@ -121,49 +156,91 @@ export class FilterService {
     this.filterChanged(changed);
   }
 
-  setEvent(newEvent: any) {
+  setEvent(newEvent: Event) {
     if (!newEvent && this.event) {
       this.event = null;
 
       return {
         added: [],
-        removed: [this.event]
+        removed: [this.event],
       };
-    } else if (newEvent && !this.event || this.event.id !== newEvent.id) {
+    } else if ((newEvent && !this.event) || this.event.id !== newEvent.id) {
       var added = [newEvent];
       var removed = this.event ? [this.event] : [];
 
       this.userService.addRecentEvent(newEvent).subscribe({
-        error: e => console.error('Error adding recent event', e)
+        error: (e) => console.error("Error adding recent event", e),
       });
 
       this.event = newEvent;
 
       return {
         added: added,
-        removed: removed
+        removed: removed,
       };
     } else {
       return null;
     }
   }
 
-  getEvent() {
+  getEvent(): Event {
     return this.event;
   }
 
-  setTeams(newTeams: any) {
+  setUsers(newUsers: User[]) {
     var added = [];
     var removed = [];
 
-    newTeams.forEach((team: any) => {
+    newUsers.forEach((user: User) => {
+      if (this.users.findIndex((u) => u.id === user.id) < 0) added.push(user);
+    });
+
+    this.users.forEach((user: User) => {
+      if (newUsers.findIndex((u) => u.id === user.id) < 0) removed.push(user);
+    });
+
+    this.users = newUsers;
+    this.localStorageService.setUsers(this.users);
+
+    return {
+      added: added,
+      removed: removed,
+    };
+  }
+
+  setForms(newForms: Form[]) {
+    var added = [];
+    var removed = [];
+
+    newForms.forEach((form: Form) => {
+      if (this.forms.findIndex((f) => f.id === form.id) < 0) added.push(form);
+    });
+
+    this.forms.forEach((form: Form) => {
+      if (newForms.findIndex((f) => f.id === form.id) < 0) removed.push(form);
+    });
+
+    this.forms = newForms;
+    this.localStorageService.setForms(this.forms);
+
+    return {
+      added: added,
+      removed: removed,
+    };
+  }
+
+  setTeams(newTeams: Team[]) {
+    var added = [];
+    var removed = [];
+
+    newTeams.forEach((team: Team) => {
       if (!this.teamsById[team.id]) {
         added.push(team);
       }
-    })
+    });
 
-    var newTeamsById = _.keyBy(newTeams, 'id');
-    Object.values(this.teamsById).forEach((team: any) => {
+    var newTeamsById = _.keyBy(newTeams, "id");
+    Object.values(this.teamsById).forEach((team: Team) => {
       if (!newTeamsById[team.id]) {
         removed.push(team);
       }
@@ -174,12 +251,20 @@ export class FilterService {
 
     return {
       added: added,
-      removed: removed
+      removed: removed,
     };
   }
 
   getTeams() {
     return Object.values(this.teamsById);
+  }
+
+  getUsers() {
+    return this.users;
+  }
+
+  getForms() {
+    return this.forms;
   }
 
   getTeamsById() {
@@ -194,10 +279,14 @@ export class FilterService {
     return this.interval;
   }
 
-  setTimeInterval(newInterval: any) {
-    if (newInterval.choice.filter === 'custom') {
-      if (this.interval.startDate && newInterval.options.startDate === this.interval.options.startDate &&
-        this.interval.endDate && newInterval.options.endDate === this.interval.options.endDate) {
+  setTimeInterval(newInterval: Interval) {
+    if (newInterval.choice.filter === "custom") {
+      if (
+        this.interval.options?.startDate &&
+        newInterval.options.startDate === this.interval.options?.startDate &&
+        this.interval.options?.endDate &&
+        newInterval.options.endDate === this.interval.options?.endDate
+      ) {
         return false;
       }
     } else if (this.interval.choice === newInterval.choice) {
@@ -208,87 +297,110 @@ export class FilterService {
     return true;
   }
 
-  observationInFilter(o) {
-    if (!this.isUserInTeamFilter(o.userId)) {
-      return false;
-    }
+  observationInFilter(o: Observation) {
+    if (!this.isObservationInTimeFilter(o)) return false;
 
-    if (!this.isObservationInTimeFilter(o)) {
+    if (!this.isUserInTeamFilter(o.userId)) return false;
+
+    if (this.forms.length > 0 && !this.hasFormInList(o.properties.forms))
       return false;
-    }
+
+    if (this.users.length > 0 && !this.isUserInList(o.userId)) return false;
 
     // remove observations that are not part of action filter
-    if (this.actionFilter === 'important' && !o.important) {
-      return false;
-    }
+    if (this.actionFilter === "important" && !o.important) return false;
 
-    if (this.actionFilter === 'favorite' && !o.favoriteUserIds.includes(this.userService.myself.id)) {
+    if (
+      this.actionFilter === "favorite" &&
+      !o.favoriteUserIds.includes(this.userService.myself.id)
+    )
       return false;
-    }
 
-    if (this.actionFilter === 'attachments' && !o.attachments.length) {
+    if (this.actionFilter === "attachments" && !o.attachments.length)
       return false;
-    }
 
     return true;
   }
 
-  isObservationInTimeFilter(o: any) {
+  isUserInList(observationUserId: string) {
+    if (this.users.length <= 0) return true;
+    return this.users.findIndex((u) => u.id === observationUserId) >= 0;
+  }
+
+  hasFormInList(observationForms: FormProperties[]) {
+    if (this.forms.length <= 0) return true;
+    var intersection = this.forms
+      .map((x) => x.id)
+      .filter((fID) => observationForms.map((y) => y.formId).includes(fID));
+    return intersection.length > 0;
+  }
+
+  isObservationInTimeFilter(o: Observation) {
     var time = this.formatInterval(this.interval);
     if (time) {
       var properties = o.properties;
-      if (time.start && time.end) {
-        if (!moment(properties.timestamp).isBetween(time.start, time.end)) return false;
-      } else if (time.start) {
-        if (!moment(properties.timestamp).isAfter(time.start)) return false;
-      } else if (time.end) {
-        if (!moment(properties.timestamp).isBefore(time.start)) return false;
+      if (time?.start && time?.end) {
+        return moment(properties.timestamp).isBetween(time.start, time.end);
+      } else if (time?.start) {
+        return moment(properties.timestamp).isAfter(time.start);
+      } else if (time?.end) {
+        return moment(properties.timestamp).isBefore(time.start);
       }
     }
-
     return true;
   }
 
-  isUserInTeamFilter(userId: any) {
-    if (Object.keys(this.teamsById).length === 0) return true
-    return Object.values(this.teamsById).some((team: any) => team.userIds.includes(userId))
+  isUserInTeamFilter(userId: string) {
+    if (Object.keys(this.teamsById).length === 0) return true;
+    return Object.values(this.teamsById).some((team: Team) =>
+      team.userIds.includes(userId)
+    );
   }
 
-  formatInterval(interval: any) {
+  formatInterval(interval: Interval) {
     if (!interval) return null;
-
     var choice = interval.choice;
     var options = interval.options;
+    var start: string = null;
+    var end: string = null;
 
-    if (choice.filter === 'all') {
+    if (choice.filter === "all") {
       return null;
-    } else if (choice.filter === 'today') {
-      return { start: moment().startOf('day').toISOString() };
-    } else if (choice.filter === 'custom') {
+    } else if (choice.filter === "today") {
+      start = moment().startOf("day").toISOString();
+      end = moment().endOf("day").toISOString();
+    } else if (choice.filter === "custom") {
       var startDate = moment(options.startDate);
       if (startDate) {
         startDate = options.localTime ? startDate.utc() : startDate;
-        var start = startDate.utc().toISOString();
+        start = startDate.utc().toISOString();
       }
-
       var endDate = moment(options.endDate);
       if (endDate) {
         endDate = options.localTime ? endDate.utc() : endDate;
-        var end = endDate.utc().toISOString();
+        end = endDate.utc().toISOString();
       }
-
-      return { start: start, end: end };
     } else {
-      return { start: moment().utc().subtract('seconds', parseInt(choice.filter)).toISOString() };
+      start = moment()
+        .utc()
+        .subtract(
+          typeof choice.filter === "string"
+            ? parseInt(choice.filter)
+            : choice.filter,
+          "seconds"
+        )
+        .toISOString();
+      end = moment().toISOString();
     }
+
+    return { start: start, end: end };
   }
 
-  filterChanged(filter: any) {
+  filterChanged(filter: Changes) {
     this.listeners.forEach((listener: any) => {
-      if (typeof listener.onFilterChanged === 'function') {
+      if (typeof listener.onFilterChanged === "function") {
         listener.onFilterChanged(filter);
       }
     });
   }
-
 }

--- a/web-app/src/app/filter/filter.types.ts
+++ b/web-app/src/app/filter/filter.types.ts
@@ -1,0 +1,146 @@
+import { User } from "@ngageoint/mage.web-core-lib/user";
+import { filterChanges } from "../event/event.types";
+
+export type FormField = {
+  name: string;
+  id: number;
+  title: string;
+  type: string;
+  required: boolean;
+  allowedAttachmentTypes: string[];
+  choices: string[];
+  value: any;
+};
+export type Form = {
+  name: string;
+  primaryFeedField: string;
+  secondaryFeedField: string;
+  id: number;
+  color: string;
+  default: boolean;
+  fields: FormField[];
+  userFields: string[];
+  archived: boolean;
+  min: number;
+  max: number;
+};
+
+export type FormProperties = {
+  formId: number;
+  id: string;
+  [name: string]: any;
+};
+
+export type Team = {
+  name?: string;
+  id?: number;
+  acl?: Record<string, { role: string; permissions: string[] }>;
+  description?: string;
+  teamEventId?: number;
+  userIds?: string[];
+  __v?: number;
+};
+
+export type TeamById = Record<string, Team>;
+
+export type Style = {
+  fill: string;
+  fillOpacity: number;
+  stroke: string;
+  strokeOpacity: number;
+  strokeWidth: number;
+};
+
+export type Layer = {
+  name: string;
+  id: number;
+  state: string;
+  type: string;
+  url: string;
+  __v: number;
+};
+
+export type Event = {
+  name: string;
+  id: number;
+  acl?: Record<string, { role: string; permissions: string[] }>;
+  description: string;
+  feedIds: string[];
+  forms: Form[];
+  layers: Layer[];
+  style: Style;
+  teams: Team[];
+};
+
+export type FilterChoice = {
+  filter: string | number;
+  label: string;
+};
+
+export type IntervalOptions = {
+  endDate?: Date;
+  startDate?: Date;
+  localTime?: Boolean;
+};
+
+export type Interval = {
+  choice?: FilterChoice;
+  options?: IntervalOptions;
+};
+
+export type Attachment = {
+  contentType: string;
+  fieldName: string;
+  id: string;
+  lastModified: Date;
+  name: string;
+  observationFormId: string;
+  oriented: boolean;
+  relativePath: string;
+  size: number;
+  url: string;
+};
+
+export type Observation = {
+  id: string;
+  attachments: Attachment[];
+  createdAt: Date;
+  deviceId: string;
+  eventId: number;
+  favoriteUserIds: string[];
+  geometry: { type: string; coordinates: number[] };
+  lastModified: Date;
+  properties: { forms: FormProperties[]; timestamp: Date };
+  state: {
+    id: string;
+    name: string;
+    url: string;
+    userId: string;
+  };
+  style: Style;
+  type: string;
+  url: string;
+  user: User;
+  userId: string;
+  important: { desciption: string; timestamp: Date; user: User };
+};
+
+export type Filter = {
+  event?: Event;
+  teams?: Team[];
+  users?: User[];
+  forms?: Form[];
+  intervalChoice?: FilterChoice;
+  timeInterval?: Interval;
+  actionFilter?: string;
+};
+
+export type Changes = {
+  event?: filterChanges;
+  teams?: filterChanges;
+  users?: filterChanges;
+  forms?: filterChanges;
+  timeInterval?: Interval;
+  actionFilter?: string;
+  intervalChoice?: FilterChoice;
+};

--- a/web-app/src/app/filter/filter.types.ts
+++ b/web-app/src/app/filter/filter.types.ts
@@ -83,6 +83,11 @@ export type IntervalOptions = {
   localTime?: Boolean;
 };
 
+export type SearchInterval = {
+    start: string;
+    end: string;
+}
+
 export type Interval = {
   choice?: FilterChoice;
   options?: IntervalOptions;

--- a/web-app/src/app/http/local-storage.service.ts
+++ b/web-app/src/app/http/local-storage.service.ts
@@ -1,157 +1,187 @@
-import { Injectable } from "@angular/core"
+import { Injectable } from "@angular/core";
+import { User } from "@ngageoint/mage.web-core-lib/user";
+import { Form, Interval } from "../filter/filter.types";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root",
 })
 export class LocalStorageService {
-
-  tokenKey = 'token'
-  pollingIntervalKey = 'pollingInterval'
-  timeIntervalKey = 'timeInterval'
-  teamsKey = 'teams'
-  mapPositionKey = 'mapPosition'
-  coordinateSystemViewKey = 'coordinateSystemView'
-  coordinateSystemEditKey = 'coordinateSystemEdit'
-  timeZoneViewKey = 'timeZoneView'
-  timeZoneEditKey = 'timeZoneEdit'
-  timeFormatKey = 'timeFormat'
+  tokenKey = "token";
+  pollingIntervalKey = "pollingInterval";
+  timeIntervalKey = "timeInterval";
+  teamsKey = "teams";
+  usersKey = "users";
+  formsKey = "forms";
+  mapPositionKey = "mapPosition";
+  coordinateSystemViewKey = "coordinateSystemView";
+  coordinateSystemEditKey = "coordinateSystemEdit";
+  timeZoneViewKey = "timeZoneView";
+  timeZoneEditKey = "timeZoneEdit";
+  timeFormatKey = "timeFormat";
 
   getToken() {
-    return this.getLocalItem(this.tokenKey)
+    return this.getLocalItem(this.tokenKey);
   }
 
   setToken(token: any) {
-    return this.setLocalItem(this.tokenKey, token)
+    return this.setLocalItem(this.tokenKey, token);
   }
 
   removeToken() {
-    return this.removeLocalItem(this.tokenKey)
+    return this.removeLocalItem(this.tokenKey);
   }
 
   setPollingInterval(pollingInterval) {
-    return this.setLocalItem(this.pollingIntervalKey, pollingInterval)
+    return this.setLocalItem(this.pollingIntervalKey, pollingInterval);
   }
 
   getPollingInterval() {
-    return this.getLocalItem(this.pollingIntervalKey)
+    return this.getLocalItem(this.pollingIntervalKey);
   }
 
-  setTimeInterval(timeInterval: any) {
-    return this.setLocalItem(this.timeIntervalKey, JSON.stringify(timeInterval))
+  setTimeInterval(timeInterval: Interval) {
+    return this.setLocalItem(
+      this.timeIntervalKey,
+      JSON.stringify(timeInterval)
+    );
   }
 
   getTimeInterval() {
-    const item = this.getLocalItem(this.timeIntervalKey)
+    const item = this.getLocalItem(this.timeIntervalKey);
     if (item) {
-      const time = JSON.parse(item)
+      const time = JSON.parse(item);
 
       if (time && time.options) {
         if (time.options.startDate) {
-          time.options.startDate = new Date(time.options.startDate)
+          time.options.startDate = new Date(time.options.startDate);
         }
         if (time.options.endDate) {
-          time.options.endDate = new Date(time.options.endDate)
+          time.options.endDate = new Date(time.options.endDate);
         }
       }
-      
-      return time
-    } else return undefined
+
+      return time;
+    } else return undefined;
   }
 
   getTeams() {
-    const item = this.getLocalItem(this.teamsKey)
+    const item = this.getLocalItem(this.teamsKey);
     if (item) {
-      return JSON.parse(item)
-    } else return undefined
+      return JSON.parse(item);
+    } else return undefined;
   }
 
   setTeams(teams: any) {
-    return this.setLocalItem(this.teamsKey, JSON.stringify(teams))
+    return this.setLocalItem(this.teamsKey, JSON.stringify(teams));
+  }
+
+  getUsers(): User[] {
+    const item = this.getLocalItem(this.usersKey);
+    if (item) {
+      return JSON.parse(item) as User[];
+    } else return undefined;
+  }
+
+  setUsers(users: User[]) {
+    return this.setLocalItem(this.usersKey, JSON.stringify(users));
+  }
+
+  getForms(): Form[] {
+    const item = this.getLocalItem(this.formsKey);
+    if (item) {
+      return JSON.parse(item) as Form[];
+    } else return undefined;
+  }
+
+  setForms(forms: Form[]) {
+    return this.setLocalItem(this.formsKey, JSON.stringify(forms));
   }
 
   removeTeams() {
-    return this.removeLocalItem(this.teamsKey)
+    return this.removeLocalItem(this.teamsKey);
   }
 
   setMapPosition(mapPosition: any) {
-    return this.setLocalItem(this.mapPositionKey, JSON.stringify(mapPosition))
+    return this.setLocalItem(this.mapPositionKey, JSON.stringify(mapPosition));
   }
 
   getMapPosition() {
-    const item = this.getLocalItem(this.mapPositionKey)
+    const item = this.getLocalItem(this.mapPositionKey);
     if (item) {
-      return JSON.parse(item)
-    } else return undefined
+      return JSON.parse(item);
+    } else return undefined;
   }
 
   getCoordinateSystemView() {
-    return this.getLocalItem(this.coordinateSystemViewKey) || 'wgs84'
+    return this.getLocalItem(this.coordinateSystemViewKey) || "wgs84";
   }
 
   setCoordinateSystemView(coordinateSystem: any) {
-    return this.setLocalItem(this.coordinateSystemViewKey, coordinateSystem)
+    return this.setLocalItem(this.coordinateSystemViewKey, coordinateSystem);
   }
 
   getCoordinateSystemEdit() {
-    return this.getLocalItem(this.coordinateSystemEditKey) || this.getCoordinateSystemView()
+    return (
+      this.getLocalItem(this.coordinateSystemEditKey) ||
+      this.getCoordinateSystemView()
+    );
   }
 
   setCoordinateSystemEdit(coordinateSystem: any) {
-    return this.setLocalItem(this.coordinateSystemEditKey, coordinateSystem)
+    return this.setLocalItem(this.coordinateSystemEditKey, coordinateSystem);
   }
 
   getTimeZoneView() {
-    return this.getLocalItem(this.timeZoneViewKey) || 'local'
+    return this.getLocalItem(this.timeZoneViewKey) || "local";
   }
 
   setTimeZoneView(timeZone: any) {
-    return this.setLocalItem(this.timeZoneViewKey, timeZone)
+    return this.setLocalItem(this.timeZoneViewKey, timeZone);
   }
 
   getTimeZoneEdit() {
-    return this.getLocalItem(this.timeZoneEditKey) || this.getTimeZoneView()
+    return this.getLocalItem(this.timeZoneEditKey) || this.getTimeZoneView();
   }
 
   setTimeZoneEdit(timeZone: any) {
-    return this.setLocalItem(this.timeZoneEditKey, timeZone)
+    return this.setLocalItem(this.timeZoneEditKey, timeZone);
   }
 
   getTimeFormat() {
-    return this.getLocalItem(this.timeFormatKey) || 'absolute'
+    return this.getLocalItem(this.timeFormatKey) || "absolute";
   }
 
   setTimeFormat(timeFormat: any) {
-    return this.setLocalItem(this.timeFormatKey, timeFormat)
+    return this.setLocalItem(this.timeFormatKey, timeFormat);
   }
 
   getLocalItem(key: any) {
     try {
-      if ('localStorage' in window && window['localStorage'] !== null) {
-        return localStorage.getItem(key)
+      if ("localStorage" in window && window["localStorage"] !== null) {
+        return localStorage.getItem(key);
       }
     } catch (e) {
-      return undefined
+      return undefined;
     }
   }
 
   setLocalItem(key: any, value: any) {
     try {
-      if ('localStorage' in window && window.localStorage !== null) {
-        return localStorage.setItem(key, value)
+      if ("localStorage" in window && window.localStorage !== null) {
+        return localStorage.setItem(key, value);
       }
     } catch (e) {
-      return undefined
+      return undefined;
     }
   }
 
   removeLocalItem(key: any) {
     try {
-      if ('localStorage' in window && window.localStorage !== null) {
-        return localStorage.removeItem(key)
+      if ("localStorage" in window && window.localStorage !== null) {
+        return localStorage.removeItem(key);
       }
     } catch (e) {
-      return false
+      return false;
     }
   }
-
 }

--- a/web-app/src/app/observation/observation-edit/observation-edit.component.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit.component.ts
@@ -1,102 +1,127 @@
-import { animate, style, transition, trigger } from '@angular/animations'
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop'
-import { DOCUMENT } from '@angular/common'
-import { Component, ElementRef, EventEmitter, Inject, Input, OnChanges, OnInit, Output, QueryList, SimpleChanges, ViewChild, ViewChildren } from '@angular/core'
-import { UntypedFormArray, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms'
-import { DomSanitizer } from '@angular/platform-browser'
-import { first } from 'rxjs/operators'
-import { ObservationEditFormPickerComponent } from './observation-edit-form-picker.component'
-import * as moment from 'moment';
-import { ObservationEditDiscardComponent } from './observation-edit-discard/observation-edit-discard.component'
-import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar'
-import { MatIconRegistry } from '@angular/material/icon'
-import { MatDialog } from '@angular/material/dialog'
-import { MatBottomSheet } from '@angular/material/bottom-sheet'
-import { AttachmentService, AttachmentUploadEvent, AttachmentUploadStatus } from '../attachment/attachment.service'
-import { FileUpload } from '../attachment/attachment-upload/attachment-upload.component'
-import { AttachmentAction } from './observation-edit-attachment/observation-edit-attachment-action'
-import { LocalStorageService } from '../../http/local-storage.service'
-import { MapService } from 'src/app/map/map.service'
-import { UserService } from 'src/app/user/user.service'
-import { EventService } from 'src/app/event/event.service'
-import { FilterService } from 'src/app/filter/filter.service'
-import { ObservationService } from '../observation.service'
+import { animate, style, transition, trigger } from "@angular/animations";
+import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
+import { DOCUMENT } from "@angular/common";
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  QueryList,
+  SimpleChanges,
+  ViewChild,
+  ViewChildren,
+} from "@angular/core";
+import {
+  UntypedFormArray,
+  UntypedFormBuilder,
+  UntypedFormControl,
+  UntypedFormGroup,
+  Validators,
+} from "@angular/forms";
+import { DomSanitizer } from "@angular/platform-browser";
+import { first } from "rxjs/operators";
+import { ObservationEditFormPickerComponent } from "./observation-edit-form-picker.component";
+import * as moment from "moment";
+import { ObservationEditDiscardComponent } from "./observation-edit-discard/observation-edit-discard.component";
+import {
+  MatSnackBar,
+  MatSnackBarRef,
+  SimpleSnackBar,
+} from "@angular/material/snack-bar";
+import { MatIconRegistry } from "@angular/material/icon";
+import { MatDialog } from "@angular/material/dialog";
+import { MatBottomSheet } from "@angular/material/bottom-sheet";
+import {
+  AttachmentService,
+  AttachmentUploadEvent,
+  AttachmentUploadStatus,
+} from "../attachment/attachment.service";
+import { FileUpload } from "../attachment/attachment-upload/attachment-upload.component";
+import { AttachmentAction } from "./observation-edit-attachment/observation-edit-attachment-action";
+import { LocalStorageService } from "../../http/local-storage.service";
+import { MapService } from "src/app/map/map.service";
+import { UserService } from "src/app/user/user.service";
+import { EventService } from "src/app/event/event.service";
+import { FilterService } from "src/app/filter/filter.service";
+import { ObservationService } from "../observation.service";
 
-export type ObservationFormControl = UntypedFormControl & { definition: any }
+export type ObservationFormControl = UntypedFormControl & { definition: any };
 
 @Component({
-  selector: 'observation-edit',
-  templateUrl: './observation-edit.component.html',
-  styleUrls: ['./observation-edit.component.scss'],
+  selector: "observation-edit",
+  templateUrl: "./observation-edit.component.html",
+  styleUrls: ["./observation-edit.component.scss"],
   animations: [
-    trigger('error', [
-      transition(':enter', [
+    trigger("error", [
+      transition(":enter", [
         style({ height: 0, opacity: 0 }),
-        animate('250ms', style({ height: '*', opacity: 1 })),
+        animate("250ms", style({ height: "*", opacity: 1 })),
       ]),
-      transition(':leave', [
-        animate('250ms', style({ height: 0, opacity: 0 }))
-      ])
+      transition(":leave", [
+        animate("250ms", style({ height: 0, opacity: 0 })),
+      ]),
     ]),
-    trigger('mask', [
-      transition(':enter', [
+    trigger("mask", [
+      transition(":enter", [
         style({ opacity: 0 }),
-        animate('250ms', style({ opacity: .2 })),
+        animate("250ms", style({ opacity: 0.2 })),
       ]),
-      transition(':leave', [
-        animate('250ms', style({ opacity: 0 }))
-      ])
-    ])
-  ]
+      transition(":leave", [animate("250ms", style({ opacity: 0 }))]),
+    ]),
+  ],
 })
 export class ObservationEditComponent implements OnInit, OnChanges {
-  @Input() preview: boolean
-  @Input() observation: any
-  attachments =[]
+  @Input() preview: boolean;
+  @Input() observation: any;
+  attachments = [];
 
-  @Output() close = new EventEmitter<any>()
+  @Output() close = new EventEmitter<any>();
 
-  @ViewChild('editContent', { static: true }) editContent: ElementRef
-  @ViewChild('dragHandle', { static: true }) dragHandle: ElementRef
-  @ViewChildren('form') formElements: QueryList<ElementRef>
+  @ViewChild("editContent", { static: true }) editContent: ElementRef;
+  @ViewChild("dragHandle", { static: true }) dragHandle: ElementRef;
+  @ViewChildren("form") formElements: QueryList<ElementRef>;
 
-  event: any
-  formGroup: UntypedFormGroup
-  formDefinitions: any
+  event: any;
+  formGroup: UntypedFormGroup;
+  formDefinitions: any;
   timestampDefinition = {
-    title: '',
-    type: 'date',
-    name: 'timestamp',
-    required: true
-  }
+    title: "",
+    type: "date",
+    name: "timestamp",
+    required: true,
+  };
   geometryDefinition = {
-    title: 'Location',
-    type: 'geometry',
-    name: 'geometry',
-    required: true
-  }
+    title: "Location",
+    type: "geometry",
+    name: "geometry",
+    required: true,
+  };
 
-  mask = false
-  saving = false
-  error: any
+  mask = false;
+  saving = false;
+  error: any;
 
-  uploads: FileUpload[] = []
-  attachmentUrl: string
+  uploads: FileUpload[] = [];
+  attachmentUrl: string;
 
-  isNewObservation: boolean
-  canDeleteObservation: boolean
-  observationForm = {}
-  formOptions = { expand: false }
+  isNewObservation: boolean;
+  canDeleteObservation: boolean;
+  observationForm = {};
+  formOptions = { expand: false };
 
-  initialObservation: any
-  geometryStyle: any
+  initialObservation: any;
+  geometryStyle: any;
 
-  primaryField: any
-  primaryFieldValue: string
-  secondaryField: any
-  secondaryFieldValue: string
+  primaryField: any;
+  primaryFieldValue: string;
+  secondaryField: any;
+  secondaryFieldValue: string;
 
-  formRemoveSnackbar: MatSnackBarRef<SimpleSnackBar>
+  formRemoveSnackbar: MatSnackBarRef<SimpleSnackBar>;
 
   constructor(
     sanitizer: DomSanitizer,
@@ -112,89 +137,113 @@ export class ObservationEditComponent implements OnInit, OnChanges {
     private filterService: FilterService,
     private eventService: EventService,
     private observationService: ObservationService,
-    private localStorageService: LocalStorageService) {
-
-    matIconRegistry.addSvgIcon('handle', sanitizer.bypassSecurityTrustResourceUrl('assets/images/handle-24px.svg'));
+    private localStorageService: LocalStorageService
+  ) {
+    matIconRegistry.addSvgIcon(
+      "handle",
+      sanitizer.bypassSecurityTrustResourceUrl("assets/images/handle-24px.svg")
+    );
   }
 
   ngOnInit(): void {
-    if (this.observation.id === 'new') {
-      this.formOptions.expand = true
+    if (this.observation.id === "new") {
+      this.formOptions.expand = true;
     }
 
-    this.canDeleteObservation = this.observation.id !== 'new' &&
-      (this.hasEventUpdatePermission() || this.isCurrentUsersObservation() || this.hasUpdatePermissionsInEventAcl())
+    this.canDeleteObservation =
+      this.observation.id !== "new" &&
+      (this.hasEventUpdatePermission() ||
+        this.isCurrentUsersObservation() ||
+        this.hasUpdatePermissionsInEventAcl());
 
-    this.attachmentService.upload$.subscribe(event => this.onAttachmentUpload(event))
+    this.attachmentService.upload$.subscribe((event) =>
+      this.onAttachmentUpload(event)
+    );
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.observation  && changes.observation.currentValue) {
-      this.event = this.eventService.getEventById(this.observation.eventId)
-      this.formDefinitions = this.eventService.getFormsForEvent(this.event).reduce((map, form) => {
-        map[form.id] = form
-        return map
-      }, {})
+    if (changes.observation && changes.observation.currentValue) {
+      this.event = this.eventService.getEventById(this.observation.eventId);
+      this.formDefinitions = this.eventService
+        .getFormsForEvent(this.event)
+        .reduce((map, form) => {
+          map[form.id] = form;
+          return map;
+        }, {});
 
-      this.isNewObservation = this.observation.id === 'new'
-      this.initialObservation = JSON.parse(JSON.stringify(this.observation))
+      this.isNewObservation = this.observation.id === "new";
+      this.initialObservation = JSON.parse(JSON.stringify(this.observation));
 
       if (this.observation.style) {
-        this.geometryStyle = JSON.parse(JSON.stringify(this.observation.style))
+        this.geometryStyle = JSON.parse(JSON.stringify(this.observation.style));
       }
 
       if (this.isNewObservation) {
-        this.mapService.addFeaturesToLayer([this.observation], 'observations')
+        this.mapService.addFeaturesToLayer([this.observation], "observations");
       }
 
-      this.toFormGroup(this.observation)
-      this.updatePrimarySecondary()
+      this.toFormGroup(this.observation);
+      this.updatePrimarySecondary();
     }
   }
 
   hasEventUpdatePermission(): boolean {
-    return this.userService.myself.role.permissions.includes('DELETE_OBSERVATION')
+    return this.userService.myself.role.permissions.includes(
+      "DELETE_OBSERVATION"
+    );
   }
 
   isCurrentUsersObservation(): boolean {
-    return this.observation.userId === this.userService.myself.id
+    return this.observation.userId === this.userService.myself.id;
   }
 
   hasUpdatePermissionsInEventAcl(): boolean {
-    const myAccess = this.filterService.getEvent().acl[this.userService.myself.id] || {}
-    const aclPermissions = myAccess.permissions || []
-    return aclPermissions.includes('update')
+    const myAccess =
+      this.filterService.getEvent().acl[this.userService.myself.id] || {};
+    const aclPermissions = myAccess["permissions"] || [];
+    return aclPermissions.includes("update");
   }
 
   token(): string {
-    return this.localStorageService.getToken()
+    return this.localStorageService.getToken();
   }
 
   // TODO multi-form build out validators here as well for each form control
   toFormGroup(observation: any): void {
-    const timestampControl = new UntypedFormControl(moment(observation.properties.timestamp).toDate(), Validators.required);
-    const geometryControl = new UntypedFormControl(observation.geometry, Validators.required);
+    const timestampControl = new UntypedFormControl(
+      moment(observation.properties.timestamp).toDate(),
+      Validators.required
+    );
+    const geometryControl = new UntypedFormControl(
+      observation.geometry,
+      Validators.required
+    );
 
-    const formArray = new UntypedFormArray([])
-    const observationForms = observation.properties.forms || []
-    observationForms.forEach(observationForm => {
-      const formDefinition = this.formDefinitions[observationForm.formId]
+    const formArray = new UntypedFormArray([]);
+    const observationForms = observation.properties.forms || [];
+    observationForms.forEach((observationForm) => {
+      const formDefinition = this.formDefinitions[observationForm.formId];
       const fieldGroup = new UntypedFormGroup({
         id: new UntypedFormControl(observationForm.id),
-        formId: new UntypedFormControl(formDefinition.id)
-      })
+        formId: new UntypedFormControl(formDefinition.id),
+      });
 
       formDefinition.fields
-        .filter(field => !field.archived)
+        .filter((field) => !field.archived)
         .sort((a, b) => a.id - b.id)
-        .forEach(field => {
-          const value = this.isNewObservation ? field.value : observationForm[field.name]
-          const fieldControl = new UntypedFormControl(value, field.required ? Validators.required : null)
-          fieldGroup.addControl(field.name, fieldControl)
-        })
+        .forEach((field) => {
+          const value = this.isNewObservation
+            ? field.value
+            : observationForm[field.name];
+          const fieldControl = new UntypedFormControl(
+            value,
+            field.required ? Validators.required : null
+          );
+          fieldGroup.addControl(field.name, fieldControl);
+        });
 
-      formArray.push(fieldGroup)
-    })
+      formArray.push(fieldGroup);
+    });
 
     this.formGroup = this.formBuilder.group({
       id: observation.id,
@@ -203,62 +252,86 @@ export class ObservationEditComponent implements OnInit, OnChanges {
       geometry: geometryControl,
       properties: new UntypedFormGroup({
         timestamp: timestampControl,
-        forms: formArray
-      })
-    })
+        forms: formArray,
+      }),
+    });
 
-    if (observation.properties.forms.length === 0 && this.hasForms() && observation.id === 'new') {
-      this.pickForm()
+    if (
+      observation.properties.forms.length === 0 &&
+      this.hasForms() &&
+      observation.id === "new"
+    ) {
+      this.pickForm();
     }
   }
 
   updatePrimarySecondary(): void {
-    const forms = this.formGroup.get('properties').get('forms') as UntypedFormArray
+    const forms = this.formGroup
+      .get("properties")
+      .get("forms") as UntypedFormArray;
     if (forms.length) {
-      const primaryFormGroup = forms.at(0) as UntypedFormGroup
-      const definition = this.formDefinitions[primaryFormGroup.get('formId').value]
+      const primaryFormGroup = forms.at(0) as UntypedFormGroup;
+      const definition =
+        this.formDefinitions[primaryFormGroup.get("formId").value];
 
-      let primaryFieldValue
+      let primaryFieldValue;
       if (primaryFormGroup.contains(definition.primaryFeedField)) {
-        this.primaryField = definition.fields.find(field => field.name === definition.primaryFeedField)
-        primaryFieldValue = primaryFormGroup.get(definition.primaryFeedField).value
+        this.primaryField = definition.fields.find(
+          (field) => field.name === definition.primaryFeedField
+        );
+        primaryFieldValue = primaryFormGroup.get(
+          definition.primaryFeedField
+        ).value;
       }
 
-      let secondaryFieldValue
+      let secondaryFieldValue;
       if (primaryFormGroup.contains(definition.secondaryFeedField)) {
-        this.secondaryField = definition.fields.find(field => field.name === definition.secondaryFeedField)
-        secondaryFieldValue = primaryFormGroup.get(definition.secondaryFeedField).value
+        this.secondaryField = definition.fields.find(
+          (field) => field.name === definition.secondaryFeedField
+        );
+        secondaryFieldValue = primaryFormGroup.get(
+          definition.secondaryFeedField
+        ).value;
       }
 
-      if ((this.primaryField && primaryFieldValue !== this.primaryFieldValue) ||
-          ((this.secondaryField && secondaryFieldValue !== this.secondaryFieldValue))) {
-        this.primaryFieldValue = this.primaryField ? primaryFieldValue : null
-        this.secondaryFieldValue = this.secondaryField ? secondaryFieldValue : null
+      if (
+        (this.primaryField && primaryFieldValue !== this.primaryFieldValue) ||
+        (this.secondaryField &&
+          secondaryFieldValue !== this.secondaryFieldValue)
+      ) {
+        this.primaryFieldValue = this.primaryField ? primaryFieldValue : null;
+        this.secondaryFieldValue = this.secondaryField
+          ? secondaryFieldValue
+          : null;
 
-        const observation = this.formGroup.value
+        const observation = this.formGroup.value;
 
-        const style = this.observationService.getObservationStyleForForm(observation, this.event, definition)
-        observation.style = style
-        this.geometryStyle = style
+        const style = this.observationService.getObservationStyleForForm(
+          observation,
+          this.event,
+          definition
+        );
+        observation.style = style;
+        this.geometryStyle = style;
 
-        this.mapService.updateFeatureForLayer(observation, 'observations')
+        this.mapService.updateFeatureForLayer(observation, "observations");
       }
     }
   }
 
   save(): void {
     if (this.formRemoveSnackbar) {
-      this.formRemoveSnackbar.dismiss()
+      this.formRemoveSnackbar.dismiss();
     }
 
-    this.saving = true
-    this.uploads = []
+    this.saving = true;
+    this.uploads = [];
 
     // TODO look at this: this is a hack that will be corrected when we pull ids from the server
-    const form = this.formGroup.getRawValue()
+    const form = this.formGroup.getRawValue();
     const id = form.id;
-    if (form.id === 'new') {
-      delete form.id
+    if (form.id === "new") {
+      delete form.id;
     }
 
     this.eventService.saveObservation(form).subscribe({
@@ -266,188 +339,238 @@ export class ObservationEditComponent implements OnInit, OnChanges {
         // If this feature was added to the map as a new observation, remove it
         // as the event service will add it back to the map based on it new id
         // if it passes the current filter.
-        if (id === 'new') {
-          this.mapService.removeFeatureFromLayer({ id: id }, 'observations')
+        if (id === "new") {
+          this.mapService.removeFeatureFromLayer({ id: id }, "observations");
         }
 
-        this.error = null
-        this.observation = observation
-        this.formGroup.get('id').setValue(observation.id)
+        this.error = null;
+        this.observation = observation;
+        this.formGroup.get("id").setValue(observation.id);
 
-        form.properties.forms.forEach(form => {
+        form.properties.forms.forEach((form) => {
           const formDefinition = this.formDefinitions[form.formId];
-          Object.keys(form).forEach(fieldName => {
-            const fieldDefinition = formDefinition.fields.find(field => field.name === fieldName);
+          Object.keys(form).forEach((fieldName) => {
+            const fieldDefinition = formDefinition.fields.find(
+              (field) => field.name === fieldName
+            );
             const value = form[fieldName];
-            if (fieldDefinition && fieldDefinition.type === 'attachment' && Array.isArray(value)) {
-              value.forEach(fieldAttachment => {
-                const attachment = observation.attachments.find(attachment => {
-                  return !attachment.url &&
-                    attachment.name === fieldAttachment.name &&
-                    attachment.contentType == fieldAttachment.contentType
-                });
+            if (
+              fieldDefinition &&
+              fieldDefinition.type === "attachment" &&
+              Array.isArray(value)
+            ) {
+              value.forEach((fieldAttachment) => {
+                const attachment = observation.attachments.find(
+                  (attachment) => {
+                    return (
+                      !attachment.url &&
+                      attachment.name === fieldAttachment.name &&
+                      attachment.contentType == fieldAttachment.contentType
+                    );
+                  }
+                );
 
-                if (fieldAttachment.file && fieldAttachment.action === AttachmentAction.ADD && attachment) {
-                  fieldAttachment.attachmentId = attachment.id
-                  this.uploads.push(attachment)
+                if (
+                  fieldAttachment.file &&
+                  fieldAttachment.action === AttachmentAction.ADD &&
+                  attachment
+                ) {
+                  fieldAttachment.attachmentId = attachment.id;
+                  this.uploads.push(attachment);
                 }
-              })
+              });
             }
-          })
-        })
+          });
+        });
 
         if (this.uploads.length) {
-          this.attachmentUrl = observation.url
+          this.attachmentUrl = observation.url;
         } else {
-          this.close.emit(this.observation)
+          this.close.emit(this.observation);
         }
       },
       error: (err) => {
-        this.formGroup.markAllAsTouched()
+        this.formGroup.markAllAsTouched();
 
-        if (id === 'new') {
-          this.observation.id = 'new'
+        if (id === "new") {
+          this.observation.id = "new";
         }
 
         this.saving = false;
         this.error = {
-          message: err.data.message
-        }
-      }
-    })
+          message: err.data.message,
+        };
+      },
+    });
   }
 
   cancel(): void {
     this.observation.geometry = this.initialObservation.geometry;
-    if (this.observation.id !== 'new') {
-      this.mapService.updateFeatureForLayer(this.observation, 'observations')
+    if (this.observation.id !== "new") {
+      this.mapService.updateFeatureForLayer(this.observation, "observations");
     } else {
-      this.mapService.removeFeatureFromLayer(this.observation, 'observations')
+      this.mapService.removeFeatureFromLayer(this.observation, "observations");
     }
 
     if (this.formRemoveSnackbar) {
-      this.formRemoveSnackbar.dismiss()
+      this.formRemoveSnackbar.dismiss();
     }
 
-    this.dialog.open(ObservationEditDiscardComponent, {
-      width: '300px',
-      autoFocus: false,
-      position: { left: '75px' }
-    }).afterClosed().subscribe(result => {
-      if (result === 'discard') {
-        this.close.emit()
-      }
-    })
+    this.dialog
+      .open(ObservationEditDiscardComponent, {
+        width: "300px",
+        autoFocus: false,
+        position: { left: "75px" },
+      })
+      .afterClosed()
+      .subscribe((result) => {
+        if (result === "discard") {
+          this.close.emit();
+        }
+      });
   }
 
   hasForms(): boolean {
-    const definitions = this.formDefinitions || {}
-    return Object.keys(definitions).length > 0
+    const definitions = this.formDefinitions || {};
+    return Object.keys(definitions).length > 0;
   }
 
   onGeometryEdit(event): void {
-    this.mask = event.action === 'edit';
+    this.mask = event.action === "edit";
 
     if (this.mask) {
       const elementBounds = event.source.nativeElement.getBoundingClientRect();
-      const parentBounds = this.editContent.nativeElement.getBoundingClientRect();
-      if (elementBounds.top < parentBounds.top || elementBounds.bottom > parentBounds.bottom) {
-        event.source.nativeElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      const parentBounds =
+        this.editContent.nativeElement.getBoundingClientRect();
+      if (
+        elementBounds.top < parentBounds.top ||
+        elementBounds.bottom > parentBounds.bottom
+      ) {
+        event.source.nativeElement.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
       }
     }
   }
 
   pickForm(): void {
-    this.formOptions.expand = true
-    this.bottomSheet.open(ObservationEditFormPickerComponent, {
-      panelClass: 'feed-panel'
-    }).afterDismissed().subscribe(form => {
-      if (!form) return
+    this.formOptions.expand = true;
+    this.bottomSheet
+      .open(ObservationEditFormPickerComponent, {
+        panelClass: "feed-panel",
+      })
+      .afterDismissed()
+      .subscribe((form) => {
+        if (!form) return;
 
-      const fieldsGroup = new UntypedFormGroup({
-        formId: new UntypedFormControl(form.id)
-      });
-
-      form.fields
-        .filter(field => !field.archived)
-        .sort((a, b) => a.id - b.id)
-        .forEach(field => {
-          const fieldControl = new UntypedFormControl(field.value, field.required ? Validators.required : null)
-          fieldsGroup.addControl(field.name, fieldControl)
+        const fieldsGroup = new UntypedFormGroup({
+          formId: new UntypedFormControl(form.id),
         });
 
-      (this.formGroup.get('properties').get('forms') as UntypedFormArray).push(fieldsGroup);
+        form.fields
+          .filter((field) => !field.archived)
+          .sort((a, b) => a.id - b.id)
+          .forEach((field) => {
+            const fieldControl = new UntypedFormControl(
+              field.value,
+              field.required ? Validators.required : null
+            );
+            fieldsGroup.addControl(field.name, fieldControl);
+          });
 
-      this.formElements.changes.pipe(first()).subscribe((queryList: QueryList<ElementRef>) => {
-        queryList.last.nativeElement.scrollIntoView({ behavior: 'smooth' })
-      })
-    })
+        (
+          this.formGroup.get("properties").get("forms") as UntypedFormArray
+        ).push(fieldsGroup);
+
+        this.formElements.changes
+          .pipe(first())
+          .subscribe((queryList: QueryList<ElementRef>) => {
+            queryList.last.nativeElement.scrollIntoView({ behavior: "smooth" });
+          });
+      });
   }
 
   removeForm(formGroup: UntypedFormGroup): void {
-    const formArray = this.formGroup.get('properties').get('forms') as UntypedFormArray
-    const index = formArray.controls.indexOf(formGroup)
-    formArray.removeAt(index)
+    const formArray = this.formGroup
+      .get("properties")
+      .get("forms") as UntypedFormArray;
+    const index = formArray.controls.indexOf(formGroup);
+    formArray.removeAt(index);
 
-    this.formRemoveSnackbar = this.snackBar.open('Form Deleted', 'UNDO', {
+    this.formRemoveSnackbar = this.snackBar.open("Form Deleted", "UNDO", {
       duration: 5000,
-      panelClass: 'form-remove-snackbar',
-    })
+      panelClass: "form-remove-snackbar",
+    });
 
     this.formRemoveSnackbar.onAction().subscribe(() => {
-      formArray.insert(index, formGroup)
-    })
+      formArray.insert(index, formGroup);
+    });
   }
 
   reorderForm(event: CdkDragDrop<any, any>): void {
-    if (event.currentIndex === event.previousIndex) return
+    if (event.currentIndex === event.previousIndex) return;
 
-    const forms = (this.formGroup.get('properties').get('forms') as UntypedFormArray).controls
-    moveItemInArray(forms, event.previousIndex, event.currentIndex)
+    const forms = (
+      this.formGroup.get("properties").get("forms") as UntypedFormArray
+    ).controls;
+    moveItemInArray(forms, event.previousIndex, event.currentIndex);
 
     // re-calculate primary/secondary based new first form
     if (event.currentIndex === 0 || event.previousIndex === 0) {
-      this.updatePrimarySecondary()
+      this.updatePrimarySecondary();
     }
   }
 
   dragStart(event: DragEvent): void {
-    this.document.body.classList.add('item-drag')
+    this.document.body.classList.add("item-drag");
   }
 
   dragEnd(event: DragEvent): void {
-    this.document.body.classList.remove('item-drag')
+    this.document.body.classList.remove("item-drag");
   }
 
   private onAttachmentUpload(event: AttachmentUploadEvent): void {
     switch (event.status) {
       case AttachmentUploadStatus.COMPLETE: {
-        this.eventService.addAttachmentToObservation(this.observation, event.response)
+        this.eventService.addAttachmentToObservation(
+          this.observation,
+          event.response
+        );
 
-        this.uploads = this.uploads.filter(attachment => attachment.id !== event.upload.attachmentId)
+        this.uploads = this.uploads.filter(
+          (attachment) => attachment.id !== event.upload.attachmentId
+        );
         if (this.uploads.length === 0) {
-          this.saving = false
-          this.close.emit(this.observation)
+          this.saving = false;
+          this.close.emit(this.observation);
         }
 
         break;
       }
       case AttachmentUploadStatus.ERROR: {
-        this.snackBar.open(event.response?.error, null, { duration: 4000 })
+        this.snackBar.open(event.response?.error, null, { duration: 4000 });
 
-        const formArray = this.formGroup.get('properties').get('forms') as UntypedFormArray
+        const formArray = this.formGroup
+          .get("properties")
+          .get("forms") as UntypedFormArray;
         formArray.controls.forEach((formGroup: UntypedFormGroup) => {
-          const formId = formGroup.get('formId').value
+          const formId = formGroup.get("formId").value;
           const formDefinition = this.formDefinitions[formId];
-          Object.keys(formGroup.controls).forEach(fieldName => {
-            const fieldDefinition = formDefinition.fields.find(field => field.name === fieldName);
-            if (fieldDefinition && fieldDefinition.type === 'attachment') {
-              let attachments = formGroup.get(fieldName).value || []
-              attachments = attachments.filter(attachment => attachment.attachmentId !== event.upload.attachmentId)
-              formGroup.get(fieldName).setValue(attachments)
+          Object.keys(formGroup.controls).forEach((fieldName) => {
+            const fieldDefinition = formDefinition.fields.find(
+              (field) => field.name === fieldName
+            );
+            if (fieldDefinition && fieldDefinition.type === "attachment") {
+              let attachments = formGroup.get(fieldName).value || [];
+              attachments = attachments.filter(
+                (attachment) =>
+                  attachment.attachmentId !== event.upload.attachmentId
+              );
+              formGroup.get(fieldName).setValue(attachments);
             }
-          })
-        })
+          });
+        });
 
         this.saving = false;
         break;

--- a/web-app/src/app/observation/observation.service.ts
+++ b/web-app/src/app/observation/observation.service.ts
@@ -1,122 +1,173 @@
-import { Injectable } from "@angular/core"
+import { Injectable } from "@angular/core";
 import { LocalStorageService } from "../http/local-storage.service";
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Observable, map, mergeMap } from "rxjs";
-import * as _ from 'underscore';
+import * as _ from "underscore";
 import { MageEvent } from "core-lib-src/event";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root",
 })
 export class ObservationService {
-
   constructor(
     private client: HttpClient,
     private localStorageService: LocalStorageService
-  ) { }
+  ) {}
 
   getId(eventId: number): Observable<any> {
-    return this.client.post<any>(`/api/events/${eventId}/observations/id/`, { eventId: eventId });
+    return this.client.post<any>(`/api/events/${eventId}/observations/id/`, {
+      eventId: eventId,
+    });
   }
 
   getObservation(eventId: string, observationId: string): Observable<any> {
-    return this.client.get<any>(`/api/events/${eventId}/observations/${observationId}`);
+    return this.client.get<any>(
+      `/api/events/${eventId}/observations/${observationId}`
+    );
   }
 
   getObservationsForEvent(event: MageEvent, options: any): Observable<any> {
-    const parameters: any = { eventId: event.id, states: 'active', populate: 'true' };
+    const parameters: any = {
+      eventId: event.id,
+      states: "active",
+      populate: "true",
+    };
     if (options.interval) {
       parameters.observationStartDate = options.interval.start;
       parameters.observationEndDate = options.interval.end;
     }
 
-    return this.client.get<any>(`/api/events/${event.id}/observations`, { params: parameters }).pipe(
-      map((observations: any) => {
-        return this.transformObservations(observations, event)
-      })
-    )
+    return this.client
+      .get<any>(`/api/events/${event.id}/observations`, { params: parameters })
+      .pipe(
+        map((observations: any) => {
+          return this.transformObservations(observations, event);
+        })
+      );
   }
 
   saveObservationForEvent(event: MageEvent, observation: any): Observable<any> {
     return this.saveObservation(event, observation).pipe(
       map((observation) => {
-        return this.transformObservations(observation, event)[0]
-     })
-    )
+        return this.transformObservations(observation, event)[0];
+      })
+    );
   }
 
   private saveObservation(event: MageEvent, observation: any): Observable<any> {
     if (observation.id) {
-      return this.client.put<any>(`/api/events/${event.id}/observations/${observation.id}`, observation);
+      return this.client.put<any>(
+        `/api/events/${event.id}/observations/${observation.id}`,
+        observation
+      );
     } else {
       return this.getId(event.id).pipe(
-        mergeMap(result => {
-          return this.client.put<any>(`/api/events/${event.id}/observations/${result.id}`, observation);
+        mergeMap((result) => {
+          return this.client.put<any>(
+            `/api/events/${event.id}/observations/${result.id}`,
+            observation
+          );
         })
-      )
+      );
     }
   }
 
   addObservationFavorite(event, observation): Observable<any> {
-    return this.client.put<any>(`/api/events/${event.id}/observations/${observation.id}/favorite`, observation)
+    return this.client.put<any>(
+      `/api/events/${event.id}/observations/${observation.id}/favorite`,
+      observation
+    );
   }
 
   removeObservationFavorite(event, observation): Observable<any> {
-    return this.client.delete<any>(`/api/events/${event.id}/observations/${observation.id}/favorite`, { body: observation })
+    return this.client.delete<any>(
+      `/api/events/${event.id}/observations/${observation.id}/favorite`,
+      { body: observation }
+    );
   }
 
-  markObservationAsImportantForEvent(event, observation, important): Observable<any>  {
-    return this.client.put<any>(`/api/events/${event.id}/observations/${observation.id}/important`, important)
+  markObservationAsImportantForEvent(
+    event,
+    observation,
+    important
+  ): Observable<any> {
+    return this.client.put<any>(
+      `/api/events/${event.id}/observations/${observation.id}/important`,
+      important
+    );
   }
 
-  clearObservationAsImportantForEvent(event, observation): Observable<any>  {
-    return this.client.delete<any>(`/api/events/${event.id}/observations/${observation.id}/important`, { body: observation })
+  clearObservationAsImportantForEvent(event, observation): Observable<any> {
+    return this.client.delete<any>(
+      `/api/events/${event.id}/observations/${observation.id}/important`,
+      { body: observation }
+    );
   }
 
   archiveObservationForEvent(event, observation): Observable<any> {
-    return this.client.post<any>(`/api/events/${event.id}/observations/${observation.id}/states`, { name: 'archive' }).pipe(
-      map(() => observation)
-    )
+    return this.client
+      .post<any>(
+        `/api/events/${event.id}/observations/${observation.id}/states`,
+        { name: "archive" }
+      )
+      .pipe(map(() => observation));
   }
 
   addAttachmentToObservationForEvent(event, observation, attachment) {
     const attachments = observation.attachments.slice();
-    const update = attachments.find(a => a.id === attachment.id);
+    const update = attachments.find((a) => a.id === attachment.id);
     if (update) {
       update.url = attachment.url;
     }
 
-    observation.attachments = attachments
+    observation.attachments = attachments;
   }
 
-  deleteAttachmentInObservationForEvent(event, observation, attachment): Observable<any> {
-    return this.client.delete<any>(`/api/events/${event.id}/observations/${observation.id}/attachments/${attachment.id}`).pipe(
-      map((response: any) => {
-        response.attachments = _.reject(observation.attachments, function (a) { return attachment.id === a.id; });
-        return response
-      })
-    )
+  deleteAttachmentInObservationForEvent(
+    event,
+    observation,
+    attachment
+  ): Observable<any> {
+    return this.client
+      .delete<any>(
+        `/api/events/${event.id}/observations/${observation.id}/attachments/${attachment.id}`
+      )
+      .pipe(
+        map((response: any) => {
+          response.attachments = _.reject(
+            observation.attachments,
+            function (a) {
+              return attachment.id === a.id;
+            }
+          );
+          return response;
+        })
+      );
   }
 
   transformObservations(observations, event) {
     if (!_.isArray(observations)) observations = [observations];
 
-    var formMap = _.indexBy(event.forms, 'id');
+    var formMap = _.indexBy(event.forms, "id");
     observations.forEach((observation: any) => {
       let form: any;
       if (observation.properties.forms.length) {
         form = formMap[observation.properties.forms[0].formId];
       }
 
-      observation.style = this.getObservationStyleForForm(observation, event, form);
-      if (observation.geometry.type === 'Polygon') {
+      observation.style = this.getObservationStyleForForm(
+        observation,
+        event,
+        form
+      );
+      if (observation.geometry.type === "Polygon") {
         this.minimizePolygon(observation.geometry.coordinates);
-      } else if (observation.geometry.type === 'LineString') {
+      } else if (observation.geometry.type === "LineString") {
         this.minimizeLineString(observation.geometry.coordinates);
       }
-    })
+    });
 
-    return observations
+    return observations;
   }
 
   minimizePolygon(polygon) {
@@ -156,8 +207,18 @@ export class ObservationService {
       variantField = firstForm[form.variantField];
     }
 
-    let style: any = this.getObservationStyle(event.style, formStyle, primaryField, variantField);
-    style.iconUrl = this.getObservationIconUrlForEvent(event.id, formId, primaryField, variantField);
+    let style: any = this.getObservationStyle(
+      event.style,
+      formStyle,
+      primaryField,
+      variantField
+    );
+    style.iconUrl = this.getObservationIconUrlForEvent(
+      event.id,
+      formId,
+      primaryField,
+      variantField
+    );
 
     return style;
   }
@@ -165,7 +226,12 @@ export class ObservationService {
   getObservationStyle(eventStyle, formStyle, primary, variant) {
     var style = eventStyle || {};
     if (formStyle) {
-      if (primary && formStyle[primary] && variant && formStyle[primary][variant]) {
+      if (
+        primary &&
+        formStyle[primary] &&
+        variant &&
+        formStyle[primary][variant]
+      ) {
         style = formStyle[primary][variant];
       } else if (primary && formStyle[primary]) {
         style = formStyle[primary];
@@ -179,29 +245,28 @@ export class ObservationService {
       fillColor: style.fill,
       fillOpacity: style.fillOpacity,
       opacity: style.strokeOpacity,
-      weight: style.strokeWidth
+      weight: style.strokeWidth,
     };
   }
 
   getObservationIconUrlForEvent(eventId, formId, primary, variant) {
-    var url = '/api/events/' + eventId + '/icons';
+    var url = "/api/events/" + eventId + "/icons";
 
     if (formId) {
-      url += '/' + formId;
+      url += "/" + formId;
     }
 
     if (primary) {
-      url += '/' + primary;
+      url += "/" + primary;
     }
 
     if (variant) {
-      url += '/' + variant;
+      url += "/" + variant;
     }
 
     var params = new HttpParams();
-    params = params.append('access_token', this.localStorageService.getToken())
-    
+    params = params.append("access_token", this.localStorageService.getToken());
 
-    return url + '?' + params.toString()
+    return url + "?" + params.toString();
   }
 }


### PR DESCRIPTION
This PR Fixes the Date Based Filtering for Observations, as well as adds two new Options {User, Form} to choose from. 

![image](https://github.com/user-attachments/assets/0b6bc92c-ff5c-473f-80dd-8a657ac0e616)


Test Instructions:

Before Testing, you will need a server that has multiple observations, with multiple forms, and multiple users.

1. Log into Mage 
2. On the Map Page Click the Filter Funnel Button in the upper left
3. Set Filter Options To Your Liking (Event, Teams, User, Forms, Time)
4. Click Filter
5. Expected result is that your Observations are Filtered in based on your selections.
6. Play around with different combinations, All combinations should work.
7. Change Events
8. All Filters should clear
9. Try to filter on the new event