### PR TITLE
add null default

### DIFF
--- a/service/src/routes/events.ts
+++ b/service/src/routes/events.ts
@@ -213,7 +213,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
       if (req.parameters!.userId) {
         filter.userId = req.parameters!.userId
       }
-      const pageSize = parseInt(String(req.query.page_size)) || parseInt(String(req.query.limit))
+      const pageSize = parseInt(String(req.query.page_size)) || parseInt(String(req.query.limit)) || null
       const page = parseInt(String(req.query.page)) || parseInt(String(req.query.start)) || 0
       EventModel.getEvents({ access: req.access, filter: filter, populate: req.parameters!.populate, projection: req.parameters!.projection, limit: pageSize, start: page }, (err, events, totalCount) => {
         if (err) {


### PR DESCRIPTION
Adds a null default for the pageSize param in the getEvents endpoint. This is due to an issue where older mongo versions can't handle the NaN value being passed