### PR TITLE
Allow any attachment file type to be uploaded

### DIFF
--- a/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.html
+++ b/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.html
@@ -71,9 +71,9 @@
 
             <div class="config-inline-item">
                 <div class="config-inline-label">
-                    <strong>Allowed Attachment Types *</strong>
-                    <p class="field-hint">Select which types of attachments users can upload. At least one type must be
-                        selected.</p>
+                    <strong>Allowed Attachment Types</strong>
+                    <p class="field-hint">Limit which types of attachments users can upload. If none are selected, all
+                        file types will be allowed.</p>
                 </div>
                 <div class="config-inline-control">
                     <div class="checkbox-group">
@@ -83,6 +83,10 @@
                             <span>{{ type.title }}</span>
                         </label>
                     </div>
+                    <p class="field-warning" *ngIf="hasNoAttachmentTypes()">
+                        <i class="fa fa-exclamation-triangle"></i>
+                        Warning: If no types are selected, users will be able to upload any file type.
+                    </p>
                 </div>
             </div>
         </div>

--- a/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.scss
+++ b/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.scss
@@ -59,6 +59,24 @@
                 }
             }
 
+            .field-warning {
+                font-size: 12px;
+                color: #d97706;
+                margin: 8px 0 0 0;
+                line-height: 1.4;
+                display: flex;
+                align-items: center;
+                gap: 4px;
+                padding: 6px 10px;
+                background-color: #fffbeb;
+                border: 1px solid #fde68a;
+                border-radius: 4px;
+
+                i {
+                    color: #d97706;
+                }
+            }
+
             .form-input {
                 width: 100%;
                 padding: 8px 12px;

--- a/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.ts
+++ b/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.ts
@@ -65,16 +65,16 @@ export class FieldDialogComponent {
         }
 
         if (this.field.type === 'attachment') {
-            if (!this.field.allowedAttachmentTypes || this.field.allowedAttachmentTypes.length === 0) {
-                this.field.allowedAttachmentTypes = this.data.attachmentAllowedTypes.map(type => type.name);
+            if (!this.field.allowedAttachmentTypes) {
+                this.field.allowedAttachmentTypes = [];
             }
         }
     }
 
     onFieldTypeChange(newType: string): void {
         if (newType === 'attachment') {
-            if (!this.field.allowedAttachmentTypes || this.field.allowedAttachmentTypes.length === 0) {
-                this.field.allowedAttachmentTypes = this.data.attachmentAllowedTypes.map(type => type.name);
+            if (!this.field.allowedAttachmentTypes) {
+                this.field.allowedAttachmentTypes = [];
             }
         }
     }
@@ -106,10 +106,12 @@ export class FieldDialogComponent {
         if (this.isFieldNameDuplicate()) {
             return false;
         }
-        if (this.field.type === 'attachment') {
-            return this.field.allowedAttachmentTypes && this.field.allowedAttachmentTypes.length > 0;
-        }
         return true;
+    }
+
+    hasNoAttachmentTypes(): boolean {
+        return this.field.type === 'attachment' &&
+            (!this.field.allowedAttachmentTypes || this.field.allowedAttachmentTypes.length === 0);
     }
 
     onSave(): void {

--- a/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/form-details.component.ts
+++ b/web-app/admin/src/app/admin/admin-event/admin-event-form/form-details/form-details.component.ts
@@ -139,7 +139,7 @@ export class FormDetailsComponent implements OnInit {
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
     private localStorageService: LocalStorageService
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.token = this.localStorageService.getToken() ?? null;
@@ -338,10 +338,10 @@ export class FormDetailsComponent implements OnInit {
 
     const saveObservable = this.form.id
       ? this.eventsService.updateForm(
-          this.event.id.toString(),
-          this.form.id.toString(),
-          payload
-        )
+        this.event.id.toString(),
+        this.form.id.toString(),
+        payload
+      )
       : this.eventsService.createForm(this.event.id.toString(), payload);
 
     saveObservable.subscribe({
@@ -697,7 +697,7 @@ export class FormDetailsComponent implements OnInit {
       !field.allowedAttachmentTypes ||
       field.allowedAttachmentTypes.length === 0
     ) {
-      return '';
+      return 'All file types';
     }
     return field.allowedAttachmentTypes
       .map((typeName) => {
@@ -1039,9 +1039,8 @@ export class FormDetailsComponent implements OnInit {
       const formData = new FormData();
       formData.append('icon', file);
 
-      let url = `/api/events/${this.event.id}/icons/${
-        this.form.id
-      }/${encodeURIComponent(primary)}`;
+      let url = `/api/events/${this.event.id}/icons/${this.form.id
+        }/${encodeURIComponent(primary)}`;
       if (variant) {
         url += `/${encodeURIComponent(variant)}`;
       }
@@ -1098,14 +1097,14 @@ export class FormDetailsComponent implements OnInit {
     try {
       const eventId = this.eventId;
       const token = this.localStorageService.getToken() ?? null;
-  
+
       if (!eventId || !token) {
         this.observations = [];
         return;
       }
-  
+
       const myself = await firstValueFrom(this.adminUserService.getMyself());
-  
+
       this.observations = ObservationFeedHelper.generateSampleObservations(
         this.form,
         Number(this.form.id),
@@ -1118,5 +1117,5 @@ export class FormDetailsComponent implements OnInit {
       this.observations = [];
     }
   }
-  
+
 }


### PR DESCRIPTION
This PR reverses a change made when upgrading the event forms page where the user had to limit attachments to specific types. Now users could choose to allow any file type as before.

Testing instructions:
1. Create a new form with an attachment field with no options selected. Verify that you get a warning message and are able to save the form.
2. Create observations with non media attachments like a csv or pdf. Verify that they are uploaded successfully.
3. Restrict the attachment types on the form field and verify that you can no longer upload any file type.

Form edit modal with warning
<img width="743" height="629" alt="Screenshot 2026-02-17 at 11 25 09 AM" src="https://github.com/user-attachments/assets/754fd31c-0cfb-440f-b0da-06beae30c3d5" />

Observation with non media attachment
<img width="455" height="372" alt="Screenshot 2026-02-17 at 11 25 43 AM" src="https://github.com/user-attachments/assets/439b664b-a9a8-49ab-a977-bfab37f48977" />
