### PR TITLE
Remove default limit for getting Events in api

### DIFF
--- a/service/src/models/event.js
+++ b/service/src/models/event.js
@@ -401,7 +401,14 @@ exports.getEvents = async function (options, callback) {
 
   const totalCount = await Event.countDocuments(query).exec();
 
-  Event.find(query, projection, (err, events) => {
+  let findQuery = Event.find(query, projection)
+    .sort({ name: 1, _id: 1 });
+
+  if (options.limit != null) {
+    findQuery = findQuery.limit(options.limit).skip(options.start * options.limit || 0);
+  }
+
+  findQuery.exec((err, events) => {
     if (err) return callback(err);
 
     if (options.populate) {
@@ -411,10 +418,7 @@ exports.getEvents = async function (options, callback) {
     } else {
       callback(null, events, totalCount);
     }
-  })
-    .sort({ name: 1, _id: 1 })
-    .limit(options.limit || 1000)
-    .skip(options.start * options.limit || 0);
+  });
 };
 
 exports.getById = function (id, options, callback) {

--- a/service/src/routes/events.ts
+++ b/service/src/routes/events.ts
@@ -213,7 +213,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
       if (req.parameters!.userId) {
         filter.userId = req.parameters!.userId
       }
-      const pageSize = parseInt(String(req.query.page_size)) || parseInt(String(req.query.limit)) || 20
+      const pageSize = parseInt(String(req.query.page_size)) || parseInt(String(req.query.limit))
       const page = parseInt(String(req.query.page)) || parseInt(String(req.query.start)) || 0
       EventModel.getEvents({ access: req.access, filter: filter, populate: req.parameters!.populate, projection: req.parameters!.projection, limit: pageSize, start: page }, (err, events, totalCount) => {
         if (err) {


### PR DESCRIPTION
This pr removes the 20 default limit and changes the behavior to return all events if no limit is set