### PR TITLE
Update @systemjs (From v6.10.0 to v6.15.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "6.5.4",
       "hasInstallScript": true,
       "dependencies": {
-        "p-limit": "^7.1.1"
+        "p-limit": "^7.1.1",
+        "systemjs": "^6.15.1"
       },
       "devDependencies": {
         "@types/angular-ui-router": "^1.1.44",
@@ -1877,6 +1878,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/systemjs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.15.1.tgz",
+      "integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
+      "license": "MIT"
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "npm-run-all": "4.1.5"
   },
   "dependencies": {
-    "p-limit": "^7.1.1"
+    "p-limit": "^7.1.1",
+    "systemjs": "^6.15.1"
   }
 }


### PR DESCRIPTION
This commit updates the `SystemJS` library in the server repo from `v6.10.0` to `v6.15.1`, as required by the ATO ticket.

- Updated `package.json` and `package-lock.json` to the latest supported SystemJS version.
- Verified that the app builds successfully (`npm run build`) and runs without breaking changes.
- No source code changes were required; SystemJS usage remains compatible.
- This upgrade satisfies the ticket requirement to meet NGA security standards for ATO.

Branch: `ato-systemjs-upgrade-1627`