### PR TITLE
Publish containers as packages

### DIFF
--- a/.github/workflows/aws_dev.deploy.yaml
+++ b/.github/workflows/aws_dev.deploy.yaml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
+  packages: write
 
 jobs:
   build-and-push:
@@ -25,31 +25,18 @@ jobs:
             echo "IMAGE_TAG=dev" >> $GITHUB_ENV
           fi
 
-      - name: AWS config
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Login to Github Registry ghcr.io
+        uses: docker/login-action@v3
         with:
-          role-to-assume: ${{ secrets.AWS_DEV_ROLE }}
-          role-session-name: GithubNGAGeointSession
-          aws-region: ${{ secrets.AWS_DEV_REGION }}
-
-      - name: AWS ECR Login
-        id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
-        env:
-          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          REPOSITORY: "/mage"
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
-          docker build -t $REGISTRY$REPOSITORY:$IMAGE_TAG .
+          docker build -t ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG .
 
       - name: Push Image
-        if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
-        env:
-          SERVICE: "mage${{ env.IMAGE_TAG }}"
-          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          REPOSITORY: "/mage"
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        # if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
         run: |
-          docker push $REGISTRY$REPOSITORY:$IMAGE_TAG
+          docker push ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG

--- a/.github/workflows/dev.container_build.yaml
+++ b/.github/workflows/dev.container_build.yaml
@@ -37,5 +37,6 @@ jobs:
           docker build -t ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG .
 
       - name: Push Image
+        if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
         run: |
           docker push ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG

--- a/.github/workflows/dev.container_build.yaml
+++ b/.github/workflows/dev.container_build.yaml
@@ -37,6 +37,6 @@ jobs:
           docker build -t ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG .
 
       - name: Push Image
-        # if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
+        if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
         run: |
           docker push ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG

--- a/.github/workflows/dev.container_build.yaml
+++ b/.github/workflows/dev.container_build.yaml
@@ -1,4 +1,4 @@
-name: AWS Dev Deployment
+name: Dev Container Build
 
 on:
   push:
@@ -37,6 +37,5 @@ jobs:
           docker build -t ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG .
 
       - name: Push Image
-        if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
         run: |
           docker push ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG

--- a/.github/workflows/prod.container_build.yaml
+++ b/.github/workflows/prod.container_build.yaml
@@ -1,0 +1,31 @@
+name: Production Container Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Login to Github Registry ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG ./docker/server
+
+      - name: Push Image
+        if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
+        run: |
+          docker push ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,19 +75,20 @@ COPY --from=build-arcserviceplugin /arcgisserviceplugin/ngageoint*.tgz /arcgisse
 COPY --from=build-sftpserviceplugin /sftpserviceplugin/ngageoint*.tgz /sftpserviceplugin/
 COPY --from=build-sftpwebplugin /sftpwebplugin/ngageoint*.tgz /sftpwebplugin/
 
-WORKDIR /instance
-RUN ls -la ../sftpwebplugin
-RUN npm install ../service/ngageoint-mage.service*.tgz 
-RUN npm install ../web-app/ngageoint-mage.web-app*.tgz
-RUN npm install ../sftpwebplugin/ngageoint-mage.sftp.web*.tgz 
-RUN npm install ../sftpserviceplugin/ngageoint-mage.sftp.service*.tgz 
-RUN npm install ../arcgiswebplugin/ngageoint*.tgz 
-RUN npm install ../arcgisserviceplugin/ngageoint*.tgz 
+ENV MAGE_HOME=/home/mage/instance
+WORKDIR ${MAGE_HOME}
 
+RUN npm install ../../../service/ngageoint-mage.service*.tgz 
+RUN npm install ../../../web-app/ngageoint-mage.web-app*.tgz
+RUN npm install ../../../sftpwebplugin/ngageoint-mage.sftp.web*.tgz 
+RUN npm install ../../../sftpserviceplugin/ngageoint-mage.sftp.service*.tgz 
+RUN npm install ../../../arcgiswebplugin/ngageoint*.tgz 
+RUN npm install ../../../arcgisserviceplugin/ngageoint*.tgz 
+RUN ln -s ./node_modules/.bin/mage.service
 
 ENV NODE_PATH=./node_modules
 ENTRYPOINT [ \ 
-    "./node_modules/.bin/mage.service", \
+    "./mage.service", \
     "--plugin", "@ngageoint/mage.arcgis.service", \
     "--plugin", "@ngageoint/mage.sftp.service", \
     "--web-plugin", "@ngageoint/mage.sftp.web", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ COPY service/package*.json ./
 RUN npm install
 COPY service/ ./
 RUN npm run build
-
 RUN npm pack
 
 # Build web-app
@@ -16,27 +15,26 @@ COPY web-app/package*.json ./
 RUN npm install
 COPY web-app/ ./
 RUN npm run build
-
 RUN npm pack ./dist
 
-FROM node:20.11.1 AS build-arcwebplugin
-# Build arcgis service plugin
-WORKDIR /arcgiswebplugin
-COPY plugins/arcgis/web-app/package*.json ./
-RUN npm install
-COPY --from=build-service /service /arcgiswebplugin/node_modules/@ngageoint/mage.service
-COPY plugins/arcgis/web-app/ ./
-RUN npm run build
-RUN npm pack ./dist/main
+# FROM node:20.11.1 AS build-arcwebplugin
+# # Build arcgis service plugin
+# WORKDIR /arcgiswebplugin
+# COPY plugins/arcgis/web-app/package*.json ./
+# RUN npm install
+# COPY --from=build-service /service /arcgiswebplugin/node_modules/@ngageoint/mage.service
+# COPY plugins/arcgis/web-app/ ./
+# RUN npm run build
+# RUN npm pack ./dist/main
 
-FROM node:20.11.1 AS build-arcserviceplugin
-WORKDIR /arcgisserviceplugin
-COPY plugins/arcgis/service/package*.json ./
-RUN npm install
-COPY --from=build-service /service /arcgisserviceplugin/node_modules/@ngageoint/mage.service
-COPY plugins/arcgis/service/ ./
-RUN npm run build
-RUN npm pack
+# FROM node:20.11.1 AS build-arcserviceplugin
+# WORKDIR /arcgisserviceplugin
+# COPY plugins/arcgis/service/package*.json ./
+# RUN npm install
+# COPY --from=build-service /service /arcgisserviceplugin/node_modules/@ngageoint/mage.service
+# COPY plugins/arcgis/service/ ./
+# RUN npm run build
+# RUN npm pack
 
 # FROM node:20.11.1 AS build-imageserviceplugin
 # WORKDIR /imageserviceplugin
@@ -48,49 +46,43 @@ RUN npm pack
 # RUN npm run build
 # RUN npm pack
 
-FROM node:20.11.1 AS build-sftpserviceplugin
-WORKDIR /sftpserviceplugin
-COPY plugins/sftp/service/package*.json ./
-RUN npm install
-COPY --from=build-service /service /sftpserviceplugin/node_modules/@ngageoint/mage.service
-COPY plugins/sftp/service/ ./
-RUN npm run build
-RUN npm pack
+# FROM node:20.11.1 AS build-sftpserviceplugin
+# WORKDIR /sftpserviceplugin
+# COPY plugins/sftp/service/package*.json ./
+# RUN npm install
+# COPY --from=build-service /service /sftpserviceplugin/node_modules/@ngageoint/mage.service
+# COPY plugins/sftp/service/ ./
+# RUN npm run build
+# RUN npm pack
 
-FROM node:20.11.1 AS build-sftpwebplugin
-# Build sftp service plugin
-WORKDIR /sftpwebplugin
-COPY plugins/sftp/web/package*.json ./
-RUN npm install
-COPY plugins/sftp/web/ ./
-RUN npm run build
-RUN npm pack ./dist/main
+# FROM node:20.11.1 AS build-sftpwebplugin
+# # Build sftp service plugin
+# WORKDIR /sftpwebplugin
+# COPY plugins/sftp/web/package*.json ./
+# RUN npm install
+# COPY plugins/sftp/web/ ./
+# RUN npm run build
+# RUN npm pack ./dist/main
 
 # Build instance
 FROM node:20.11.1 AS build-instance
 COPY --from=build-service /service/ngageoint*.tgz /service/
 COPY --from=build-webapp /web-app/ngageoint*.tgz /web-app/
-COPY --from=build-arcwebplugin /arcgiswebplugin/ngageoint*.tgz /arcgiswebplugin/
-COPY --from=build-arcserviceplugin /arcgisserviceplugin/ngageoint*.tgz /arcgisserviceplugin/
-COPY --from=build-sftpserviceplugin /sftpserviceplugin/ngageoint*.tgz /sftpserviceplugin/
-COPY --from=build-sftpwebplugin /sftpwebplugin/ngageoint*.tgz /sftpwebplugin/
+# COPY --from=build-arcwebplugin /arcgiswebplugin/ngageoint*.tgz /arcgiswebplugin/
+# COPY --from=build-arcserviceplugin /arcgisserviceplugin/ngageoint*.tgz /arcgisserviceplugin/
+# COPY --from=build-sftpserviceplugin /sftpserviceplugin/ngageoint*.tgz /sftpserviceplugin/
+# COPY --from=build-sftpwebplugin /sftpwebplugin/ngageoint*.tgz /sftpwebplugin/
 
 ENV MAGE_HOME=/home/mage/instance
 WORKDIR ${MAGE_HOME}
 
 RUN npm install ../../../service/ngageoint-mage.service*.tgz 
 RUN npm install ../../../web-app/ngageoint-mage.web-app*.tgz
-RUN npm install ../../../sftpwebplugin/ngageoint-mage.sftp.web*.tgz 
-RUN npm install ../../../sftpserviceplugin/ngageoint-mage.sftp.service*.tgz 
-RUN npm install ../../../arcgiswebplugin/ngageoint*.tgz 
-RUN npm install ../../../arcgisserviceplugin/ngageoint*.tgz 
+# RUN npm install ../../../sftpwebplugin/ngageoint-mage.sftp.web*.tgz 
+# RUN npm install ../../../sftpserviceplugin/ngageoint-mage.sftp.service*.tgz 
+# RUN npm install ../../../arcgiswebplugin/ngageoint*.tgz 
+# RUN npm install ../../../arcgisserviceplugin/ngageoint*.tgz 
 RUN ln -s ./node_modules/.bin/mage.service
 
 ENV NODE_PATH=./node_modules
-ENTRYPOINT [ \ 
-    "./mage.service", \
-    "--plugin", "@ngageoint/mage.arcgis.service", \
-    "--plugin", "@ngageoint/mage.sftp.service", \
-    "--web-plugin", "@ngageoint/mage.sftp.web", \
-    "--web-plugin", "@ngageoint/mage.arcgis.web-app" \
-    ]
+ENTRYPOINT [ "./mage.service" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,6 @@ RUN npm install ../arcgisserviceplugin/ngageoint*.tgz
 ENV NODE_PATH=./node_modules
 ENTRYPOINT [ \ 
     "./node_modules/.bin/mage.service", \
-    "--plugin", "@ngageoint/mage.image.service", \
     "--plugin", "@ngageoint/mage.arcgis.service", \
     "--plugin", "@ngageoint/mage.sftp.service", \
     "--web-plugin", "@ngageoint/mage.sftp.web", \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: ./
       # dockerfile: Dockerfile-debug
-    image: mage:local
+    image: mage:dev
     # entrypoint: ["./node_modules/.bin/mage.service", "--plugin", "@ngageoint/mage.image.service"]  Uncomment to specify new entrypoint commands
     platform: linux/amd64
     volumes:

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -26,7 +26,7 @@ RUN ls -l \
     && if [ "$ARC_SERVICE_VERSION" != "NONE" ]; then npm i --omit dev @ngageoint/mage.arcgis.service@$ARC_SERVICE_VERSION; fi\
     && if [ "$ARC_WEB_VERSION" != "NONE" ]; then npm i --omit dev @ngageoint/mage.arcgis.web-app@$ARC_WEB_VERSION; fi \
     && if [ "$SFTP_SERVICE_VERSION" != "NONE" ]; then npm i --omit dev @ngageoint/mage.sftp.service@$SFTP_SERVICE_VERSION; fi \
-    && if [ "$SFTP_WEB_VERSOIN" != "NONE" ]; then npm i --omit dev @ngageoint/mage.sftp.web@$SFTP_WEB_VERSION; fi \
+    && if [ "$SFTP_WEB_VERSION" != "NONE" ]; then npm i --omit dev @ngageoint/mage.sftp.web@$SFTP_WEB_VERSION; fi \
     && ln -s ./node_modules/.bin/mage.service
 
 VOLUME /var/lib/mage


### PR DESCRIPTION
removes the github action for pushing to the aws dev environment. Now dev and test branches will build dev and test containers that will be added to github packages.

Prod actions created as a first pass. this will not work. Due to how github actions work, I created this as a way to initialize the action for a future card.