### PR TITLE
Predisk ClamAV Scan 1755

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,10 +18,10 @@
       "sourceMaps": true
     },
     {
+      "name": "Attach to MAGE Service",
       "type": "node",
       "request": "attach",
-      "name": "Attach to MAGE Service",
-      "port": 9229, // For Node.js inspect
+      "port": 9229,
       "restart": true,
       "skipFiles": [
         "<node_internals>/**"
@@ -29,7 +29,7 @@
       "cwd": "${workspaceFolder}/service"
     },
     {
-      "name": "mage server instance",
+      "name": "Debug MAGE Backend",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "npm",
@@ -44,7 +44,6 @@
       },
       "cwd": "${workspaceFolder}/instance",
       "console": "integratedTerminal",
-      "preLaunchTask": "service:build",
       "sourceMaps": true,
       "outFiles": [
         "${workspaceFolder}/service/lib/**/*.js",
@@ -57,7 +56,7 @@
     {
       "name": "Debug Backend + WebApp",
       "configurations": [
-        "Attach to MAGE Service",
+        "Debug MAGE Backend",
         "Launch WebApp"
       ],
       "stopAll": true
@@ -65,7 +64,7 @@
     {
       "name": "Debug Backend + AdminApp",
       "configurations": [
-        "Attach to MAGE Service",
+        "Debug MAGE Backend",
         "Launch AdminApp"
       ],
       "stopAll": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       MAGE_TOKEN_EXPIRATION: "28800"
       # NOTE: default INSECURE salt value, recommend generate new UUID before deployment, **NOT** after deployment
       SFTP_PLUGIN_CONFIG_SALT: "A0E6D3B4-25BD-4DD6-BBC9-B367931966AB"
+      CLAM_AV_URL: tcp://clamav:3310
 
   # Uncomment the following block to enable the TLS reverse proxy.  You will
   # also need to generate the key and certificate as the README describes.

--- a/service/docs/attachments/pre-disk-clamav-scan.md
+++ b/service/docs/attachments/pre-disk-clamav-scan.md
@@ -1,0 +1,236 @@
+# MAGE Pre-Disk Attachment Scan – Comprehensive Summary (Updated)
+
+## Purpose
+Document all work, understanding, decisions, and implementation details regarding MAGE attachments, **pre-disk virus scanning**, and Observation handling. This includes lifecycle, backend wiring, ClamAV integration, debugging lessons, and final architectural invariants.
+
+---
+
+## 1. Context & Track
+
+- **Origin**: Work initiated from GitLab tickets covering the full pre-disk attachment scanning track for MAGE Observations.
+- **Primary Goal**: Guarantee that **all attachment bytes are scanned for viruses before**:
+  - Any filesystem write
+  - Any MongoDB attachment metadata commit
+- **Key Invariant (now explicit and enforced)**:
+  > **Busboy stream → ClamAV scan → clean stream → storage**
+
+- **Tracking**: Multiple GitLab tickets (IDs omitted for security) define incremental requirements: discovery, proof-of-concept, controller interception, and final enforcement.
+
+- **Challenges encountered**:
+  - Strict Observation prerequisites caused false negatives during testing
+  - Confusion between frontend rendering behavior vs backend success
+  - Attempting to debug Node streams from the browser console
+  - Overuse of breakpoints inside async stream callbacks
+  - Repeated assumptions without validating execution context → **“Mission Stupid”**
+
+---
+
+## 2. MAGE Attachment Lifecycle (Authoritative)
+
+### 2.1 Observation Creation (Hard Requirements)
+An Observation **must** have:
+- Event
+- User
+- Team
+- Map Layer
+- Form containing **at least one Attachment-type field**
+
+Without all of the above, attachments may upload but will **not render** in the UI.
+
+---
+
+### 2.2 Attachment Submission (Front-End)
+
+- User selects:
+  - Form → Attachment field → local file
+- Front-end issues:
+  ```
+  PUT /api/events/:eventId/observations/:observationId/attachments/:attachmentId
+  ```
+- Browser **never sees file bytes again** after upload
+- UI rendering depends on Observation validity, not upload success alone
+
+---
+
+### 2.3 Backend Handling (Critical Path)
+
+**Primary controller**:
+```
+service/src/adapters/observations/adapters.observations.controllers.web.ts
+```
+
+Flow:
+1. Express route initializes **Busboy**
+2. Busboy emits `file` event
+3. Raw upload stream is received **in-memory**
+4. **NEW**: Stream is scanned via ClamAV **before** any persistence
+5. Only a clean stream proceeds to storage
+6. Storage layer writes:
+   - File bytes to disk
+   - Attachment metadata to MongoDB
+
+---
+
+### 2.4 Attachment Retrieval
+
+- List attachments:
+  ```
+  GET /api/events/:eventId/observations/:observationId/attachments
+  ```
+- Fetch attachment bytes:
+  ```
+  GET /api/events/:eventId/observations/:observationId/attachments/:attachmentId?access_token=...
+  ```
+
+MongoDB stores attachment metadata as **embedded documents** within the Observation.
+
+---
+
+## 3. ClamAV Integration (Final Design)
+
+### 3.1 Implementation File (New)
+
+```
+service/src/adapters/observations/adapters.attachments.clamav.ts
+```
+
+### 3.2 Responsibilities
+
+- Accept a **Readable stream** (Busboy file stream)
+- Pipe bytes to ClamAV via stdin
+- Interpret ClamAV exit codes:
+  - `0` → clean
+  - `1` → virus detected
+  - `>1` → scanner error
+- Return a **new readable stream** containing clean bytes
+- Throw on detection or error
+
+### 3.3 Key Design Decision
+
+- **No byte peeking, logging, or buffering for debugging**
+- Stream safety and correctness > observability
+- Virus detection is authoritative; no partial writes allowed
+
+---
+
+## 4. Controller Wiring (What Actually Changed)
+
+### 4.1 Exact Hook Point
+
+Inside:
+```
+.on('file', async (fieldName, stream, info) => { ... })
+```
+
+### 4.2 Critical Change
+
+- **Before**: raw Busboy stream passed directly to `storeAttachmentContent()`
+- **After**:
+  1. `scanAttachmentWithClamAV(stream)`
+  2. Receive clean stream
+  3. Pass clean stream to storage
+
+### 4.3 Failure Behavior
+
+- Virus detected → request rejected
+- No disk write
+- No MongoDB attachment commit
+- Upload fails fast and safely
+
+---
+
+## 5. Debugging Reality (Hard Lessons)
+
+### 5.1 Where Logs Actually Appear
+
+- `console.log` in controllers → **Node terminal**, not browser DevTools
+- Browser DevTools only shows **frontend JS**, never backend logs
+
+### 5.2 VS Code Debugger Truth
+
+- "Debug MAGE Backend" **is** a Node debugger
+- Breakpoints:
+  - Cannot reliably bind to inline arrow callbacks
+  - Must be placed on named functions or executable statements
+- Stepping into Busboy callbacks is unreliable due to async stream timing
+
+### 5.3 What Did NOT Help
+
+- Logging stream chunks
+- Trying to view bytes in DevTools
+- Adding repeated `data` handlers
+- Inspecting `ReadableState` internals
+
+> Seeing bytes was **never required** to validate correctness.
+
+---
+
+## 6. Front-End Notes (Clarified)
+
+- Attachment rendering depends on:
+  - Valid Observation
+  - Form contains Attachment field
+- UI buttons (Activate / Complete) do **not** reflect attachment readiness
+- Successful upload ≠ visible attachment
+
+---
+
+## 7. Backend Structure (Relevant Only)
+
+```
+mage-server/service/
+├── src/
+│   ├── adapters/
+│   │   └── observations/
+│   │       ├── adapters.observations.controllers.web.ts
+│   │       ├── adapters.attachments.clamav.ts   ← NEW
+│   │       └── adapters.observations.db.mongoose.ts
+```
+
+MongoDB updates:
+- Attachments updated via `$set` and `$elemMatch`
+- No structural changes required for scanning
+
+---
+
+## 8. Network / API Confirmation
+
+- Metadata confirmed stored correctly
+- Retrieval endpoints verified
+- Token-based access confirmed
+
+Example attachment metadata:
+```json
+{
+  "id": "6984cf0ec088cb625ee0922c",
+  "fieldName": "thurspm_attachment",
+  "url": "...",
+  "contentStored": true
+}
+```
+
+---
+
+## 9. Lessons Learned / Rules Going Forward
+
+1. **Never assume execution context** (browser vs Node)
+2. **Do not debug streams by logging bytes**
+3. Breakpoints ≠ execution guarantees in async streaming code
+4. Observation setup errors masquerade as attachment bugs
+5. Enforce invariants in code, not via debugging
+
+---
+
+## ✅ Current Status (Updated)
+
+- ✅ ClamAV streaming scan implemented
+- ✅ Pre-disk invariant enforced
+- ✅ Controller correctly intercepts upload stream
+- ✅ Clean stream only reaches storage
+- ✅ Infected files are rejected early
+- ✅ No dependency on byte inspection or debugging hacks
+
+**System is now ready for:**
+- EICAR test validation
+- Timeout / resilience hardening
+- Ticket closure and PR

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -5,6 +5,9 @@ const CLAMAV_HOST = process.env.CLAMAV_HOST || 'localhost'
 const CLAMAV_PORT = Number(process.env.CLAMAV_PORT) || 3310
 const CLAMAV_TIMEOUT_MS = 60_000
 
+// LOG: CLAMAV host and port
+console.log(`[CLAMAV] Using host: ${CLAMAV_HOST}, port: ${CLAMAV_PORT}`)
+
 export async function scanAttachmentWithClamAV(
   inputStream: Readable
 ): Promise<Readable> {
@@ -46,6 +49,8 @@ export async function scanAttachmentWithClamAV(
 
     clam.on('connect', () => {
       clamReady = true
+      console.log('[CLAMAV] Connection established, ready to stream data')
+
       clam.write('zINSTREAM\0')
 
       // flush queued chunks
@@ -54,6 +59,7 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
+        console.log(`[CLAMAV] Queued chunk sent, size: ${chunk.length}`)
       }
       writeQueue.length = 0
     })
@@ -68,8 +74,10 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
+        console.log(`[CLAMAV] Chunk sent, size: ${chunk.length}`)
       } else {
         writeQueue.push(chunk)
+        console.log(`[CLAMAV] Chunk queued, size: ${chunk.length}`)
       }
     })
 
@@ -104,6 +112,7 @@ export async function scanAttachmentWithClamAV(
       settled = true
 
       if (response.includes('OK')) {
+        console.log('[CLAMAV] Scan result: OK, file is clean')
         tee.pipe(gatedStream)
         gatedStream.resume()
         resolve(gatedStream)
@@ -111,14 +120,15 @@ export async function scanAttachmentWithClamAV(
       }
 
       if (response.includes('FOUND')) {
+        console.log('[CLAMAV] Scan result: VIRUS FOUND')
         const virusErr = new Error('ClamAV detected a virus in uploaded file')
-        // destroy streams quietly without emitting 'error'
         gatedStream.destroy()
         tee.destroy()
         return reject(virusErr)
       }
 
       const unknownErr = new Error(`ClamAV scan failed: ${response.trim()}`)
+      console.log('[CLAMAV] Scan result: UNKNOWN ERROR')
       gatedStream.destroy()
       tee.destroy()
       reject(unknownErr)

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -6,7 +6,7 @@ const CLAMAV_PORT = Number(process.env.CLAMAV_PORT) || 3310
 const CLAMAV_TIMEOUT_MS = 60_000
 
 export type AttachmentScanResult = {
-  status: 'success' | 'failed'
+  status: 'clean' | 'infected' | 'scan_error'
   stream?: Readable
   error?: string
 }
@@ -110,28 +110,40 @@ export async function scanAttachmentWithClamAV(
       if (settled) return
       settled = true
 
+      // ----------------------
+      // CLEAN FILE
+      // ----------------------
       if (response.includes('OK')) {
         tee.pipe(gatedStream)
         gatedStream.resume()
+
         return resolve({
-          status: 'success',
+          status: 'clean',
           stream: gatedStream
         })
       }
 
+      // ----------------------
+      // VIRUS FOUND
+      // ----------------------
       if (response.includes('FOUND')) {
         gatedStream.destroy()
         tee.destroy()
+
         return resolve({
-          status: 'failed',
+          status: 'infected',
           error: 'ClamAV detected a virus in uploaded file'
         })
       }
 
+      // ----------------------
+      // UNKNOWN SCAN ERROR
+      // ----------------------
       gatedStream.destroy()
       tee.destroy()
+
       return resolve({
-        status: 'failed',
+        status: 'scan_error',
         error: `ClamAV scan failed: ${response.trim()}`
       })
     })

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -29,7 +29,7 @@ export async function scanAttachmentWithClamAV(
       reject(err)
     }
 
-    // Pipe input into tee
+    // pipe input into tee
     inputStream.pipe(tee)
     inputStream.on('error', (err) => fail(new Error(`Input stream error: ${err.message}`)))
     tee.on('error', (err) => fail(new Error(`Tee stream error: ${err.message}`)))
@@ -40,7 +40,7 @@ export async function scanAttachmentWithClamAV(
       clamReady = true
       clam.write('zINSTREAM\0')
 
-      // Flush queued chunks
+      // flush queued chunks
       for (const chunk of writeQueue) {
         const size = Buffer.alloc(4)
         size.writeUInt32BE(chunk.length, 0)
@@ -52,7 +52,7 @@ export async function scanAttachmentWithClamAV(
 
     clam.on('error', (err) => fail(new Error(`Failed to connect to ClamAV: ${err.message}`)))
 
-    // Send chunks to ClamAV
+    // send chunks to ClamAV
     tee.on('data', (chunk: Buffer) => {
       if (settled) return
       if (clamReady) {
@@ -86,7 +86,7 @@ export async function scanAttachmentWithClamAV(
       }
     })
 
-    // Collect ClamAV response
+    // collect ClamAV response
     let response = ''
     clam.on('data', (chunk) => {
       const chunkStr = chunk.toString()
@@ -113,7 +113,7 @@ export async function scanAttachmentWithClamAV(
       fail(new Error(`ClamAV scan failed: ${response.trim()}`))
     })
 
-    // Timeout
+    // timeout
     const timeout = setTimeout(() => fail(new Error('ClamAV scan timed out')), CLAMAV_TIMEOUT_MS)
     const clearTimers = (): void => clearTimeout(timeout)
     clam.on('end', clearTimers)

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -1,48 +1,122 @@
 import { Readable, PassThrough } from 'stream'
-import { spawn } from 'child_process'
+import net from 'net'
 
-/**
- * Scan an uploaded attachment using ClamAV **before writing to disk**.
- * Streams bytes directly; no full-file buffering.
- * 
- * @param inputStream - Readable stream from Busboy
- * @returns Promise<Readable> - clean stream to pass to storage
- * @throws Error if virus detected or ClamAV fails
- */
-export async function scanAttachmentWithClamAV(inputStream: Readable): Promise<Readable> {
+const CLAMAV_HOST = process.env.CLAMAV_HOST || 'localhost'
+const CLAMAV_PORT = Number(process.env.CLAMAV_PORT) || 3310
+const CLAMAV_TIMEOUT_MS = 60_000
+
+export async function scanAttachmentWithClamAV(
+  inputStream: Readable
+): Promise<Readable> {
   console.log('>>> CLAMAV SCAN STARTED <<<')
 
   return new Promise((resolve, reject) => {
-    const clam = spawn('clamscan', ['--stdout', '--no-summary', '-'])
+    let settled = false
+    const writeQueue: Buffer[] = []
 
-    // Clean PassThrough stream for downstream storage
-    const cleanStream = new PassThrough()
+    const tee = new PassThrough()
+    const gatedStream = new PassThrough()
+    gatedStream.pause()
 
-    // Pipe input directly to ClamAV stdin
-    inputStream.pipe(clam.stdin)
+    const clam = net.createConnection({ host: CLAMAV_HOST, port: CLAMAV_PORT })
 
-    // Pipe ClamAV stdout to clean stream
-    clam.stdout.pipe(cleanStream)
+    const fail = (err: Error): void => {
+      if (settled) return
+      settled = true
+      inputStream.destroy(err)
+      tee.destroy(err)
+      gatedStream.destroy(err)
+      clam.destroy()
+      reject(err)
+    }
 
-    clam.on('close', (code) => {
-      if (code === 0) {
-        console.log('>>> CLAMAV SCAN CLEAN <<<')
-        resolve(cleanStream)
-      } else if (code === 1) {
-        reject(new Error('ClamAV detected a virus in the uploaded file'))
+    // Pipe input into tee
+    inputStream.pipe(tee)
+    inputStream.on('error', fail)
+    tee.on('error', fail)
+
+    let clamReady = false
+
+    clam.on('connect', () => {
+      console.log('✅ Connected to ClamAV server')
+      clamReady = true
+      clam.write('zINSTREAM\0')
+
+      // Flush queued chunks
+      for (const chunk of writeQueue) {
+        const size = Buffer.alloc(4)
+        size.writeUInt32BE(chunk.length, 0)
+        clam.write(size)
+        clam.write(chunk)
+      }
+      writeQueue.length = 0
+    })
+
+    clam.on('error', (err) => fail(new Error(`Failed to connect to ClamAV: ${err.message}`)))
+
+    // Send chunks to ClamAV
+    tee.on('data', (chunk: Buffer) => {
+      if (settled) return
+      if (clamReady) {
+        const size = Buffer.alloc(4)
+        size.writeUInt32BE(chunk.length, 0)
+        clam.write(size)
+        clam.write(chunk)
       } else {
-        reject(new Error(`ClamAV error (exit code ${code})`))
+        writeQueue.push(chunk)
       }
     })
 
-    clam.on('error', (err) => {
-      reject(new Error(`Failed to start ClamAV: ${err.message}`))
+    // Only end ClamAV after all data sent
+    tee.on('end', () => {
+      if (settled) return
+      if (clamReady) {
+        const zero = Buffer.alloc(4)
+        zero.writeUInt32BE(0, 0)
+        clam.write(zero)
+        clam.end()
+      } else {
+        // Wait for socket ready, then end
+        const checkReady = setInterval(() => {
+          if (clamReady) {
+            clearInterval(checkReady)
+            const zero = Buffer.alloc(4)
+            zero.writeUInt32BE(0, 0)
+            clam.write(zero)
+            clam.end()
+          }
+        }, 10)
+      }
     })
 
-    // Ensure upstream errors kill ClamAV
-    inputStream.on('error', (err) => {
-      clam.kill()
-      reject(err)
+    // Collect ClamAV response
+    let response = ''
+    clam.on('data', (chunk) => (response += chunk.toString()))
+
+    clam.on('end', () => {
+      if (settled) return
+
+      if (response.includes('OK')) {
+        console.log('>>> CLAMAV SCAN CLEAN <<<')
+        settled = true
+        tee.pipe(gatedStream)
+        gatedStream.resume()
+        resolve(gatedStream)
+        return
+      }
+
+      if (response.includes('FOUND')) {
+        fail(new Error('ClamAV detected a virus in uploaded file'))
+        return
+      }
+
+      fail(new Error(`ClamAV scan failed: ${response.trim()}`))
     })
+
+    // Timeout
+    const timeout = setTimeout(() => fail(new Error('ClamAV scan timed out')), CLAMAV_TIMEOUT_MS)
+    const clearTimers = (): void => clearTimeout(timeout)
+    clam.on('end', clearTimers)
+    clam.on('error', clearTimers)
   })
 }

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -17,6 +17,14 @@ export async function scanAttachmentWithClamAV(
     const gatedStream = new PassThrough()
     gatedStream.pause()
 
+    // Prevent unhandled 'error' events on the gated stream
+    gatedStream.on('error', (err) => {
+      if (!settled) {
+        settled = true
+        reject(err)
+      }
+    })
+
     const clam = net.createConnection({ host: CLAMAV_HOST, port: CLAMAV_PORT })
 
     const fail = (err: Error): void => {
@@ -40,7 +48,7 @@ export async function scanAttachmentWithClamAV(
       clamReady = true
       clam.write('zINSTREAM\0')
 
-      // flush chunks
+      // flush queued chunks
       for (const chunk of writeQueue) {
         const size = Buffer.alloc(4)
         size.writeUInt32BE(chunk.length, 0)
@@ -68,19 +76,18 @@ export async function scanAttachmentWithClamAV(
     // end ClamAV after all data sent
     tee.on('end', () => {
       if (settled) return
-      if (clamReady) {
+      const sendEnd = (): void => {
         const zero = Buffer.alloc(4)
         zero.writeUInt32BE(0, 0)
         clam.write(zero)
         clam.end()
-      } else {
-        const checkReady = setInterval(() => {
+      }
+      if (clamReady) sendEnd()
+      else {
+        const interval = setInterval(() => {
           if (clamReady) {
-            clearInterval(checkReady)
-            const zero = Buffer.alloc(4)
-            zero.writeUInt32BE(0, 0)
-            clam.write(zero)
-            clam.end()
+            clearInterval(interval)
+            sendEnd()
           }
         }, 10)
       }
@@ -89,42 +96,38 @@ export async function scanAttachmentWithClamAV(
     // ClamAV response
     let response = ''
     clam.on('data', (chunk) => {
-      const chunkStr = chunk.toString()
-      response += chunkStr
+      response += chunk.toString()
     })
 
     clam.on('end', () => {
       if (settled) return
-    
-      settled = true // avoid double handling
-    
+      settled = true
+
       if (response.includes('OK')) {
         tee.pipe(gatedStream)
         gatedStream.resume()
         resolve(gatedStream)
         return
       }
-    
+
       if (response.includes('FOUND')) {
         const virusErr = new Error('ClamAV detected a virus in uploaded file')
-        // reject gracefully
-        gatedStream.destroy(virusErr)
-        tee.destroy(virusErr)
-        reject(virusErr)
-        return
+        // destroy streams quietly without emitting 'error'
+        gatedStream.destroy()
+        tee.destroy()
+        return reject(virusErr)
       }
-    
+
       const unknownErr = new Error(`ClamAV scan failed: ${response.trim()}`)
-      gatedStream.destroy(unknownErr)
-      tee.destroy(unknownErr)
+      gatedStream.destroy()
+      tee.destroy()
       reject(unknownErr)
     })
-    
+
     // timeout
     const timeout = setTimeout(() => fail(new Error('ClamAV scan timed out')), CLAMAV_TIMEOUT_MS)
     const clearTimers = (): void => clearTimeout(timeout)
     clam.on('end', clearTimers)
     clam.on('error', clearTimers)
-
   })
 }

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -1,0 +1,56 @@
+import { Readable, PassThrough } from 'stream'
+import { spawn } from 'child_process'
+
+/**
+ * Takes a readable stream (Busboy file stream), scans it with ClamAV,
+ * and returns a new readable stream of the same content if clean.
+ * Throws an error if ClamAV finds a virus.
+ *
+ * Usage:
+ * const cleanStream = await scanAttachmentWithClamAV(uploadStream)
+ * cleanStream.pipe(storageStream)
+ */
+export async function scanAttachmentWithClamAV(inputStream: Readable): Promise<Readable> {
+  return new Promise((resolve, reject) => {
+    // Spawn ClamAV scan process: read from stdin, output to stdout, no summary
+    const clam = spawn('clamscan', ['--stdout', '--no-summary', '-'])
+
+    // Buffer to capture bytes from ClamAV stdout
+    const chunks: Buffer[] = []
+    
+    // Pipe the uploaded file into ClamAV stdin
+    inputStream.pipe(clam.stdin)
+
+    // Collect ClamAV stdout into chunks (this is the same file content)
+    clam.stdout.on('data', (chunk) => {
+      chunks.push(Buffer.from(chunk))
+    })
+
+    // Handle ClamAV process exit
+    clam.on('close', (code) => {
+      // Exit codes:
+      // 0 = no virus, 1 = virus found, >1 = error
+      if (code === 0) {
+        // File is clean: create a new PassThrough stream with the buffered bytes
+        const cleanStream = new PassThrough()
+        cleanStream.end(Buffer.concat(chunks))
+        resolve(cleanStream)
+      } else if (code === 1) {
+        reject(new Error('ClamAV detected a virus in the uploaded file'))
+      } else {
+        reject(new Error(`ClamAV error (exit code ${code})`))
+      }
+    })
+
+    // Handle spawn errors
+    clam.on('error', (err) => {
+      reject(err)
+    })
+
+    // Safety: handle input stream errors
+    inputStream.on('error', (err) => {
+      reject(err)
+      clam.kill()
+    })
+  })
+}

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -2,38 +2,31 @@ import { Readable, PassThrough } from 'stream'
 import { spawn } from 'child_process'
 
 /**
- * Takes a readable stream (Busboy file stream), scans it with ClamAV,
- * and returns a new readable stream of the same content if clean.
- * Throws an error if ClamAV finds a virus.
- *
- * Usage:
- * const cleanStream = await scanAttachmentWithClamAV(uploadStream)
- * cleanStream.pipe(storageStream)
+ * Scan an uploaded attachment using ClamAV **before writing to disk**.
+ * Streams bytes directly; no full-file buffering.
+ * 
+ * @param inputStream - Readable stream from Busboy
+ * @returns Promise<Readable> - clean stream to pass to storage
+ * @throws Error if virus detected or ClamAV fails
  */
 export async function scanAttachmentWithClamAV(inputStream: Readable): Promise<Readable> {
+  console.log('>>> CLAMAV SCAN STARTED <<<')
+
   return new Promise((resolve, reject) => {
-    // Spawn ClamAV scan process: read from stdin, output to stdout, no summary
     const clam = spawn('clamscan', ['--stdout', '--no-summary', '-'])
 
-    // Buffer to capture bytes from ClamAV stdout
-    const chunks: Buffer[] = []
-    
-    // Pipe the uploaded file into ClamAV stdin
+    // Clean PassThrough stream for downstream storage
+    const cleanStream = new PassThrough()
+
+    // Pipe input directly to ClamAV stdin
     inputStream.pipe(clam.stdin)
 
-    // Collect ClamAV stdout into chunks (this is the same file content)
-    clam.stdout.on('data', (chunk) => {
-      chunks.push(Buffer.from(chunk))
-    })
+    // Pipe ClamAV stdout to clean stream
+    clam.stdout.pipe(cleanStream)
 
-    // Handle ClamAV process exit
     clam.on('close', (code) => {
-      // Exit codes:
-      // 0 = no virus, 1 = virus found, >1 = error
       if (code === 0) {
-        // File is clean: create a new PassThrough stream with the buffered bytes
-        const cleanStream = new PassThrough()
-        cleanStream.end(Buffer.concat(chunks))
+        console.log('>>> CLAMAV SCAN CLEAN <<<')
         resolve(cleanStream)
       } else if (code === 1) {
         reject(new Error('ClamAV detected a virus in the uploaded file'))
@@ -42,15 +35,14 @@ export async function scanAttachmentWithClamAV(inputStream: Readable): Promise<R
       }
     })
 
-    // Handle spawn errors
     clam.on('error', (err) => {
-      reject(err)
+      reject(new Error(`Failed to start ClamAV: ${err.message}`))
     })
 
-    // Safety: handle input stream errors
+    // Ensure upstream errors kill ClamAV
     inputStream.on('error', (err) => {
-      reject(err)
       clam.kill()
+      reject(err)
     })
   })
 }

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -8,7 +8,6 @@ const CLAMAV_TIMEOUT_MS = 60_000
 export async function scanAttachmentWithClamAV(
   inputStream: Readable
 ): Promise<Readable> {
-  console.log('>>> CLAMAV SCAN STARTED <<<')
 
   return new Promise((resolve, reject) => {
     let settled = false
@@ -38,7 +37,6 @@ export async function scanAttachmentWithClamAV(
     let clamReady = false
 
     clam.on('connect', () => {
-      console.log('✅ Connected to ClamAV server')
       clamReady = true
       clam.write('zINSTREAM\0')
 
@@ -97,7 +95,6 @@ export async function scanAttachmentWithClamAV(
       if (settled) return
 
       if (response.includes('OK')) {
-        console.log('>>> CLAMAV SCAN CLEAN <<<')
         settled = true
         tee.pipe(gatedStream)
         gatedStream.resume()

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -29,7 +29,7 @@ export async function scanAttachmentWithClamAV(
       reject(err)
     }
 
-    // pipe input into tee
+    // pipe input to tee
     inputStream.pipe(tee)
     inputStream.on('error', (err) => fail(new Error(`Input stream error: ${err.message}`)))
     tee.on('error', (err) => fail(new Error(`Tee stream error: ${err.message}`)))
@@ -40,7 +40,7 @@ export async function scanAttachmentWithClamAV(
       clamReady = true
       clam.write('zINSTREAM\0')
 
-      // flush queued chunks
+      // flush chunks
       for (const chunk of writeQueue) {
         const size = Buffer.alloc(4)
         size.writeUInt32BE(chunk.length, 0)
@@ -65,7 +65,7 @@ export async function scanAttachmentWithClamAV(
       }
     })
 
-    // Only end ClamAV after all data sent
+    // end ClamAV after all data sent
     tee.on('end', () => {
       if (settled) return
       if (clamReady) {
@@ -86,7 +86,7 @@ export async function scanAttachmentWithClamAV(
       }
     })
 
-    // collect ClamAV response
+    // ClamAV response
     let response = ''
     clam.on('data', (chunk) => {
       const chunkStr = chunk.toString()
@@ -95,24 +95,31 @@ export async function scanAttachmentWithClamAV(
 
     clam.on('end', () => {
       if (settled) return
-
-
+    
+      settled = true // avoid double handling
+    
       if (response.includes('OK')) {
-        settled = true
         tee.pipe(gatedStream)
         gatedStream.resume()
         resolve(gatedStream)
         return
       }
-
+    
       if (response.includes('FOUND')) {
-        fail(new Error('ClamAV detected a virus in uploaded file'))
+        const virusErr = new Error('ClamAV detected a virus in uploaded file')
+        // reject gracefully
+        gatedStream.destroy(virusErr)
+        tee.destroy(virusErr)
+        reject(virusErr)
         return
       }
-
-      fail(new Error(`ClamAV scan failed: ${response.trim()}`))
+    
+      const unknownErr = new Error(`ClamAV scan failed: ${response.trim()}`)
+      gatedStream.destroy(unknownErr)
+      tee.destroy(unknownErr)
+      reject(unknownErr)
     })
-
+    
     // timeout
     const timeout = setTimeout(() => fail(new Error('ClamAV scan timed out')), CLAMAV_TIMEOUT_MS)
     const clearTimers = (): void => clearTimeout(timeout)

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -5,9 +5,6 @@ const CLAMAV_HOST = process.env.CLAMAV_HOST || 'localhost'
 const CLAMAV_PORT = Number(process.env.CLAMAV_PORT) || 3310
 const CLAMAV_TIMEOUT_MS = 60_000
 
-// LOG: CLAMAV host and port
-console.log(`[CLAMAV] Using host: ${CLAMAV_HOST}, port: ${CLAMAV_PORT}`)
-
 export async function scanAttachmentWithClamAV(
   inputStream: Readable
 ): Promise<Readable> {
@@ -49,7 +46,6 @@ export async function scanAttachmentWithClamAV(
 
     clam.on('connect', () => {
       clamReady = true
-      console.log('[CLAMAV] Connection established, ready to stream data')
 
       clam.write('zINSTREAM\0')
 
@@ -59,7 +55,6 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
-        console.log(`[CLAMAV] Queued chunk sent, size: ${chunk.length}`)
       }
       writeQueue.length = 0
     })
@@ -74,10 +69,8 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
-        console.log(`[CLAMAV] Chunk sent, size: ${chunk.length}`)
       } else {
         writeQueue.push(chunk)
-        console.log(`[CLAMAV] Chunk queued, size: ${chunk.length}`)
       }
     })
 
@@ -112,7 +105,6 @@ export async function scanAttachmentWithClamAV(
       settled = true
 
       if (response.includes('OK')) {
-        console.log('[CLAMAV] Scan result: OK, file is clean')
         tee.pipe(gatedStream)
         gatedStream.resume()
         resolve(gatedStream)
@@ -120,7 +112,6 @@ export async function scanAttachmentWithClamAV(
       }
 
       if (response.includes('FOUND')) {
-        console.log('[CLAMAV] Scan result: VIRUS FOUND')
         const virusErr = new Error('ClamAV detected a virus in uploaded file')
         gatedStream.destroy()
         tee.destroy()
@@ -128,7 +119,6 @@ export async function scanAttachmentWithClamAV(
       }
 
       const unknownErr = new Error(`ClamAV scan failed: ${response.trim()}`)
-      console.log('[CLAMAV] Scan result: UNKNOWN ERROR')
       gatedStream.destroy()
       tee.destroy()
       reject(unknownErr)

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -17,11 +17,14 @@ export async function scanAttachmentWithClamAV(
     const gatedStream = new PassThrough()
     gatedStream.pause()
 
+    console.log('🔹 [CLAMAV] Starting scan stream setup')
+
     const clam = net.createConnection({ host: CLAMAV_HOST, port: CLAMAV_PORT })
 
     const fail = (err: Error): void => {
       if (settled) return
       settled = true
+      console.log('❌ [CLAMAV] Scan failed:', err.message)
       inputStream.destroy(err)
       tee.destroy(err)
       gatedStream.destroy(err)
@@ -31,13 +34,14 @@ export async function scanAttachmentWithClamAV(
 
     // Pipe input into tee
     inputStream.pipe(tee)
-    inputStream.on('error', fail)
-    tee.on('error', fail)
+    inputStream.on('error', (err) => fail(new Error(`Input stream error: ${err.message}`)))
+    tee.on('error', (err) => fail(new Error(`Tee stream error: ${err.message}`)))
 
     let clamReady = false
 
     clam.on('connect', () => {
       clamReady = true
+      console.log(`🟢 [CLAMAV] Connected to ClamAV at ${CLAMAV_HOST}:${CLAMAV_PORT}`)
       clam.write('zINSTREAM\0')
 
       // Flush queued chunks
@@ -46,6 +50,7 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
+        console.log('🔹 [CLAMAV] Flushed queued chunk of size', chunk.length)
       }
       writeQueue.length = 0
     })
@@ -60,21 +65,23 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
+        console.log('🔹 [CLAMAV] Sent chunk of size', chunk.length)
       } else {
         writeQueue.push(chunk)
+        console.log('⚠️ [CLAMAV] Chunk queued, clam not ready yet, size', chunk.length)
       }
     })
 
     // Only end ClamAV after all data sent
     tee.on('end', () => {
       if (settled) return
+      console.log('🔹 [CLAMAV] Input stream ended, finalizing scan...')
       if (clamReady) {
         const zero = Buffer.alloc(4)
         zero.writeUInt32BE(0, 0)
         clam.write(zero)
         clam.end()
       } else {
-        // Wait for socket ready, then end
         const checkReady = setInterval(() => {
           if (clamReady) {
             clearInterval(checkReady)
@@ -89,13 +96,20 @@ export async function scanAttachmentWithClamAV(
 
     // Collect ClamAV response
     let response = ''
-    clam.on('data', (chunk) => (response += chunk.toString()))
+    clam.on('data', (chunk) => {
+      const chunkStr = chunk.toString()
+      response += chunkStr
+      console.log('🔹 [CLAMAV] Received response chunk:', chunkStr.trim())
+    })
 
     clam.on('end', () => {
       if (settled) return
 
+      console.log('🔹 [CLAMAV] ClamAV connection ended, full response:', response.trim())
+
       if (response.includes('OK')) {
         settled = true
+        console.log('🟢 [CLAMAV] Scan passed, file is clean')
         tee.pipe(gatedStream)
         gatedStream.resume()
         resolve(gatedStream)
@@ -115,5 +129,7 @@ export async function scanAttachmentWithClamAV(
     const clearTimers = (): void => clearTimeout(timeout)
     clam.on('end', clearTimers)
     clam.on('error', clearTimers)
+
+    console.log('🔹 [CLAMAV] Scan setup complete, streaming started')
   })
 }

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -5,9 +5,15 @@ const CLAMAV_HOST = process.env.CLAMAV_HOST || 'localhost'
 const CLAMAV_PORT = Number(process.env.CLAMAV_PORT) || 3310
 const CLAMAV_TIMEOUT_MS = 60_000
 
+export type AttachmentScanResult = {
+  status: 'success' | 'failed'
+  stream?: Readable
+  error?: string
+}
+
 export async function scanAttachmentWithClamAV(
   inputStream: Readable
-): Promise<Readable> {
+): Promise<AttachmentScanResult> {
 
   return new Promise((resolve, reject) => {
     let settled = false
@@ -107,21 +113,27 @@ export async function scanAttachmentWithClamAV(
       if (response.includes('OK')) {
         tee.pipe(gatedStream)
         gatedStream.resume()
-        resolve(gatedStream)
-        return
+        return resolve({
+          status: 'success',
+          stream: gatedStream
+        })
       }
 
       if (response.includes('FOUND')) {
-        const virusErr = new Error('ClamAV detected a virus in uploaded file')
         gatedStream.destroy()
         tee.destroy()
-        return reject(virusErr)
+        return resolve({
+          status: 'failed',
+          error: 'ClamAV detected a virus in uploaded file'
+        })
       }
 
-      const unknownErr = new Error(`ClamAV scan failed: ${response.trim()}`)
       gatedStream.destroy()
       tee.destroy()
-      reject(unknownErr)
+      return resolve({
+        status: 'failed',
+        error: `ClamAV scan failed: ${response.trim()}`
+      })
     })
 
     // timeout

--- a/service/src/adapters/observations/adapters.attachments.clamav.ts
+++ b/service/src/adapters/observations/adapters.attachments.clamav.ts
@@ -17,14 +17,11 @@ export async function scanAttachmentWithClamAV(
     const gatedStream = new PassThrough()
     gatedStream.pause()
 
-    console.log('🔹 [CLAMAV] Starting scan stream setup')
-
     const clam = net.createConnection({ host: CLAMAV_HOST, port: CLAMAV_PORT })
 
     const fail = (err: Error): void => {
       if (settled) return
       settled = true
-      console.log('❌ [CLAMAV] Scan failed:', err.message)
       inputStream.destroy(err)
       tee.destroy(err)
       gatedStream.destroy(err)
@@ -41,7 +38,6 @@ export async function scanAttachmentWithClamAV(
 
     clam.on('connect', () => {
       clamReady = true
-      console.log(`🟢 [CLAMAV] Connected to ClamAV at ${CLAMAV_HOST}:${CLAMAV_PORT}`)
       clam.write('zINSTREAM\0')
 
       // Flush queued chunks
@@ -50,7 +46,6 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
-        console.log('🔹 [CLAMAV] Flushed queued chunk of size', chunk.length)
       }
       writeQueue.length = 0
     })
@@ -65,17 +60,14 @@ export async function scanAttachmentWithClamAV(
         size.writeUInt32BE(chunk.length, 0)
         clam.write(size)
         clam.write(chunk)
-        console.log('🔹 [CLAMAV] Sent chunk of size', chunk.length)
       } else {
         writeQueue.push(chunk)
-        console.log('⚠️ [CLAMAV] Chunk queued, clam not ready yet, size', chunk.length)
       }
     })
 
     // Only end ClamAV after all data sent
     tee.on('end', () => {
       if (settled) return
-      console.log('🔹 [CLAMAV] Input stream ended, finalizing scan...')
       if (clamReady) {
         const zero = Buffer.alloc(4)
         zero.writeUInt32BE(0, 0)
@@ -99,17 +91,14 @@ export async function scanAttachmentWithClamAV(
     clam.on('data', (chunk) => {
       const chunkStr = chunk.toString()
       response += chunkStr
-      console.log('🔹 [CLAMAV] Received response chunk:', chunkStr.trim())
     })
 
     clam.on('end', () => {
       if (settled) return
 
-      console.log('🔹 [CLAMAV] ClamAV connection ended, full response:', response.trim())
 
       if (response.includes('OK')) {
         settled = true
-        console.log('🟢 [CLAMAV] Scan passed, file is clean')
         tee.pipe(gatedStream)
         gatedStream.resume()
         resolve(gatedStream)
@@ -130,6 +119,5 @@ export async function scanAttachmentWithClamAV(
     clam.on('end', clearTimers)
     clam.on('error', clearTimers)
 
-    console.log('🔹 [CLAMAV] Scan setup complete, streaming started')
   })
 }

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -129,51 +129,48 @@ export function ObservationRoutes(
             // Only scan if ClamAV is configured
             // ----------------------
             if (process.env.CLAM_AV_URL) {
-              try {
-                console.log('[DEBUG] Running ClamAV scan on uploaded attachment')
-                const scannedResult = await scanAttachmentWithClamAV(
-                  Readable.from(originalBuffer)
-                )
-
-                console.log(`[DEBUG] ClamAV scan result: ${scannedResult.status}`, scannedResult.error || '')
-
-                // ----------------------
-                // Verification hook: log pre-disk invariant
-                // ----------------------
-                console.log(`[VERIFY] Pre-disk invariant: file must be clean before storage`)
-
-                // ----------------------
-                // If scan succeeded, read from the gated stream
-                // ----------------------
-                if (scannedResult.status === 'clean' && scannedResult.stream){
-                  const scannedChunks: Buffer[] = []
-                  for await (const chunk of scannedResult.stream) {
-                    scannedChunks.push(chunk as Buffer)
+              const maxRetries = 3
+              let attempt = 0
+              let scanSuccess = false
+              let scanErrorMsg = ''
+              let scannedBuffer: Buffer | null = null
+            
+              while (attempt < maxRetries && !scanSuccess) {
+                attempt++
+                try {
+                  console.log(`[DEBUG] ClamAV scan attempt ${attempt}`)
+                  const scannedResult = await scanAttachmentWithClamAV(Readable.from(originalBuffer))
+                  console.log(`[DEBUG] ClamAV scan result: ${scannedResult.status}`, scannedResult.error || '')
+            
+                  if (scannedResult.status === 'clean' && scannedResult.stream) {
+                    const chunks: Buffer[] = []
+                    for await (const chunk of scannedResult.stream) {
+                      chunks.push(chunk as Buffer)
+                    }
+                    scannedBuffer = Buffer.concat(chunks)
+                    scanSuccess = true
+                    console.log('[VERIFY] Scan clean: proceeding to storage')
+                  } else {
+                    scanErrorMsg = scannedResult.error || 'File rejected by ClamAV'
+                    scanSuccess = false
                   }
-                  const scannedBuffer = Buffer.concat(scannedChunks)
-                  console.log(`[DEBUG] Scanned buffer length: ${scannedBuffer.length}`)
-                  if (scannedBuffer.length > 0) {
-                    finalBuffer = scannedBuffer
-                  }
-                  console.log('[VERIFY] Scan clean: proceeding to storage')
-                } else {
-                  // ----------------------
-                  // Handle failed scan: return proper API error
-                  // ----------------------
-                  console.log('[WARN] Attachment rejected by ClamAV scan')
-                  return next(
-                    invalidInput(
-                      scannedResult.error || 'Uploaded file contains a virus and cannot be stored.'
-                    )
-                  )
+                } catch (err) {
+                  console.error(`[WARN] ClamAV scan attempt ${attempt} failed:`, err)
+                  scanErrorMsg = 'Virus scanning server unavailable'
                 }
-              } catch (err) {
-                // Catch unexpected errors in the scanning process
-                console.error('[ERROR] Unexpected ClamAV scan error:', err)
-                return next(
-                  invalidInput('Error occurred during attachment scan. Upload aborted.')
-                )
+            
+                if (!scanSuccess && attempt < maxRetries) {
+                  console.log(`[DEBUG] Retrying ClamAV scan in 500ms...`)
+                  await new Promise(r => setTimeout(r, 500))
+                }
               }
+            
+              if (!scanSuccess) {
+                console.log('[ERROR] All ClamAV scan attempts failed')
+                return next(invalidInput(scanErrorMsg))
+              }
+            
+              if (scannedBuffer) finalBuffer = scannedBuffer
             }
 
             // ----------------------

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -156,7 +156,8 @@ export function ObservationRoutes(
 
                 if (!scanSuccess) {
                   console.debug(`[ObservationRoutes] Upload rejected by ClamAV for ${info.filename}`)
-                  uploadError = { message: scanErrorMsg, errorCode: 'ClamAVDetectedVirus' }
+                  fileStream.resume() 
+                  uploadError = { message: scanErrorMsg, errorCode: 'ClamAVUnavailable' }
                   return
                 }
 

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+// ----------------------
+// Imports
+// ----------------------
 import { scanAttachmentWithClamAV } from './adapters.attachments.clamav'
 import { Readable } from 'stream'
 import express from 'express'
@@ -26,12 +30,18 @@ import busboy from 'busboy'
 import { invalidInput } from '../../app.api/app.api.errors'
 import { exoObservationModFromJson } from './adapters.observations.dto.ecma404-json'
 
+// ----------------------
+// Extend Express Request
+// ----------------------
 declare module 'express-serve-static-core' {
   interface Request {
     attachmentUpload?: busboy.Busboy
   }
 }
 
+// ----------------------
+// App Layer Interfaces
+// ----------------------
 export interface ObservationAppLayer {
   allocateObservationId: AllocateObservationId
   saveObservation: SaveObservation
@@ -39,14 +49,20 @@ export interface ObservationAppLayer {
   readAttachmentContent: ReadAttachmentContent
 }
 
+// Factory type for creating app-layer request objects
 export type ObservationWebAppRequestFactory = <Params extends object>(
   req: express.Request,
   params?: Params
 ) => Params & ObservationRequest<unknown>
+
+// Helper type to ensure an event scope exists for this request
 export type EnsureEventScope = (
   eventId: MageEventId
 ) => Promise<null | { mageEvent: MageEvent; observationRepository: EventScopedObservationRepository }>
 
+// ----------------------
+// Main Router
+// ----------------------
 export function ObservationRoutes(
   app: ObservationAppLayer,
   attachmentStore: AttachmentStore,
@@ -55,7 +71,7 @@ export function ObservationRoutes(
   const routes = express.Router()
 
   // --------------------------------------
-  // Allocate Observation ID
+  // Allocate Observation ID route
   // --------------------------------------
   routes.route('/id').post(async (req, res, next) => {
     try {
@@ -83,6 +99,7 @@ export function ObservationRoutes(
     .route('/:observationId/attachments/:attachmentId')
     .put(async (req, res, next) => {
       try {
+        // Initialize Busboy to handle multipart/form-data file upload
         const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
         let handled = false
 
@@ -96,37 +113,66 @@ export function ObservationRoutes(
           }
 
           try {
-            // buffer the uploaded file
+            // ----------------------
+            // Buffer the uploaded file into memory
+            // ----------------------
             const originalChunks: Buffer[] = []
             for await (const chunk of fileStream) {
               originalChunks.push(chunk as Buffer)
             }
             const originalBuffer = Buffer.concat(originalChunks)
+            console.log(`[DEBUG] Original uploaded file: ${info.filename}, size=${originalBuffer.length} bytes`)
 
             let finalBuffer = originalBuffer
 
+            // ----------------------
             // Only scan if ClamAV is configured
+            // ----------------------
             if (process.env.CLAM_AV_URL) {
               try {
-                const scannedStream = await scanAttachmentWithClamAV(
+                console.log('[DEBUG] Running ClamAV scan on uploaded attachment')
+                const scannedResult = await scanAttachmentWithClamAV(
                   Readable.from(originalBuffer)
                 )
-            
-                const scannedChunks: Buffer[] = []
-                for await (const chunk of scannedStream) {
-                  scannedChunks.push(chunk as Buffer)
+
+                console.log(`[DEBUG] ClamAV scan result: ${scannedResult.status}`, scannedResult.error || '')
+
+                // ----------------------
+                // If scan succeeded, read from the gated stream
+                // ----------------------
+                if (scannedResult.status === 'success' && scannedResult.stream) {
+                  const scannedChunks: Buffer[] = []
+                  for await (const chunk of scannedResult.stream) {
+                    scannedChunks.push(chunk as Buffer)
+                  }
+                  const scannedBuffer = Buffer.concat(scannedChunks)
+                  console.log(`[DEBUG] Scanned buffer length: ${scannedBuffer.length}`)
+                  if (scannedBuffer.length > 0) {
+                    finalBuffer = scannedBuffer
+                  }
+                } else {
+                  // ----------------------
+                  // Handle failed scan: return proper API error
+                  // ----------------------
+                  console.log('[WARN] ClamAV scan failed, rejecting upload')
+                  return next(
+                    invalidInput(
+                      scannedResult.error || 'Uploaded file contains a virus and cannot be stored.'
+                    )
+                  )
                 }
-            
-                const scannedBuffer = Buffer.concat(scannedChunks)
-                if (scannedBuffer.length > 0) {
-                  finalBuffer = scannedBuffer
-                }
-              } catch {
+              } catch (err) {
+                // Catch unexpected errors in the scanning process
+                console.error('[ERROR] Unexpected ClamAV scan error:', err)
                 return next(
-                  invalidInput('Uploaded file contains a virus and cannot be stored.')
+                  invalidInput('Error occurred during attachment scan. Upload aborted.')
                 )
               }
             }
+
+            // ----------------------
+            // Prepare content object to store attachment
+            // ----------------------
             const { observationId, attachmentId } = req.params
             const content: ExoIncomingAttachmentContent = {
               bytes: Readable.from(finalBuffer),
@@ -142,12 +188,16 @@ export function ObservationRoutes(
             const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
             const appRes = await app.storeAttachmentContent(appReq)
 
+            // ----------------------
+            // Return JSON for the newly stored attachment
+            // ----------------------
             if (appRes.success) {
               const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
               const attachmentJson = jsonForAttachment(
                 attachment,
                 `${qualifiedBaseUrl(req)}/${observationId}`
               )
+              console.log('[DEBUG] Attachment stored successfully:', attachmentJson)
               return res.json(attachmentJson)
             }
 
@@ -158,11 +208,15 @@ export function ObservationRoutes(
           }
         })
 
+        // ----------------------
+        // Handle unexpected form fields or limits
+        // ----------------------
         bb.on('field', (name) => next(invalidInput(`unexpected form field: ${name}`)))
         bb.on('filesLimit', () => next(invalidInput(`too many files`)))
         bb.on('fieldsLimit', () => next(invalidInput(`too many fields`)))
         bb.on('error', (err) => next(err))
 
+        // Pipe request stream into Busboy
         req.pipe(bb)
       } catch (err) {
         next(err)
@@ -170,6 +224,9 @@ export function ObservationRoutes(
     })
     .get(async (req, res, next) => {
       try {
+        // ----------------------
+        // Handle range queries and image resizing (minDimension)
+        // ----------------------
         const sizeParam = req.query.size
         const minDimension =
           typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined
@@ -218,6 +275,9 @@ export function ObservationRoutes(
       }
     })
     .delete(async (req, res) => {
+      // ----------------------
+      // Delete attachment route (204 No Content)
+      // ----------------------
       res.sendStatus(204)
     })
 
@@ -228,21 +288,28 @@ export function ObservationRoutes(
     try {
       const body = req.body
       const observationId = req.params.observationId
+
+      // Ensure path ID matches body ID
       if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== observationId) {
         return res
           .status(400)
           .json({ message: 'Body observation ID does not match path observation ID' })
       }
+
+      // Parse observation modification
       const mod = exoObservationModFromJson({ ...body, id: observationId })
       if (mod instanceof Error) return next(mod)
 
       const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
+
+      // Ensure body event ID matches path event ID
       if (
         Object.prototype.hasOwnProperty.call(body, 'eventId') &&
         body.eventId !== appReq.context.mageEvent.id
       ) {
         return res.status(400).json({ message: 'Body event ID does not match path event ID' })
       }
+
       const appRes = await app.saveObservation(appReq)
       if (appRes.success) return res.json(jsonForObservation(appRes.success, qualifiedBaseUrl(req)))
       next(appRes.error)
@@ -251,11 +318,14 @@ export function ObservationRoutes(
     }
   })
 
+  // --------------------------------------
+  // Apply global error handler
+  // --------------------------------------
   return routes.use(compatibilityMageAppErrorHandler)
 }
 
 // ----------------------
-// JSON serialization
+// JSON serialization helpers
 // ----------------------
 export type WebObservation = Omit<ExoObservation, 'attachments' | 'state'> & {
   url: string
@@ -280,6 +350,9 @@ export function jsonForAttachment(a: ExoAttachment, observationUrl: string): Web
   return { ...a, url: a.contentStored ? `${observationUrl}/attachments/${a.id}` : void 0 }
 }
 
+// ----------------------
+// Helper: construct base URL
+// ----------------------
 function qualifiedBaseUrl(req: express.Request): string {
   return req.getRoot() + req.baseUrl
 }

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -80,111 +80,130 @@ export function ObservationRoutes(
   // Attachment upload / download / delete
   // --------------------------------------
   routes
-    .route('/:observationId/attachments/:attachmentId')
-    .put(async (req, res, next) => {
-      try {
-        const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
-        let handled = false
+  .route('/:observationId/attachments/:attachmentId')
+  .put(async (req, res, next) => {
+    try {
+      console.log('[DEBUG] PUT /attachments handler invoked')
+      const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
+      let handled = false
 
-        bb.on('file', async (fieldName, fileStream, info) => {
-          if (handled) {
-            return fileStream.resume()
+      bb.on('file', async (fieldName, fileStream, info) => {
+        console.log(`[DEBUG] file event received: fieldName=${fieldName}, filename=${info.filename}, mimeType=${info.mimeType}`)
+        if (handled) {
+          console.log('[DEBUG] already handled a file, skipping this one')
+          return fileStream.resume()
+        }
+        handled = true
+
+        if (fieldName !== 'attachment') {
+          console.log('[DEBUG] invalid fieldName, expected "attachment"')
+          fileStream.resume()
+          return next(invalidInput(`request must contain only one file part named 'attachment'`))
+        }
+
+        try {
+          // buffer the uploaded file
+          const originalChunks: Buffer[] = []
+          for await (const chunk of fileStream) {
+            console.log(`[DEBUG] buffering chunk: ${chunk.length} bytes`)
+            originalChunks.push(chunk as Buffer)
           }
-          handled = true
+          const originalBuffer = Buffer.concat(originalChunks)
+          console.log(`[DEBUG] total original buffer length: ${originalBuffer.length}`)
 
-          if (fieldName !== 'attachment') {
-            fileStream.resume()
-            return next(invalidInput(`request must contain only one file part named 'attachment'`))
-          }
-
+          // scan with ClamAV
+          const passThrough = Readable.from(originalBuffer)
+          let scannedStream: Readable
           try {
-            // buffer the uploaded file
-            const originalChunks: Buffer[] = []
-            for await (const chunk of fileStream) {
-              originalChunks.push(chunk as Buffer)
-            }
-            const originalBuffer = Buffer.concat(originalChunks)
-
-            // scan with ClamAV
-            const passThrough = Readable.from(originalBuffer)
-            let scannedStream: Readable
-            try {
-              scannedStream = await scanAttachmentWithClamAV(passThrough)
-            } catch (err) {
-              console.warn('[DEBUG] ClamAV rejected file:', err)
-              return next(invalidInput('Uploaded file contains a virus and cannot be stored.'))
-            }
-
-            // handle any emitted errors on scanned stream
-            scannedStream.on('error', (err) => {
-              console.warn('[DEBUG] Error emitted from scanned stream:', err)
-              return next(invalidInput('Uploaded file contains a virus or could not be scanned.'))
-            })
-
-            // buffer scanned output
-            const scannedChunks: Buffer[] = []
-            for await (const chunk of scannedStream) {
-              scannedChunks.push(chunk as Buffer)
-            }
-            let finalBuffer = Buffer.concat(scannedChunks)
-
-            // fallback if scanned result is empty
-            if (finalBuffer.length === 0) {
-              finalBuffer = originalBuffer
-            }
-
-            const { observationId, attachmentId } = req.params
-            const content: ExoIncomingAttachmentContent = {
-              bytes: Readable.from(finalBuffer),
-              mediaType: info.mimeType,
-              name: info.filename
-            }
-
-            const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
-              observationId,
-              attachmentId,
-              content
-            }
-            const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
-            const appRes = await app.storeAttachmentContent(appReq)
-
-            if (appRes.success) {
-              const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
-              const attachmentJson = jsonForAttachment(
-                attachment,
-                `${qualifiedBaseUrl(req)}/${observationId}`
-              )
-              return res.json(attachmentJson)
-            }
-
-            if (appRes.error) {
-              return next(appRes.error)
-            }
-
-            next(invalidInput('Attachment could not be stored'))
+            console.log('[DEBUG] sending file to ClamAV for scanning...')
+            scannedStream = await scanAttachmentWithClamAV(passThrough)
+            console.log('[DEBUG] ClamAV scan completed successfully')
           } catch (err) {
-            return next(err)
+            console.warn('[DEBUG] ClamAV rejected file:', err)
+            return next(invalidInput('Uploaded file contains a virus and cannot be stored.'))
           }
-        })
 
-        bb.on('field', (name) => {
-          return next(invalidInput(`unexpected form field: ${name}`))
-        })
-        bb.on('filesLimit', () => {
-          return next(invalidInput(`too many files`))
-        })
-        bb.on('fieldsLimit', () => {
-          return next(invalidInput(`too many fields`))
-        })
-        bb.on('error', (err) => {
+          scannedStream.on('error', (err) => {
+            console.warn('[DEBUG] Error emitted from scanned stream:', err)
+            return next(invalidInput('Uploaded file contains a virus or could not be scanned.'))
+          })
+
+          // buffer scanned output
+          const scannedChunks: Buffer[] = []
+          for await (const chunk of scannedStream) {
+            console.log(`[DEBUG] buffering scanned chunk: ${chunk.length} bytes`)
+            scannedChunks.push(chunk as Buffer)
+          }
+          let finalBuffer = Buffer.concat(scannedChunks)
+          console.log(`[DEBUG] final buffer length after scanning: ${finalBuffer.length}`)
+
+          if (finalBuffer.length === 0) {
+            console.log('[DEBUG] scanned buffer empty, falling back to original buffer')
+            finalBuffer = originalBuffer
+          }
+
+          const { observationId, attachmentId } = req.params
+          const content: ExoIncomingAttachmentContent = {
+            bytes: Readable.from(finalBuffer),
+            mediaType: info.mimeType,
+            name: info.filename
+          }
+
+          console.log(`[DEBUG] storing attachment: observationId=${observationId}, attachmentId=${attachmentId}`)
+          const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
+            observationId,
+            attachmentId,
+            content
+          }
+          const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
+          const appRes = await app.storeAttachmentContent(appReq)
+
+          if (appRes.success) {
+            console.log('[DEBUG] attachment stored successfully')
+            const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
+            const attachmentJson = jsonForAttachment(
+              attachment,
+              `${qualifiedBaseUrl(req)}/${observationId}`
+            )
+            return res.json(attachmentJson)
+          }
+
+          if (appRes.error) {
+            console.log('[DEBUG] storeAttachmentContent returned error:', appRes.error)
+            return next(appRes.error)
+          }
+
+          next(invalidInput('Attachment could not be stored'))
+        } catch (err) {
+          console.error('[DEBUG] unexpected error in file handling:', err)
           return next(err)
-        })
+        }
+      })
 
-        req.pipe(bb)
-      } catch (err) {
+      bb.on('field', (name) => {
+        console.log(`[DEBUG] unexpected form field received: ${name}`)
+        return next(invalidInput(`unexpected form field: ${name}`))
+      })
+      bb.on('filesLimit', () => {
+        console.log('[DEBUG] files limit exceeded')
+        return next(invalidInput(`too many files`))
+      })
+      bb.on('fieldsLimit', () => {
+        console.log('[DEBUG] fields limit exceeded')
+        return next(invalidInput(`too many fields`))
+      })
+      bb.on('error', (err) => {
+        console.error('[DEBUG] busboy error:', err)
         return next(err)
-      }
-    })
+      })
+
+      req.pipe(bb)
+    } catch (err) {
+      console.error('[DEBUG] unexpected error in PUT handler:', err)
+      return next(err)
+    }
+  })
+
     .get(async (req, res, next) => {
       try {
         const sizeParam = req.query.size

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -26,7 +26,6 @@ import busboy from 'busboy'
 import { invalidInput } from '../../app.api/app.api.errors'
 import { exoObservationModFromJson } from './adapters.observations.dto.ecma404-json'
 
-
 declare module 'express-serve-static-core' {
   interface Request {
     attachmentUpload?: busboy.Busboy
@@ -59,18 +58,25 @@ export function ObservationRoutes(
   // Allocate Observation ID
   // --------------------------------------
   routes.route('/id').post(async (req, res, next) => {
-    const appReq = createAppRequest(req)
-    const appRes = await app.allocateObservationId(appReq)
-    const id = appRes.success
-    const path = `${req.baseUrl}/${id}`
-    if (id) {
-      return res.status(201).location(path).json({
-        id,
-        eventId: appReq.context.mageEvent.id,
-        url: `${req.getRoot()}${path}`
-      })
+    try {
+      const appReq = createAppRequest(req)
+      console.log('🔹 [DEBUG] Allocating observation ID, appReq:', appReq)
+      const appRes = await app.allocateObservationId(appReq)
+      const id = appRes.success
+      const path = `${req.baseUrl}/${id}`
+      if (id) {
+        console.log('🟢 [DEBUG] Allocated observation ID:', id)
+        return res.status(201).location(path).json({
+          id,
+          eventId: appReq.context.mageEvent.id,
+          url: `${req.getRoot()}${path}`
+        })
+      }
+      next(appRes.error)
+    } catch (err) {
+      console.log('❌ [DEBUG] Exception in /id route:', err)
+      next(err)
     }
-    next(appRes.error)
   })
 
   // --------------------------------------
@@ -80,23 +86,57 @@ export function ObservationRoutes(
     .route('/:observationId/attachments/:attachmentId')
     .put(async (req, res, next) => {
       try {
+        console.log('🔹 [DEBUG] Incoming attachment PUT request:', req.params)
         const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
         let handled = false
 
         bb.on('file', async (fieldName, fileStream, info) => {
-          if (handled) return fileStream.resume()
+          console.log('🔹 [DEBUG] Busboy received file field: ', fieldName, info)
+          if (handled) {
+            console.log('⚠️ [DEBUG] Already handled a file, skipping extra stream')
+            return fileStream.resume()
+          }
           handled = true
 
           if (fieldName !== 'attachment') {
+            console.log('⚠️ [DEBUG] Unexpected field name, rejecting file')
             fileStream.resume()
             return next(invalidInput(`request must contain only one file part named 'attachment'`))
           }
 
           try {
-            const cleanStream: Readable = await scanAttachmentWithClamAV(fileStream)
+            // -----------------------------
+            // FIX: Guarantee file has bytes
+            // -----------------------------
+            // Step 1: fully buffer the uploaded file
+            const originalChunks: Buffer[] = []
+            for await (const chunk of fileStream) {
+              originalChunks.push(chunk as Buffer)
+            }
+            const originalBuffer = Buffer.concat(originalChunks)
+            console.log('🔹 [DEBUG] Buffered original file size:', originalBuffer.length)
+
+            // Step 2: scan with ClamAV
+            const passThrough = Readable.from(originalBuffer)
+            const scannedStream: Readable = await scanAttachmentWithClamAV(passThrough)
+
+            // Step 3: buffer scanned output
+            const scannedChunks: Buffer[] = []
+            for await (const chunk of scannedStream) {
+              scannedChunks.push(chunk as Buffer)
+            }
+            let finalBuffer = Buffer.concat(scannedChunks)
+            console.log('🔹 [DEBUG] Scanned file size:', finalBuffer.length)
+
+            // Step 4: fallback if scanned result is empty
+            if (finalBuffer.length === 0) {
+              console.log('⚠️ [DEBUG] Scanned file empty, using original buffer')
+              finalBuffer = originalBuffer
+            }
+
             const { observationId, attachmentId } = req.params
             const content: ExoIncomingAttachmentContent = {
-              bytes: cleanStream,
+              bytes: Readable.from(finalBuffer),
               mediaType: info.mimeType,
               name: info.filename
             }
@@ -107,7 +147,9 @@ export function ObservationRoutes(
               content
             }
             const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
+            console.log('🔹 [DEBUG] Prepared content object for storage:', content)
             const appRes = await app.storeAttachmentContent(appReq)
+            console.log('🟢 [DEBUG] storeAttachmentContent response:', appRes)
 
             if (appRes.success) {
               const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
@@ -115,64 +157,108 @@ export function ObservationRoutes(
                 attachment,
                 `${qualifiedBaseUrl(req)}/${observationId}`
               )
+              console.log('🟢 [DEBUG] Returning attachment JSON:', attachmentJson)
               return res.json(attachmentJson)
             }
 
-            if (appRes.error) return next(appRes.error)
+            if (appRes.error) {
+              console.log('❌ [DEBUG] Error storing attachment:', appRes.error)
+              return next(appRes.error)
+            }
+
             next(invalidInput('Attachment could not be stored'))
           } catch (err) {
+            console.log('❌ [DEBUG] Exception during file handling:', err)
             return next(err)
           }
         })
 
-        bb.on('field', () => next(invalidInput(`unexpected form field`)))
-        bb.on('filesLimit', () => next(invalidInput(`too many files`)))
-        bb.on('fieldsLimit', () => next(invalidInput(`too many fields`)))
-        bb.on('error', (err) => next(err))
+        bb.on('field', (name, val) => {
+          console.log('🔹 [DEBUG] Unexpected form field detected:', name, val)
+          next(invalidInput(`unexpected form field`))
+        })
+        bb.on('filesLimit', () => {
+          console.log('⚠️ [DEBUG] Busboy filesLimit reached')
+          next(invalidInput(`too many files`))
+        })
+        bb.on('fieldsLimit', () => {
+          console.log('⚠️ [DEBUG] Busboy fieldsLimit reached')
+          next(invalidInput(`too many fields`))
+        })
+        bb.on('error', (err) => {
+          console.log('❌ [DEBUG] Busboy error:', err)
+          next(err)
+        })
 
         req.pipe(bb)
       } catch (err) {
+        console.log('❌ [DEBUG] Exception in attachment PUT route:', err)
         next(err)
       }
     })
     .get(async (req, res, next) => {
-      const sizeParam = req.query.size;
-      const minDimension =
-        typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined;
-      
-      const contentRange = req.headers.range
-        ? req.headers.range
-            .replace(/bytes=/i, '')
-            .split('-')
-            .map(x => parseInt(x, 10))
-            .filter(x => typeof x === 'number' && !Number.isNaN(x))
-        : []
-      const appReq: ReadAttachmentContentRequest = createAppRequest(req, {
-        observationId: req.params.observationId,
-        attachmentId: req.params.attachmentId,
-        minDimension,
-        contentRange:
-          contentRange.length === 2 ? { start: contentRange[0], end: contentRange[1] } : undefined
-      })
-      const appRes = await app.readAttachmentContent(appReq)
-      if (appRes.error) return next(appRes.error)
-      const content = appRes.success
-      if (!content) return res.status(500).json({ message: 'unknown application response' })
-      const { bytesRange } = content
-      const headers: any = {
-        'content-type': String(content.attachment.contentType),
-        'content-length': String(
-          bytesRange ? bytesRange.end - bytesRange.start + 1 : content.attachment.size!
-        )
+      try {
+        console.log('🔹 [DEBUG] Attachment GET request:', req.params, req.query)
+        const sizeParam = req.query.size;
+        const minDimension =
+          typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined;
+        
+        const contentRange = req.headers.range
+          ? req.headers.range
+              .replace(/bytes=/i, '')
+              .split('-')
+              .map(x => parseInt(x, 10))
+              .filter(x => typeof x === 'number' && !Number.isNaN(x))
+          : []
+        console.log('🔹 [DEBUG] Parsed contentRange:', contentRange)
+
+        const appReq: ReadAttachmentContentRequest = createAppRequest(req, {
+          observationId: req.params.observationId,
+          attachmentId: req.params.attachmentId,
+          minDimension,
+          contentRange:
+            contentRange.length === 2 ? { start: contentRange[0], end: contentRange[1] } : undefined
+        })
+        const appRes = await app.readAttachmentContent(appReq)
+        if (appRes.error) {
+          console.log('❌ [DEBUG] readAttachmentContent returned error:', appRes.error)
+          return next(appRes.error)
+        }
+
+        const content = appRes.success
+        if (!content) {
+          console.log('⚠️ [DEBUG] readAttachmentContent returned no content')
+          return res.status(500).json({ message: 'unknown application response' })
+        }
+
+        const { bytesRange } = content
+        const headers: any = {
+          'content-type': String(content.attachment.contentType)
+        }
+
+        if (content.attachment.size && content.attachment.size > 0) {
+          headers['content-length'] = String(
+            bytesRange
+              ? bytesRange.end - bytesRange.start + 1
+              : content.attachment.size
+          )
+        }
+
+        if (bytesRange) {
+          headers['content-range'] = `bytes ${bytesRange.start}-${bytesRange.end}/${
+            content.attachment.size || '*'
+          }`
+        }
+
+        console.log('🔹 [DEBUG] Sending attachment bytes with headers:', headers)
+        return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
+      } catch (err) {
+        console.log('❌ [DEBUG] Exception in attachment GET route:', err)
+        next(err)
       }
-      if (bytesRange) {
-        headers['content-range'] = `bytes ${bytesRange.start}-${bytesRange.end}/${
-          content.attachment.size || '*'
-        }`
-      }
-      return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
     })
     .delete(async (req, res) => {
+      console.log('🔹 [DEBUG] Attachment DELETE request:', req.params)
       res.sendStatus(204)
     })
 
@@ -180,25 +266,37 @@ export function ObservationRoutes(
   // Update Observation
   // --------------------------------------
   routes.route('/:observationId').put(async (req, res, next) => {
-    const body = req.body
-    const observationId = req.params.observationId
-    if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== observationId) {
-      return res
-        .status(400)
-        .json({ message: 'Body observation ID does not match path observation ID' })
+    try {
+      console.log('🔹 [DEBUG] Update Observation PUT request:', req.params, req.body)
+      const body = req.body
+      const observationId = req.params.observationId
+      if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== observationId) {
+        console.log('⚠️ [DEBUG] Body observation ID mismatch:', body.id, observationId)
+        return res
+          .status(400)
+          .json({ message: 'Body observation ID does not match path observation ID' })
+      }
+      const mod = exoObservationModFromJson({ ...body, id: observationId })
+      if (mod instanceof Error) {
+        console.log('❌ [DEBUG] Failed to create observation mod:', mod)
+        return next(mod)
+      }
+      const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
+      if (
+        Object.prototype.hasOwnProperty.call(body, 'eventId') &&
+        body.eventId !== appReq.context.mageEvent.id
+      ) {
+        console.log('⚠️ [DEBUG] Body event ID mismatch:', body.eventId, appReq.context.mageEvent.id)
+        return res.status(400).json({ message: 'Body event ID does not match path event ID' })
+      }
+      const appRes = await app.saveObservation(appReq)
+      console.log('🟢 [DEBUG] saveObservation response:', appRes)
+      if (appRes.success) return res.json(jsonForObservation(appRes.success, qualifiedBaseUrl(req)))
+      next(appRes.error)
+    } catch (err) {
+      console.log('❌ [DEBUG] Exception in Update Observation route:', err)
+      next(err)
     }
-    const mod = exoObservationModFromJson({ ...body, id: observationId })
-    if (mod instanceof Error) return next(mod)
-    const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
-    if (
-      Object.prototype.hasOwnProperty.call(body, 'eventId') &&
-      body.eventId !== appReq.context.mageEvent.id
-    ) {
-      return res.status(400).json({ message: 'Body event ID does not match path event ID' })
-    }
-    const appRes = await app.saveObservation(appReq)
-    if (appRes.success) return res.json(jsonForObservation(appRes.success, qualifiedBaseUrl(req)))
-    next(appRes.error)
   })
 
   return routes.use(compatibilityMageAppErrorHandler)

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -1,19 +1,46 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { scanAttachmentWithClamAV } from './adapters.attachments.clamav'
+import { Readable } from 'stream'
 import express from 'express'
 import { compatibilityMageAppErrorHandler } from '../adapters.controllers.web'
-import { AllocateObservationId, ExoAttachment, ExoIncomingAttachmentContent, ExoObservation, ObservationRequest, ReadAttachmentContent, ReadAttachmentContentRequest, SaveObservation, SaveObservationRequest, StoreAttachmentContent, StoreAttachmentContentRequest } from '../../app.api/observations/app.api.observations'
-import { AttachmentStore, EventScopedObservationRepository, ObservationState } from '../../entities/observations/entities.observations'
+import {
+  AllocateObservationId,
+  ExoAttachment,
+  ExoIncomingAttachmentContent,
+  ExoObservation,
+  ObservationRequest,
+  ReadAttachmentContent,
+  ReadAttachmentContentRequest,
+  SaveObservation,
+  SaveObservationRequest,
+  StoreAttachmentContent,
+  StoreAttachmentContentRequest
+} from '../../app.api/observations/app.api.observations'
+import {
+  AttachmentStore,
+  EventScopedObservationRepository,
+  ObservationState
+} from '../../entities/observations/entities.observations'
 import { MageEvent, MageEventId } from '../../entities/events/entities.events'
 import busboy from 'busboy'
 import { invalidInput } from '../../app.api/app.api.errors'
 import { exoObservationModFromJson } from './adapters.observations.dto.ecma404-json'
-import { scanAttachmentWithClamAV } from './adapters.attachments.clamav'
 
 declare module 'express-serve-static-core' {
   interface Request {
     attachmentUpload: busboy.Busboy | null
   }
 }
+
+// -------------------------------
+// PLAN FOR PRE-DISK CLAMAV SCAN
+// -------------------------------
+// 1. 'stream' is the first point we have the uploaded file bytes (BLOB in memory or pipe)
+// 2. Pipe 'stream' through ClamAV before writing anything to disk
+// 3. Fail fast if ClamAV detects infection: reject request, do NOT persist bytes or metadata
+// 4. Only after ClamAV scan passes, pass the clean stream to storeAttachmentContent()
+// 5. storeAttachmentContent() handles fs.move() and Mongo metadata commit
+// -------------------------------
 
 export interface ObservationAppLayer {
   allocateObservationId: AllocateObservationId
@@ -22,137 +49,188 @@ export interface ObservationAppLayer {
   readAttachmentContent: ReadAttachmentContent
 }
 
-export type ObservationWebAppRequestFactory = <Params extends object>(req: express.Request, params?: Params) => Params & ObservationRequest<unknown>
-export type EnsureEventScope = (eventId: MageEventId) => Promise<null | { mageEvent: MageEvent, observationRepository: EventScopedObservationRepository }>
-export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: AttachmentStore, createAppRequest: ObservationWebAppRequestFactory): express.Router {
+export type ObservationWebAppRequestFactory = <Params extends object>(
+  req: express.Request,
+  params?: Params
+) => Params & ObservationRequest<unknown>
+export type EnsureEventScope = (
+  eventId: MageEventId
+) => Promise<null | { mageEvent: MageEvent; observationRepository: EventScopedObservationRepository }>
 
-  const routes = express.Router().use(express.json())
+export function ObservationRoutes(
+  app: ObservationAppLayer,
+  attachmentStore: AttachmentStore,
+  createAppRequest: ObservationWebAppRequestFactory
+): express.Router {
+  console.error('🔥 ObservationRoutes() invoked')
+  const routes = express.Router();
+
 
   // --------------------------------------
   // Allocate Observation ID
   // --------------------------------------
-  routes.route('/id')
-    .post(async (req, res, next) => {
-      const appReq = createAppRequest(req)
-      const appRes = await app.allocateObservationId(appReq)
-      const id = appRes.success
-      const path = `${req.baseUrl}/${id}`
-      if (id) {
-        return res.status(201).location(path).json({
-          id,
-          eventId: appReq.context.mageEvent.id,
-          url: `${req.getRoot()}${path}`
-        })
-      }
-      next(appRes.error)
-    })
+  routes.route('/id').post(async (req, res, next) => {
+    const appReq = createAppRequest(req)
+    const appRes = await app.allocateObservationId(appReq)
+    const id = appRes.success
+    const path = `${req.baseUrl}/${id}`
+    if (id) {
+      return res.status(201).location(path).json({
+        id,
+        eventId: appReq.context.mageEvent.id,
+        url: `${req.getRoot()}${path}`
+      })
+    }
+    next(appRes.error)
+  })
 
   // --------------------------------------
   // Attachment upload / download / delete
   // --------------------------------------
-  routes.route('/:observationId/attachments/:attachmentId')
+  routes
+    .route('/:observationId/attachments/:attachmentId')
     .put(
-      // 1️⃣ Init Busboy for multipart upload
+      (req, res, next) => {
+        req.attachmentUpload = null
+        console.error('🔥 PUT attachment route HIT', {
+          url: req.originalUrl,
+          method: req.method,
+          headers: !!req.headers,
+        })
+        next()
+      },
+      // Init Busboy
       (req, res, next) => {
         try {
           req.attachmentUpload = busboy({
             headers: req.headers,
             limits: { files: 1, fields: 0 }
           })
+
+          req.attachmentUpload.on('error', err => {
+            console.error('BUSBOY ERROR', err)
+          })
+  
+          req.attachmentUpload.on('finish', () => {
+            console.error('BUSBOY FINISH')
+          })
+  
+          req.attachmentUpload.on('close', () => {
+            console.error('BUSBOY CLOSE')
+          })
+
         } catch (err) {
-          console.error('Error initializing attachment upload\n', req.params, '\nheaders:\n', req.headers, '\n', err)
-          return res.status(400).json({ message: err instanceof Error ? err.message : String(err) })
+          console.error('Error initializing attachment upload', err)
+          return res
+            .status(400)
+            .json({ message: err instanceof Error ? err.message : String(err) })
         }
         next()
       },
-      // 2️⃣ Handle Busboy streams
+      // Handle Busboy streams with ClamAV scan
       async (req, res, next) => {
         const { observationId, attachmentId } = req.params
-        const sendInvalidRequestStructure = () => next(invalidInput(`request must contain only one file part named 'attachment'`))
+        const sendInvalidRequestStructure = () =>
+          next(invalidInput(`request must contain only one file part named 'attachment'`))
 
-        req.pipe(req.attachmentUpload!
-          .on('file', async (fieldName, stream, info) => {
-            console.log('Received file', fieldName, info)
+        console.error('🔥 piping request into busboy')
 
-            if (fieldName !== 'attachment') {
-              console.error(`Unexpected file entry '${fieldName}' uploading attachment ${attachmentId} on observation ${observationId}`)
-              stream.resume()
-              return sendInvalidRequestStructure()
-            }
-
-            // -------------------------------
-            // PLAN FOR PRE-DISK CLAMAV SCAN
-            // -------------------------------
-            // 1. 'stream' is the first point we have the uploaded file bytes (BLOB in memory)
-            // 2. Before writing anything to disk ($MAGE_ATTACHMENT_DIR), pipe 'stream' through ClamAV
-            // 3. Fail fast if ClamAV detects infection: reject request, do NOT persist bytes or metadata
-            // 4. Only after ClamAV scan passes, pass the clean stream to storeAttachmentContent()
-            // 5. storeAttachmentContent() will handle fs.move() to pod filesystem and Mongo metadata commit
-            // 6. This ensures pre-disk scanning invariant: Busboy stream → ClamAV → clean stream → storage
-            // -------------------------------
-
-            try {
-              const cleanStream = await scanAttachmentWithClamAV(stream)
-
-              const content: ExoIncomingAttachmentContent = {
-                bytes: cleanStream,
-                mediaType: info.mimeType,
-                name: info.filename,
+        if (!req.attachmentUpload) {
+          console.error('🔥 attachmentUpload missing before pipe')
+          return next(new Error('Attachment upload not initialized'))
+        }
+        req.pipe(
+          req.attachmentUpload!
+            .on('file', async (fieldName, fileStream, info) => {
+              console.error('🔥 BUSBOY FILE EVENT FIRED', fieldName)
+        
+              if (fieldName !== 'attachment') {
+                console.error(`Unexpected file entry '${fieldName}'`)
+                fileStream.resume()
+                return sendInvalidRequestStructure()
               }
-              const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = { observationId, attachmentId, content }
-              const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
-              const appRes = await app.storeAttachmentContent(appReq)
-
-              if (appRes.success) {
-                const obs = appRes.success
-                const attachment = obs.attachments.find(x => x.id === appReq.attachmentId)!
-                const attachmentJson = jsonForAttachment(attachment, `${qualifiedBaseUrl(req)}/${observationId}`)
-                console.info(`Successfully stored attachment ${attachmentId} on observation ${observationId}`)
-                return res.json(attachmentJson)
+        
+              try {
+                console.log('>>> CLAMAV SCAN STARTED <<<', info.filename)
+        
+                // --- PRE-DISK CLAMAV SCAN ---
+                const cleanStream: Readable = await scanAttachmentWithClamAV(fileStream)
+        
+                console.log('>>> CLAMAV SCAN CLEAN <<<', info.filename)
+        
+                // --- STORE CLEAN FILE ---
+                const content: ExoIncomingAttachmentContent = {
+                  bytes: cleanStream,
+                  mediaType: info.mimeType,
+                  name: info.filename
+                }
+        
+                const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
+                  observationId,
+                  attachmentId,
+                  content
+                }
+                const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
+                const appRes = await app.storeAttachmentContent(appReq)
+        
+                if (appRes.success) {
+                  const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
+                  const attachmentJson = jsonForAttachment(
+                    attachment,
+                    `${qualifiedBaseUrl(req)}/${observationId}`
+                  )
+                  console.info(
+                    `✅ Successfully stored attachment '${info.filename}' on observation '${observationId}'`
+                  )
+                  return res.json(attachmentJson)
+                }
+        
+                if (appRes.error) return next(appRes.error)
+                sendInvalidRequestStructure()
+              } catch (err) {
+                console.error(`Error during ClamAV scan for '${info.filename}':`, err)
+                // Fail fast: reject request, no disk write, no Mongo commit
+                return next(err)
               }
-
-              if (appRes.error) return next(appRes.error)
-              sendInvalidRequestStructure()
-            } catch (err) {
-              console.error('Error processing attachment upload:', err)
-              return next(err)
-            }
-          })
-          .on('field', (fieldName) => {
-            console.error(`Unexpected field ${fieldName} uploading attachment ${attachmentId}`)
-            sendInvalidRequestStructure()
-          })
-          .on('filesLimit', () => sendInvalidRequestStructure())
-          .on('fieldsLimit', () => sendInvalidRequestStructure())
-          .on('close', () => req.attachmentUpload?.removeAllListeners())
-        )
+            })
+            .on('field', () => sendInvalidRequestStructure())
+            .on('filesLimit', () => sendInvalidRequestStructure())
+            .on('fieldsLimit', () => sendInvalidRequestStructure())
+            .on('close', () => req.attachmentUpload?.removeAllListeners())
+        )        
       }
     )
     .get(async (req, res, next) => {
       const minDimension = parseInt(String(req.query.size), 10) || undefined
-      const contentRange = req.headers.range ?
-        req.headers.range.replace(/bytes=/i, '').split('-').map(x => parseInt(x, 10)).filter(x => typeof x === 'number' && !Number.isNaN(x)) : []
+      const contentRange = req.headers.range
+        ? req.headers.range
+            .replace(/bytes=/i, '')
+            .split('-')
+            .map(x => parseInt(x, 10))
+            .filter(x => typeof x === 'number' && !Number.isNaN(x))
+        : []
       const appReq: ReadAttachmentContentRequest = createAppRequest(req, {
         observationId: req.params.observationId,
         attachmentId: req.params.attachmentId,
         minDimension,
-        contentRange: contentRange.length === 2 ? { start: contentRange[0], end: contentRange[1] } : undefined
+        contentRange:
+          contentRange.length === 2 ? { start: contentRange[0], end: contentRange[1] } : undefined
       })
       const appRes = await app.readAttachmentContent(appReq)
-      if (appRes.error) {
-        return next(appRes.error)
-      }
+      if (appRes.error) return next(appRes.error)
       const content = appRes.success
-      if (!content) {
-        return res.status(500).json({ message: 'unknown application response' })
-      }
+      if (!content) return res.status(500).json({ message: 'unknown application response' })
       const { bytesRange } = content
-      const headers = {
+      const headers: any = {
         'content-type': String(content.attachment.contentType),
-        'content-length': String(bytesRange ? bytesRange.end - bytesRange.start + 1 : content.attachment.size!)
-      } as any
+        'content-length': String(
+          bytesRange ? bytesRange.end - bytesRange.start + 1 : content.attachment.size!
+        )
+      }
       if (bytesRange) {
-        headers['content-range'] = `bytes ${bytesRange.start}-${bytesRange.end}/${content.attachment.size || '*'}`
+        headers['content-range'] = `bytes ${bytesRange.start}-${bytesRange.end}/${
+          content.attachment.size || '*'
+        }`
       }
       return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
     })
@@ -163,31 +241,34 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
   // --------------------------------------
   // Update Observation
   // --------------------------------------
-  routes.route('/:observationId')
-    .put(async (req, res, next) => {
-      const body = req.body
-      const observationId = req.params.observationId
-      if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== observationId) {
-        return res.status(400).json({ message: 'Body observation ID does not match path observation ID' })
-      }
-      const mod = exoObservationModFromJson({ ...body, id: observationId })
-      if (mod instanceof Error) {
-        return next(mod)
-      }
-      const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
-      if (Object.prototype.hasOwnProperty.call(body, 'eventId') && body.eventId !== appReq.context.mageEvent.id) {
-        return res.status(400).json({ message: 'Body event ID does not match path event ID' })
-      }
-      const appRes = await app.saveObservation(appReq)
-      if (appRes.success) {
-        return res.json(jsonForObservation(appRes.success, qualifiedBaseUrl(req)))
-      }
-      next(appRes.error)
-    })
+  routes.route('/:observationId').put(async (req, res, next) => {
+    const body = req.body
+    const observationId = req.params.observationId
+    if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== observationId) {
+      return res
+        .status(400)
+        .json({ message: 'Body observation ID does not match path observation ID' })
+    }
+    const mod = exoObservationModFromJson({ ...body, id: observationId })
+    if (mod instanceof Error) return next(mod)
+    const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
+    if (
+      Object.prototype.hasOwnProperty.call(body, 'eventId') &&
+      body.eventId !== appReq.context.mageEvent.id
+    ) {
+      return res.status(400).json({ message: 'Body event ID does not match path event ID' })
+    }
+    const appRes = await app.saveObservation(appReq)
+    if (appRes.success) return res.json(jsonForObservation(appRes.success, qualifiedBaseUrl(req)))
+    next(appRes.error)
+  })
 
   return routes.use(compatibilityMageAppErrorHandler)
 }
 
+// ----------------------
+// JSON serialization
+// ----------------------
 export type WebObservation = Omit<ExoObservation, 'attachments' | 'state'> & {
   url: string
   state?: WebObservationState
@@ -207,13 +288,13 @@ export function jsonForObservation(o: ExoObservation, baseUrl: string): WebObser
   return {
     ...o,
     url: obsUrl,
-    state: o.state ? { ...o.state, url: `${obsUrl}/states/${o.state.id as string}` } : void(0),
-    attachments: o.attachments.map(a => jsonForAttachment(a, obsUrl)),
+    state: o.state ? { ...o.state, url: `${obsUrl}/states/${o.state.id as string}` } : void 0,
+    attachments: o.attachments.map(a => jsonForAttachment(a, obsUrl))
   }
 }
 
 export function jsonForAttachment(a: ExoAttachment, observationUrl: string): WebAttachment {
-  return { ...a, url: a.contentStored ? `${observationUrl}/attachments/${a.id}` : void(0) }
+  return { ...a, url: a.contentStored ? `${observationUrl}/attachments/${a.id}` : void 0 }
 }
 
 function qualifiedBaseUrl(req: express.Request): string {

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -79,7 +79,6 @@ export function ObservationRoutes(
       const id = appRes.success
       const path = `${req.baseUrl}/${id}`
       if (id) {
-        console.debug('[ObservationRoutes] Allocated observation ID:', id)
         return res.status(201).location(path).json({
           id,
           eventId: appReq.context.mageEvent.id,
@@ -99,18 +98,15 @@ export function ObservationRoutes(
     .route('/:observationId/attachments/:attachmentId')
     .put(async (req, res, next) => {
       try {
-        console.debug('[ObservationRoutes] Upload PUT called')
         const bb = busboy({ headers: req.headers, limits: { files: 10, fields: 0 } })
         const uploadErrors: any[] = []
         const attachmentsJson: any[] = []
         const filePromises: Promise<void>[] = []
 
         bb.on('file', (fieldName, fileStream, info) => {
-          console.debug('[ObservationRoutes] Busboy file event for field:', fieldName)
         
           const filePromise = (async () => {
             if (fieldName !== 'attachment') {
-              console.debug('[ObservationRoutes] Invalid field name:', fieldName)
               fileStream.resume()
               uploadErrors.push({
                 file: info.filename,
@@ -135,7 +131,6 @@ export function ObservationRoutes(
         
                 while (attempt < maxRetries && !scanSuccess) {
                   attempt++
-                  console.debug(`[ObservationRoutes] ClamAV scan attempt ${attempt} for ${info.filename}`)
                   try {
                     const scannedResult = await scanAttachmentWithClamAV(Readable.from(originalBuffer))
                     if (scannedResult.status === 'clean' && scannedResult.stream) {
@@ -153,7 +148,6 @@ export function ObservationRoutes(
                 }
         
                 if (!scanSuccess) {
-                  console.debug(`[ObservationRoutes] Upload rejected by ClamAV for ${info.filename}`)
                   fileStream.resume()
                   uploadErrors.push({ file: info.filename, error: scanErrorMsg })
                   return
@@ -189,15 +183,13 @@ export function ObservationRoutes(
         })
 
         bb.on('field', (name) => {
-          console.debug('[ObservationRoutes] Unexpected form field:', name)
           uploadErrors.push({ field: name, error: 'Unexpected form field' })
         })
-        bb.on('filesLimit', () => { console.debug('[ObservationRoutes] Too many files'); uploadErrors.push({ error: 'Too many files' }) })
-        bb.on('fieldsLimit', () => { console.debug('[ObservationRoutes] Too many fields'); uploadErrors.push({ error: 'Too many fields' }) })
-        bb.on('error', (err) => { console.debug('[ObservationRoutes] Busboy error:', err); uploadErrors.push({ error: err }) })
+        bb.on('filesLimit', () => { uploadErrors.push({ error: 'Too many files' }) })
+        bb.on('fieldsLimit', () => { uploadErrors.push({ error: 'Too many fields' }) })
+        bb.on('error', (err) => { uploadErrors.push({ error: err }) })
 
         bb.on('finish', async () => {
-          console.debug('[ObservationRoutes] Busboy finished')
           if (filePromises.length > 0) await Promise.all(filePromises)
         
           const statusCode = attachmentsJson.length > 0 ? 200 : 400
@@ -209,7 +201,6 @@ export function ObservationRoutes(
 
         req.pipe(bb)
       } catch (err) {
-        console.debug('[ObservationRoutes] Outer error:', err)
         next(err)
       }
     })
@@ -255,15 +246,12 @@ export function ObservationRoutes(
           }`
         }
 
-        console.debug('[ObservationRoutes] Streaming file to client:', req.params.attachmentId)
         return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
       } catch (err) {
-        console.debug('[ObservationRoutes] GET attachment error:', err)
         next(err)
       }
     })
     .delete(async (req, res) => {
-      console.debug('[ObservationRoutes] DELETE attachment:', req.params.attachmentId)
       res.sendStatus(204)
     })
 

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -60,12 +60,10 @@ export function ObservationRoutes(
   routes.route('/id').post(async (req, res, next) => {
     try {
       const appReq = createAppRequest(req)
-      console.log('🔹 [DEBUG] Allocating observation ID, appReq:', appReq)
       const appRes = await app.allocateObservationId(appReq)
       const id = appRes.success
       const path = `${req.baseUrl}/${id}`
       if (id) {
-        console.log('🟢 [DEBUG] Allocated observation ID:', id)
         return res.status(201).location(path).json({
           id,
           eventId: appReq.context.mageEvent.id,
@@ -74,7 +72,6 @@ export function ObservationRoutes(
       }
       next(appRes.error)
     } catch (err) {
-      console.log('❌ [DEBUG] Exception in /id route:', err)
       next(err)
     }
   })
@@ -86,27 +83,23 @@ export function ObservationRoutes(
     .route('/:observationId/attachments/:attachmentId')
     .put(async (req, res, next) => {
       try {
-        console.log('🔹 [DEBUG] Incoming attachment PUT request:', req.params)
         const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
         let handled = false
 
         bb.on('file', async (fieldName, fileStream, info) => {
-          console.log('🔹 [DEBUG] Busboy received file field: ', fieldName, info)
           if (handled) {
-            console.log('⚠️ [DEBUG] Already handled a file, skipping extra stream')
             return fileStream.resume()
           }
           handled = true
 
           if (fieldName !== 'attachment') {
-            console.log('⚠️ [DEBUG] Unexpected field name, rejecting file')
             fileStream.resume()
             return next(invalidInput(`request must contain only one file part named 'attachment'`))
           }
 
           try {
             // -----------------------------
-            // FIX: Guarantee file has bytes
+            // FIX: Guarantee file has bytes and handle viruses
             // -----------------------------
             // Step 1: fully buffer the uploaded file
             const originalChunks: Buffer[] = []
@@ -114,11 +107,22 @@ export function ObservationRoutes(
               originalChunks.push(chunk as Buffer)
             }
             const originalBuffer = Buffer.concat(originalChunks)
-            console.log('🔹 [DEBUG] Buffered original file size:', originalBuffer.length)
 
             // Step 2: scan with ClamAV
             const passThrough = Readable.from(originalBuffer)
-            const scannedStream: Readable = await scanAttachmentWithClamAV(passThrough)
+            let scannedStream: Readable
+            try {
+              scannedStream = await scanAttachmentWithClamAV(passThrough)
+            } catch (err) {
+              console.log('❌ [DEBUG] ClamAV rejected file:', err)
+              return next(invalidInput('Uploaded file contains a virus and cannot be stored.'))
+            }
+
+            // Step 2b: also handle any emitted errors on scanned stream
+            scannedStream.on('error', (err) => {
+              console.log('❌ [DEBUG] Error emitted from scanned stream:', err)
+              return next(invalidInput('Uploaded file contains a virus or could not be scanned.'))
+            })
 
             // Step 3: buffer scanned output
             const scannedChunks: Buffer[] = []
@@ -126,11 +130,9 @@ export function ObservationRoutes(
               scannedChunks.push(chunk as Buffer)
             }
             let finalBuffer = Buffer.concat(scannedChunks)
-            console.log('🔹 [DEBUG] Scanned file size:', finalBuffer.length)
 
             // Step 4: fallback if scanned result is empty
             if (finalBuffer.length === 0) {
-              console.log('⚠️ [DEBUG] Scanned file empty, using original buffer')
               finalBuffer = originalBuffer
             }
 
@@ -147,9 +149,7 @@ export function ObservationRoutes(
               content
             }
             const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
-            console.log('🔹 [DEBUG] Prepared content object for storage:', content)
             const appRes = await app.storeAttachmentContent(appReq)
-            console.log('🟢 [DEBUG] storeAttachmentContent response:', appRes)
 
             if (appRes.success) {
               const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
@@ -157,52 +157,43 @@ export function ObservationRoutes(
                 attachment,
                 `${qualifiedBaseUrl(req)}/${observationId}`
               )
-              console.log('🟢 [DEBUG] Returning attachment JSON:', attachmentJson)
               return res.json(attachmentJson)
             }
 
             if (appRes.error) {
-              console.log('❌ [DEBUG] Error storing attachment:', appRes.error)
               return next(appRes.error)
             }
 
             next(invalidInput('Attachment could not be stored'))
           } catch (err) {
-            console.log('❌ [DEBUG] Exception during file handling:', err)
             return next(err)
           }
         })
 
-        bb.on('field', (name, val) => {
-          console.log('🔹 [DEBUG] Unexpected form field detected:', name, val)
-          next(invalidInput(`unexpected form field`))
+        bb.on('field', (name) => {
+          return next(invalidInput(`unexpected form field: ${name}`))
         })
         bb.on('filesLimit', () => {
-          console.log('⚠️ [DEBUG] Busboy filesLimit reached')
-          next(invalidInput(`too many files`))
+          return next(invalidInput(`too many files`))
         })
         bb.on('fieldsLimit', () => {
-          console.log('⚠️ [DEBUG] Busboy fieldsLimit reached')
-          next(invalidInput(`too many fields`))
+          return next(invalidInput(`too many fields`))
         })
         bb.on('error', (err) => {
-          console.log('❌ [DEBUG] Busboy error:', err)
-          next(err)
+          return next(err)
         })
 
         req.pipe(bb)
       } catch (err) {
-        console.log('❌ [DEBUG] Exception in attachment PUT route:', err)
-        next(err)
+        return next(err)
       }
     })
     .get(async (req, res, next) => {
       try {
-        console.log('🔹 [DEBUG] Attachment GET request:', req.params, req.query)
-        const sizeParam = req.query.size;
+        const sizeParam = req.query.size
         const minDimension =
-          typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined;
-        
+          typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined
+
         const contentRange = req.headers.range
           ? req.headers.range
               .replace(/bytes=/i, '')
@@ -210,7 +201,6 @@ export function ObservationRoutes(
               .map(x => parseInt(x, 10))
               .filter(x => typeof x === 'number' && !Number.isNaN(x))
           : []
-        console.log('🔹 [DEBUG] Parsed contentRange:', contentRange)
 
         const appReq: ReadAttachmentContentRequest = createAppRequest(req, {
           observationId: req.params.observationId,
@@ -221,13 +211,11 @@ export function ObservationRoutes(
         })
         const appRes = await app.readAttachmentContent(appReq)
         if (appRes.error) {
-          console.log('❌ [DEBUG] readAttachmentContent returned error:', appRes.error)
           return next(appRes.error)
         }
 
         const content = appRes.success
         if (!content) {
-          console.log('⚠️ [DEBUG] readAttachmentContent returned no content')
           return res.status(500).json({ message: 'unknown application response' })
         }
 
@@ -250,15 +238,12 @@ export function ObservationRoutes(
           }`
         }
 
-        console.log('🔹 [DEBUG] Sending attachment bytes with headers:', headers)
         return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
       } catch (err) {
-        console.log('❌ [DEBUG] Exception in attachment GET route:', err)
         next(err)
       }
     })
     .delete(async (req, res) => {
-      console.log('🔹 [DEBUG] Attachment DELETE request:', req.params)
       res.sendStatus(204)
     })
 
@@ -267,18 +252,15 @@ export function ObservationRoutes(
   // --------------------------------------
   routes.route('/:observationId').put(async (req, res, next) => {
     try {
-      console.log('🔹 [DEBUG] Update Observation PUT request:', req.params, req.body)
       const body = req.body
       const observationId = req.params.observationId
       if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== observationId) {
-        console.log('⚠️ [DEBUG] Body observation ID mismatch:', body.id, observationId)
         return res
           .status(400)
           .json({ message: 'Body observation ID does not match path observation ID' })
       }
       const mod = exoObservationModFromJson({ ...body, id: observationId })
       if (mod instanceof Error) {
-        console.log('❌ [DEBUG] Failed to create observation mod:', mod)
         return next(mod)
       }
       const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
@@ -286,15 +268,12 @@ export function ObservationRoutes(
         Object.prototype.hasOwnProperty.call(body, 'eventId') &&
         body.eventId !== appReq.context.mageEvent.id
       ) {
-        console.log('⚠️ [DEBUG] Body event ID mismatch:', body.eventId, appReq.context.mageEvent.id)
         return res.status(400).json({ message: 'Body event ID does not match path event ID' })
       }
       const appRes = await app.saveObservation(appReq)
-      console.log('🟢 [DEBUG] saveObservation response:', appRes)
       if (appRes.success) return res.json(jsonForObservation(appRes.success, qualifiedBaseUrl(req)))
       next(appRes.error)
     } catch (err) {
-      console.log('❌ [DEBUG] Exception in Update Observation route:', err)
       next(err)
     }
   })

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -138,9 +138,14 @@ export function ObservationRoutes(
                 console.log(`[DEBUG] ClamAV scan result: ${scannedResult.status}`, scannedResult.error || '')
 
                 // ----------------------
+                // Verification hook: log pre-disk invariant
+                // ----------------------
+                console.log(`[VERIFY] Pre-disk invariant: file must be clean before storage`)
+
+                // ----------------------
                 // If scan succeeded, read from the gated stream
                 // ----------------------
-                if (scannedResult.status === 'success' && scannedResult.stream) {
+                if (scannedResult.status === 'clean' && scannedResult.stream){
                   const scannedChunks: Buffer[] = []
                   for await (const chunk of scannedResult.stream) {
                     scannedChunks.push(chunk as Buffer)
@@ -150,11 +155,12 @@ export function ObservationRoutes(
                   if (scannedBuffer.length > 0) {
                     finalBuffer = scannedBuffer
                   }
+                  console.log('[VERIFY] Scan clean: proceeding to storage')
                 } else {
                   // ----------------------
                   // Handle failed scan: return proper API error
                   // ----------------------
-                  console.log('[WARN] ClamAV scan failed, rejecting upload')
+                  console.log('[WARN] Attachment rejected by ClamAV scan')
                   return next(
                     invalidInput(
                       scannedResult.error || 'Uploaded file contains a virus and cannot be stored.'
@@ -224,9 +230,6 @@ export function ObservationRoutes(
     })
     .get(async (req, res, next) => {
       try {
-        // ----------------------
-        // Handle range queries and image resizing (minDimension)
-        // ----------------------
         const sizeParam = req.query.size
         const minDimension =
           typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined
@@ -275,9 +278,6 @@ export function ObservationRoutes(
       }
     })
     .delete(async (req, res) => {
-      // ----------------------
-      // Delete attachment route (204 No Content)
-      // ----------------------
       res.sendStatus(204)
     })
 
@@ -289,20 +289,17 @@ export function ObservationRoutes(
       const body = req.body
       const observationId = req.params.observationId
 
-      // Ensure path ID matches body ID
       if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== observationId) {
         return res
           .status(400)
           .json({ message: 'Body observation ID does not match path observation ID' })
       }
 
-      // Parse observation modification
       const mod = exoObservationModFromJson({ ...body, id: observationId })
       if (mod instanceof Error) return next(mod)
 
       const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
 
-      // Ensure body event ID matches path event ID
       if (
         Object.prototype.hasOwnProperty.call(body, 'eventId') &&
         body.eventId !== appReq.context.mageEvent.id
@@ -318,9 +315,6 @@ export function ObservationRoutes(
     }
   })
 
-  // --------------------------------------
-  // Apply global error handler
-  // --------------------------------------
   return routes.use(compatibilityMageAppErrorHandler)
 }
 

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -53,7 +53,6 @@ export function ObservationRoutes(
   attachmentStore: AttachmentStore,
   createAppRequest: ObservationWebAppRequestFactory
 ): express.Router {
-  console.error('🔥 ObservationRoutes() invoked')
   const routes = express.Router()
 
   // --------------------------------------
@@ -80,12 +79,6 @@ export function ObservationRoutes(
   routes
     .route('/:observationId/attachments/:attachmentId')
     .put(async (req, res, next) => {
-      console.error('🔥 PUT attachment route HIT', {
-        url: req.originalUrl,
-        method: req.method,
-        headers: !!req.headers
-      })
-
       try {
         const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
         let handled = false
@@ -100,10 +93,7 @@ export function ObservationRoutes(
           }
 
           try {
-            console.log('>>> CLAMAV SCAN STARTED <<<', info.filename)
             const cleanStream: Readable = await scanAttachmentWithClamAV(fileStream)
-            console.log('>>> CLAMAV SCAN CLEAN <<<', info.filename)
-
             const { observationId, attachmentId } = req.params
             const content: ExoIncomingAttachmentContent = {
               bytes: cleanStream,
@@ -125,16 +115,12 @@ export function ObservationRoutes(
                 attachment,
                 `${qualifiedBaseUrl(req)}/${observationId}`
               )
-              console.info(
-                `✅ Successfully stored attachment '${info.filename}' on observation '${observationId}'`
-              )
               return res.json(attachmentJson)
             }
 
             if (appRes.error) return next(appRes.error)
             next(invalidInput('Attachment could not be stored'))
           } catch (err) {
-            console.error(`Error during ClamAV scan for '${info.filename}':`, err)
             return next(err)
           }
         })
@@ -150,7 +136,10 @@ export function ObservationRoutes(
       }
     })
     .get(async (req, res, next) => {
-      const minDimension = parseInt(String(req.query.size), 10) || undefined
+      const sizeParam = req.query.size;
+      const minDimension =
+        typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined;
+      
       const contentRange = req.headers.range
         ? req.headers.range
             .replace(/bytes=/i, '')

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -26,21 +26,12 @@ import busboy from 'busboy'
 import { invalidInput } from '../../app.api/app.api.errors'
 import { exoObservationModFromJson } from './adapters.observations.dto.ecma404-json'
 
+
 declare module 'express-serve-static-core' {
   interface Request {
-    attachmentUpload: busboy.Busboy | null
+    attachmentUpload?: busboy.Busboy
   }
 }
-
-// -------------------------------
-// PLAN FOR PRE-DISK CLAMAV SCAN
-// -------------------------------
-// 1. 'stream' is the first point we have the uploaded file bytes (BLOB in memory or pipe)
-// 2. Pipe 'stream' through ClamAV before writing anything to disk
-// 3. Fail fast if ClamAV detects infection: reject request, do NOT persist bytes or metadata
-// 4. Only after ClamAV scan passes, pass the clean stream to storeAttachmentContent()
-// 5. storeAttachmentContent() handles fs.move() and Mongo metadata commit
-// -------------------------------
 
 export interface ObservationAppLayer {
   allocateObservationId: AllocateObservationId
@@ -63,8 +54,7 @@ export function ObservationRoutes(
   createAppRequest: ObservationWebAppRequestFactory
 ): express.Router {
   console.error('🔥 ObservationRoutes() invoked')
-  const routes = express.Router();
-
+  const routes = express.Router()
 
   // --------------------------------------
   // Allocate Observation ID
@@ -89,117 +79,76 @@ export function ObservationRoutes(
   // --------------------------------------
   routes
     .route('/:observationId/attachments/:attachmentId')
-    .put(
-      (req, res, next) => {
-        req.attachmentUpload = null
-        console.error('🔥 PUT attachment route HIT', {
-          url: req.originalUrl,
-          method: req.method,
-          headers: !!req.headers,
+    .put(async (req, res, next) => {
+      console.error('🔥 PUT attachment route HIT', {
+        url: req.originalUrl,
+        method: req.method,
+        headers: !!req.headers
+      })
+
+      try {
+        const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
+        let handled = false
+
+        bb.on('file', async (fieldName, fileStream, info) => {
+          if (handled) return fileStream.resume()
+          handled = true
+
+          if (fieldName !== 'attachment') {
+            fileStream.resume()
+            return next(invalidInput(`request must contain only one file part named 'attachment'`))
+          }
+
+          try {
+            console.log('>>> CLAMAV SCAN STARTED <<<', info.filename)
+            const cleanStream: Readable = await scanAttachmentWithClamAV(fileStream)
+            console.log('>>> CLAMAV SCAN CLEAN <<<', info.filename)
+
+            const { observationId, attachmentId } = req.params
+            const content: ExoIncomingAttachmentContent = {
+              bytes: cleanStream,
+              mediaType: info.mimeType,
+              name: info.filename
+            }
+
+            const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
+              observationId,
+              attachmentId,
+              content
+            }
+            const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
+            const appRes = await app.storeAttachmentContent(appReq)
+
+            if (appRes.success) {
+              const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
+              const attachmentJson = jsonForAttachment(
+                attachment,
+                `${qualifiedBaseUrl(req)}/${observationId}`
+              )
+              console.info(
+                `✅ Successfully stored attachment '${info.filename}' on observation '${observationId}'`
+              )
+              return res.json(attachmentJson)
+            }
+
+            if (appRes.error) return next(appRes.error)
+            next(invalidInput('Attachment could not be stored'))
+          } catch (err) {
+            console.error(`Error during ClamAV scan for '${info.filename}':`, err)
+            return next(err)
+          }
         })
-        next()
-      },
-      // Init Busboy
-      (req, res, next) => {
-        try {
-          req.attachmentUpload = busboy({
-            headers: req.headers,
-            limits: { files: 1, fields: 0 }
-          })
 
-          req.attachmentUpload.on('error', err => {
-            console.error('BUSBOY ERROR', err)
-          })
-  
-          req.attachmentUpload.on('finish', () => {
-            console.error('BUSBOY FINISH')
-          })
-  
-          req.attachmentUpload.on('close', () => {
-            console.error('BUSBOY CLOSE')
-          })
+        bb.on('field', () => next(invalidInput(`unexpected form field`)))
+        bb.on('filesLimit', () => next(invalidInput(`too many files`)))
+        bb.on('fieldsLimit', () => next(invalidInput(`too many fields`)))
+        bb.on('error', (err) => next(err))
 
-        } catch (err) {
-          console.error('Error initializing attachment upload', err)
-          return res
-            .status(400)
-            .json({ message: err instanceof Error ? err.message : String(err) })
-        }
-        next()
-      },
-      // Handle Busboy streams with ClamAV scan
-      async (req, res, next) => {
-        const { observationId, attachmentId } = req.params
-        const sendInvalidRequestStructure = () =>
-          next(invalidInput(`request must contain only one file part named 'attachment'`))
-
-        console.error('🔥 piping request into busboy')
-
-        if (!req.attachmentUpload) {
-          console.error('🔥 attachmentUpload missing before pipe')
-          return next(new Error('Attachment upload not initialized'))
-        }
-        req.pipe(
-          req.attachmentUpload!
-            .on('file', async (fieldName, fileStream, info) => {
-              console.error('🔥 BUSBOY FILE EVENT FIRED', fieldName)
-        
-              if (fieldName !== 'attachment') {
-                console.error(`Unexpected file entry '${fieldName}'`)
-                fileStream.resume()
-                return sendInvalidRequestStructure()
-              }
-        
-              try {
-                console.log('>>> CLAMAV SCAN STARTED <<<', info.filename)
-        
-                // --- PRE-DISK CLAMAV SCAN ---
-                const cleanStream: Readable = await scanAttachmentWithClamAV(fileStream)
-        
-                console.log('>>> CLAMAV SCAN CLEAN <<<', info.filename)
-        
-                // --- STORE CLEAN FILE ---
-                const content: ExoIncomingAttachmentContent = {
-                  bytes: cleanStream,
-                  mediaType: info.mimeType,
-                  name: info.filename
-                }
-        
-                const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
-                  observationId,
-                  attachmentId,
-                  content
-                }
-                const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
-                const appRes = await app.storeAttachmentContent(appReq)
-        
-                if (appRes.success) {
-                  const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
-                  const attachmentJson = jsonForAttachment(
-                    attachment,
-                    `${qualifiedBaseUrl(req)}/${observationId}`
-                  )
-                  console.info(
-                    `✅ Successfully stored attachment '${info.filename}' on observation '${observationId}'`
-                  )
-                  return res.json(attachmentJson)
-                }
-        
-                if (appRes.error) return next(appRes.error)
-                sendInvalidRequestStructure()
-              } catch (err) {
-                console.error(`Error during ClamAV scan for '${info.filename}':`, err)
-                // Fail fast: reject request, no disk write, no Mongo commit
-                return next(err)
-              }
-            })
-            .on('field', () => sendInvalidRequestStructure())
-            .on('filesLimit', () => sendInvalidRequestStructure())
-            .on('fieldsLimit', () => sendInvalidRequestStructure())
-            .on('close', () => req.attachmentUpload?.removeAllListeners())
-        )        
+        req.pipe(bb)
+      } catch (err) {
+        next(err)
       }
-    )
+    })
     .get(async (req, res, next) => {
       const minDimension = parseInt(String(req.query.size), 10) || undefined
       const contentRange = req.headers.range

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -27,7 +27,6 @@ import {
 } from '../../entities/observations/entities.observations'
 import { MageEvent, MageEventId } from '../../entities/events/entities.events'
 import busboy from 'busboy'
-import { invalidInput } from '../../app.api/app.api.errors'
 import { exoObservationModFromJson } from './adapters.observations.dto.ecma404-json'
 
 // ----------------------
@@ -101,29 +100,31 @@ export function ObservationRoutes(
     .put(async (req, res, next) => {
       try {
         console.debug('[ObservationRoutes] Upload PUT called')
-        const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
-        let uploadError: any = null
-        let attachmentJson: any = null
-        let resultSent = false
-        let filePromise: Promise<void> | null = null
+        const bb = busboy({ headers: req.headers, limits: { files: 10, fields: 0 } })
+        const uploadErrors: any[] = []
+        const attachmentsJson: any[] = []
+        const filePromises: Promise<void>[] = []
 
         bb.on('file', (fieldName, fileStream, info) => {
           console.debug('[ObservationRoutes] Busboy file event for field:', fieldName)
-          filePromise = (async () => {
+        
+          const filePromise = (async () => {
             if (fieldName !== 'attachment') {
               console.debug('[ObservationRoutes] Invalid field name:', fieldName)
               fileStream.resume()
-              uploadError = invalidInput(`request must contain only one file part named 'attachment'`)
+              uploadErrors.push({
+                file: info.filename,
+                error: "request must contain only file parts named 'attachment'"
+              })
               return
             }
-
+        
             try {
               const chunks: Buffer[] = []
               for await (const chunk of fileStream) chunks.push(chunk as Buffer)
               const originalBuffer = Buffer.concat(chunks)
-              console.debug('[ObservationRoutes] File buffered:', info.filename, 'size:', originalBuffer.length)
               let finalBuffer = originalBuffer
-
+        
               // ClamAV scan
               if (process.env.CLAM_AV_URL) {
                 const maxRetries = 3
@@ -131,7 +132,7 @@ export function ObservationRoutes(
                 let scanSuccess = false
                 let scanErrorMsg = ''
                 let scannedBuffer: Buffer | null = null
-
+        
                 while (attempt < maxRetries && !scanSuccess) {
                   attempt++
                   console.debug(`[ObservationRoutes] ClamAV scan attempt ${attempt} for ${info.filename}`)
@@ -142,28 +143,25 @@ export function ObservationRoutes(
                       for await (const chunk of scannedResult.stream) scannedChunks.push(chunk as Buffer)
                       scannedBuffer = Buffer.concat(scannedChunks)
                       scanSuccess = true
-                      console.debug(`[ObservationRoutes] ClamAV clean for ${info.filename}`)
                     } else {
                       scanErrorMsg = scannedResult.error || 'File rejected by ClamAV'
-                      console.debug(`[ObservationRoutes] ClamAV rejected file:`, scanErrorMsg)
                     }
                   } catch (err) {
                     scanErrorMsg = 'Virus scanning server unavailable'
-                    console.debug(`[ObservationRoutes] ClamAV error:`, err)
                   }
                   if (!scanSuccess && attempt < maxRetries) await new Promise(r => setTimeout(r, 500))
                 }
-
+        
                 if (!scanSuccess) {
                   console.debug(`[ObservationRoutes] Upload rejected by ClamAV for ${info.filename}`)
-                  fileStream.resume() 
-                  uploadError = { message: scanErrorMsg, errorCode: 'ClamAVUnavailable' }
+                  fileStream.resume()
+                  uploadErrors.push({ file: info.filename, error: scanErrorMsg })
                   return
                 }
-
+        
                 if (scannedBuffer) finalBuffer = scannedBuffer
               }
-
+        
               // Store attachment
               const { observationId, attachmentId } = req.params
               const content: ExoIncomingAttachmentContent = {
@@ -171,51 +169,42 @@ export function ObservationRoutes(
                 mediaType: info.mimeType,
                 name: info.filename
               }
-
+        
               const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = { observationId, attachmentId, content }
               const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
               const appRes = await app.storeAttachmentContent(appReq)
-
+        
               if (appRes.success) {
                 const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
-                attachmentJson = jsonForAttachment(attachment, `${qualifiedBaseUrl(req)}/${observationId}`)
-                console.debug('[ObservationRoutes] Attachment stored successfully:', attachment.id)
+                attachmentsJson.push(jsonForAttachment(attachment, `${qualifiedBaseUrl(req)}/${observationId}`))
               } else if (appRes.error) {
-                console.debug('[ObservationRoutes] Attachment storage error:', appRes.error)
-                uploadError = appRes.error
+                uploadErrors.push({ file: info.filename, error: appRes.error })
               }
             } catch (err) {
-              console.debug('[ObservationRoutes] File processing error:', err)
-              uploadError = err
+              uploadErrors.push({ file: info.filename, error: err })
             }
           })()
+        
+          filePromises.push(filePromise)
         })
 
         bb.on('field', (name) => {
           console.debug('[ObservationRoutes] Unexpected form field:', name)
-          uploadError = invalidInput(`unexpected form field: ${name}`)
+          uploadErrors.push({ field: name, error: 'Unexpected form field' })
         })
-        bb.on('filesLimit', () => { console.debug('[ObservationRoutes] Too many files'); uploadError = invalidInput('too many files') })
-        bb.on('fieldsLimit', () => { console.debug('[ObservationRoutes] Too many fields'); uploadError = invalidInput('too many fields') })
-        bb.on('error', (err) => { console.debug('[ObservationRoutes] Busboy error:', err); uploadError = err })
+        bb.on('filesLimit', () => { console.debug('[ObservationRoutes] Too many files'); uploadErrors.push({ error: 'Too many files' }) })
+        bb.on('fieldsLimit', () => { console.debug('[ObservationRoutes] Too many fields'); uploadErrors.push({ error: 'Too many fields' }) })
+        bb.on('error', (err) => { console.debug('[ObservationRoutes] Busboy error:', err); uploadErrors.push({ error: err }) })
 
         bb.on('finish', async () => {
           console.debug('[ObservationRoutes] Busboy finished')
-          if (resultSent) return
-          resultSent = true
-
-          if (filePromise) await filePromise
-
-          if (uploadError) {
-            console.debug('[ObservationRoutes] Sending error response')
-            return next(uploadError)
-          }
-          if (attachmentJson) {
-            console.debug('[ObservationRoutes] Sending success response')
-            return res.json(attachmentJson)
-          }
-          console.debug('[ObservationRoutes] No file uploaded')
-          return next(invalidInput('No file uploaded'))
+          if (filePromises.length > 0) await Promise.all(filePromises)
+        
+          const statusCode = attachmentsJson.length > 0 ? 200 : 400
+          return res.status(statusCode).json({
+            successes: attachmentsJson,
+            failures: uploadErrors
+          })
         })
 
         req.pipe(bb)
@@ -224,7 +213,6 @@ export function ObservationRoutes(
         next(err)
       }
     })
-    // .get / .delete unchanged (same as your previous version)
     .get(async (req, res, next) => {
       try {
         const sizeParam = req.query.size

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -80,6 +80,7 @@ export function ObservationRoutes(
       const id = appRes.success
       const path = `${req.baseUrl}/${id}`
       if (id) {
+        console.debug('[ObservationRoutes] Allocated observation ID:', id)
         return res.status(201).location(path).json({
           id,
           eventId: appReq.context.mageEvent.id,
@@ -99,138 +100,134 @@ export function ObservationRoutes(
     .route('/:observationId/attachments/:attachmentId')
     .put(async (req, res, next) => {
       try {
-        // Initialize Busboy to handle multipart/form-data file upload
+        console.debug('[ObservationRoutes] Upload PUT called')
         const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
-        let handled = false
+        let uploadError: any = null
+        let attachmentJson: any = null
+        let resultSent = false
+        let filePromise: Promise<void> | null = null
 
-        bb.on('file', async (fieldName, fileStream, info) => {
-          if (handled) return fileStream.resume()
-          handled = true
-
-          if (fieldName !== 'attachment') {
-            fileStream.resume()
-            return next(invalidInput(`request must contain only one file part named 'attachment'`))
-          }
-
-          try {
-            // ----------------------
-            // Buffer the uploaded file into memory
-            // ----------------------
-            const originalChunks: Buffer[] = []
-            for await (const chunk of fileStream) {
-              originalChunks.push(chunk as Buffer)
+        bb.on('file', (fieldName, fileStream, info) => {
+          console.debug('[ObservationRoutes] Busboy file event for field:', fieldName)
+          filePromise = (async () => {
+            if (fieldName !== 'attachment') {
+              console.debug('[ObservationRoutes] Invalid field name:', fieldName)
+              fileStream.resume()
+              uploadError = invalidInput(`request must contain only one file part named 'attachment'`)
+              return
             }
-            const originalBuffer = Buffer.concat(originalChunks)
-            console.log(`[DEBUG] Original uploaded file: ${info.filename}, size=${originalBuffer.length} bytes`)
 
-            let finalBuffer = originalBuffer
+            try {
+              const chunks: Buffer[] = []
+              for await (const chunk of fileStream) chunks.push(chunk as Buffer)
+              const originalBuffer = Buffer.concat(chunks)
+              console.debug('[ObservationRoutes] File buffered:', info.filename, 'size:', originalBuffer.length)
+              let finalBuffer = originalBuffer
 
-            // ----------------------
-            // Only scan if ClamAV is configured
-            // ----------------------
-            if (process.env.CLAM_AV_URL) {
-              const maxRetries = 3
-              let attempt = 0
-              let scanSuccess = false
-              let scanErrorMsg = ''
-              let scannedBuffer: Buffer | null = null
-            
-              while (attempt < maxRetries && !scanSuccess) {
-                attempt++
-                try {
-                  console.log(`[DEBUG] ClamAV scan attempt ${attempt}`)
-                  const scannedResult = await scanAttachmentWithClamAV(Readable.from(originalBuffer))
-                  console.log(`[DEBUG] ClamAV scan result: ${scannedResult.status}`, scannedResult.error || '')
-            
-                  if (scannedResult.status === 'clean' && scannedResult.stream) {
-                    const chunks: Buffer[] = []
-                    for await (const chunk of scannedResult.stream) {
-                      chunks.push(chunk as Buffer)
+              // ClamAV scan
+              if (process.env.CLAM_AV_URL) {
+                const maxRetries = 3
+                let attempt = 0
+                let scanSuccess = false
+                let scanErrorMsg = ''
+                let scannedBuffer: Buffer | null = null
+
+                while (attempt < maxRetries && !scanSuccess) {
+                  attempt++
+                  console.debug(`[ObservationRoutes] ClamAV scan attempt ${attempt} for ${info.filename}`)
+                  try {
+                    const scannedResult = await scanAttachmentWithClamAV(Readable.from(originalBuffer))
+                    if (scannedResult.status === 'clean' && scannedResult.stream) {
+                      const scannedChunks: Buffer[] = []
+                      for await (const chunk of scannedResult.stream) scannedChunks.push(chunk as Buffer)
+                      scannedBuffer = Buffer.concat(scannedChunks)
+                      scanSuccess = true
+                      console.debug(`[ObservationRoutes] ClamAV clean for ${info.filename}`)
+                    } else {
+                      scanErrorMsg = scannedResult.error || 'File rejected by ClamAV'
+                      console.debug(`[ObservationRoutes] ClamAV rejected file:`, scanErrorMsg)
                     }
-                    scannedBuffer = Buffer.concat(chunks)
-                    scanSuccess = true
-                    console.log('[VERIFY] Scan clean: proceeding to storage')
-                  } else {
-                    scanErrorMsg = scannedResult.error || 'File rejected by ClamAV'
-                    scanSuccess = false
+                  } catch (err) {
+                    scanErrorMsg = 'Virus scanning server unavailable'
+                    console.debug(`[ObservationRoutes] ClamAV error:`, err)
                   }
-                } catch (err) {
-                  console.error(`[WARN] ClamAV scan attempt ${attempt} failed:`, err)
-                  scanErrorMsg = 'Virus scanning server unavailable'
+                  if (!scanSuccess && attempt < maxRetries) await new Promise(r => setTimeout(r, 500))
                 }
-            
-                if (!scanSuccess && attempt < maxRetries) {
-                  console.log(`[DEBUG] Retrying ClamAV scan in 500ms...`)
-                  await new Promise(r => setTimeout(r, 500))
+
+                if (!scanSuccess) {
+                  console.debug(`[ObservationRoutes] Upload rejected by ClamAV for ${info.filename}`)
+                  uploadError = { message: scanErrorMsg, errorCode: 'ClamAVDetectedVirus' }
+                  return
                 }
+
+                if (scannedBuffer) finalBuffer = scannedBuffer
               }
-            
-              if (!scanSuccess) {
-                console.log('[ERROR] All ClamAV scan attempts failed')
-                return next(invalidInput(scanErrorMsg))
+
+              // Store attachment
+              const { observationId, attachmentId } = req.params
+              const content: ExoIncomingAttachmentContent = {
+                bytes: Readable.from(finalBuffer),
+                mediaType: info.mimeType,
+                name: info.filename
               }
-            
-              if (scannedBuffer) finalBuffer = scannedBuffer
-            }
 
-            // ----------------------
-            // Prepare content object to store attachment
-            // ----------------------
-            const { observationId, attachmentId } = req.params
-            const content: ExoIncomingAttachmentContent = {
-              bytes: Readable.from(finalBuffer),
-              mediaType: info.mimeType,
-              name: info.filename
-            }
+              const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = { observationId, attachmentId, content }
+              const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
+              const appRes = await app.storeAttachmentContent(appReq)
 
-            const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
-              observationId,
-              attachmentId,
-              content
+              if (appRes.success) {
+                const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
+                attachmentJson = jsonForAttachment(attachment, `${qualifiedBaseUrl(req)}/${observationId}`)
+                console.debug('[ObservationRoutes] Attachment stored successfully:', attachment.id)
+              } else if (appRes.error) {
+                console.debug('[ObservationRoutes] Attachment storage error:', appRes.error)
+                uploadError = appRes.error
+              }
+            } catch (err) {
+              console.debug('[ObservationRoutes] File processing error:', err)
+              uploadError = err
             }
-            const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
-            const appRes = await app.storeAttachmentContent(appReq)
-
-            // ----------------------
-            // Return JSON for the newly stored attachment
-            // ----------------------
-            if (appRes.success) {
-              const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
-              const attachmentJson = jsonForAttachment(
-                attachment,
-                `${qualifiedBaseUrl(req)}/${observationId}`
-              )
-              console.log('[DEBUG] Attachment stored successfully:', attachmentJson)
-              return res.json(attachmentJson)
-            }
-
-            if (appRes.error) return next(appRes.error)
-            next(invalidInput('Attachment could not be stored'))
-          } catch (err) {
-            next(err)
-          }
+          })()
         })
 
-        // ----------------------
-        // Handle unexpected form fields or limits
-        // ----------------------
-        bb.on('field', (name) => next(invalidInput(`unexpected form field: ${name}`)))
-        bb.on('filesLimit', () => next(invalidInput(`too many files`)))
-        bb.on('fieldsLimit', () => next(invalidInput(`too many fields`)))
-        bb.on('error', (err) => next(err))
+        bb.on('field', (name) => {
+          console.debug('[ObservationRoutes] Unexpected form field:', name)
+          uploadError = invalidInput(`unexpected form field: ${name}`)
+        })
+        bb.on('filesLimit', () => { console.debug('[ObservationRoutes] Too many files'); uploadError = invalidInput('too many files') })
+        bb.on('fieldsLimit', () => { console.debug('[ObservationRoutes] Too many fields'); uploadError = invalidInput('too many fields') })
+        bb.on('error', (err) => { console.debug('[ObservationRoutes] Busboy error:', err); uploadError = err })
 
-        // Pipe request stream into Busboy
+        bb.on('finish', async () => {
+          console.debug('[ObservationRoutes] Busboy finished')
+          if (resultSent) return
+          resultSent = true
+
+          if (filePromise) await filePromise
+
+          if (uploadError) {
+            console.debug('[ObservationRoutes] Sending error response')
+            return next(uploadError)
+          }
+          if (attachmentJson) {
+            console.debug('[ObservationRoutes] Sending success response')
+            return res.json(attachmentJson)
+          }
+          console.debug('[ObservationRoutes] No file uploaded')
+          return next(invalidInput('No file uploaded'))
+        })
+
         req.pipe(bb)
       } catch (err) {
+        console.debug('[ObservationRoutes] Outer error:', err)
         next(err)
       }
     })
+    // .get / .delete unchanged (same as your previous version)
     .get(async (req, res, next) => {
       try {
         const sizeParam = req.query.size
-        const minDimension =
-          typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined
-
+        const minDimension = typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined
         const contentRange = req.headers.range
           ? req.headers.range
               .replace(/bytes=/i, '')
@@ -269,12 +266,15 @@ export function ObservationRoutes(
           }`
         }
 
+        console.debug('[ObservationRoutes] Streaming file to client:', req.params.attachmentId)
         return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
       } catch (err) {
+        console.debug('[ObservationRoutes] GET attachment error:', err)
         next(err)
       }
     })
     .delete(async (req, res) => {
+      console.debug('[ObservationRoutes] DELETE attachment:', req.params.attachmentId)
       res.sendStatus(204)
     })
 

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -98,40 +98,37 @@ export function ObservationRoutes(
           }
 
           try {
-            // -----------------------------
-            // FIX: Guarantee file has bytes and handle viruses
-            // -----------------------------
-            // Step 1: fully buffer the uploaded file
+            // buffer the uploaded file
             const originalChunks: Buffer[] = []
             for await (const chunk of fileStream) {
               originalChunks.push(chunk as Buffer)
             }
             const originalBuffer = Buffer.concat(originalChunks)
 
-            // Step 2: scan with ClamAV
+            // scan with ClamAV
             const passThrough = Readable.from(originalBuffer)
             let scannedStream: Readable
             try {
               scannedStream = await scanAttachmentWithClamAV(passThrough)
             } catch (err) {
-              console.log('❌ [DEBUG] ClamAV rejected file:', err)
+              console.warn('[DEBUG] ClamAV rejected file:', err)
               return next(invalidInput('Uploaded file contains a virus and cannot be stored.'))
             }
 
-            // Step 2b: also handle any emitted errors on scanned stream
+            // handle any emitted errors on scanned stream
             scannedStream.on('error', (err) => {
-              console.log('❌ [DEBUG] Error emitted from scanned stream:', err)
+              console.warn('[DEBUG] Error emitted from scanned stream:', err)
               return next(invalidInput('Uploaded file contains a virus or could not be scanned.'))
             })
 
-            // Step 3: buffer scanned output
+            // buffer scanned output
             const scannedChunks: Buffer[] = []
             for await (const chunk of scannedStream) {
               scannedChunks.push(chunk as Buffer)
             }
             let finalBuffer = Buffer.concat(scannedChunks)
 
-            // Step 4: fallback if scanned result is empty
+            // fallback if scanned result is empty
             if (finalBuffer.length === 0) {
               finalBuffer = originalBuffer
             }

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -7,6 +7,7 @@ import { MageEvent, MageEventId } from '../../entities/events/entities.events'
 import busboy from 'busboy'
 import { invalidInput } from '../../app.api/app.api.errors'
 import { exoObservationModFromJson } from './adapters.observations.dto.ecma404-json'
+import { scanAttachmentWithClamAV } from './adapters.attachments.clamav'
 
 declare module 'express-serve-static-core' {
   interface Request {
@@ -21,18 +22,15 @@ export interface ObservationAppLayer {
   readAttachmentContent: ReadAttachmentContent
 }
 
-export interface ObservationWebAppRequestFactory {
-  <Params extends object>(req: express.Request, params?: Params): Params & ObservationRequest<unknown>
-}
-
-export interface EnsureEventScope {
-  (eventId: MageEventId): Promise<null | { mageEvent: MageEvent, observationRepository: EventScopedObservationRepository }>
-}
-
+export type ObservationWebAppRequestFactory = <Params extends object>(req: express.Request, params?: Params) => Params & ObservationRequest<unknown>
+export type EnsureEventScope = (eventId: MageEventId) => Promise<null | { mageEvent: MageEvent, observationRepository: EventScopedObservationRepository }>
 export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: AttachmentStore, createAppRequest: ObservationWebAppRequestFactory): express.Router {
 
   const routes = express.Router().use(express.json())
 
+  // --------------------------------------
+  // Allocate Observation ID
+  // --------------------------------------
   routes.route('/id')
     .post(async (req, res, next) => {
       const appReq = createAppRequest(req)
@@ -40,7 +38,6 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
       const id = appRes.success
       const path = `${req.baseUrl}/${id}`
       if (id) {
-        // TODO: add location header? kind of a gray area restfully speaking
         return res.status(201).location(path).json({
           id,
           eventId: appReq.context.mageEvent.id,
@@ -50,45 +47,37 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
       next(appRes.error)
     })
 
+  // --------------------------------------
+  // Attachment upload / download / delete
+  // --------------------------------------
   routes.route('/:observationId/attachments/:attachmentId')
     .put(
+      // 1️⃣ Init Busboy for multipart upload
       (req, res, next) => {
-        /*
-        encapsulate the busboy init in a middleware so the request can
-        fail-fast when busboy throws a validation error
-        */
         try {
           req.attachmentUpload = busboy({
             headers: req.headers,
             limits: { files: 1, fields: 0 }
           })
-        }
-        catch (err) {
-          console.error('error initializing attachment upload\n', req.params, '\nheaders:\n', req.headers, '\n', err)
+        } catch (err) {
+          console.error('Error initializing attachment upload\n', req.params, '\nheaders:\n', req.headers, '\n', err)
           return res.status(400).json({ message: err instanceof Error ? err.message : String(err) })
         }
         next()
       },
+      // 2️⃣ Handle Busboy streams
       async (req, res, next) => {
-        const afterUploadStreamEvent = 'afterUploadStream'
-        const sendInvalidRequestStructure = () => next(invalidInput(`request must contain only one file part named 'attachment'`))
-        const afterUploadStream = (finishResponse: () => void) => {
-          if (req.attachmentUpload?.listenerCount(afterUploadStreamEvent)) {
-            return
-          }
-          if (req.attachmentUpload?.writable) {
-            return void(req.attachmentUpload.on(afterUploadStreamEvent, finishResponse))
-          }
-          finishResponse()
-        }
         const { observationId, attachmentId } = req.params
+        const sendInvalidRequestStructure = () => next(invalidInput(`request must contain only one file part named 'attachment'`))
+
         req.pipe(req.attachmentUpload!
           .on('file', async (fieldName, stream, info) => {
+            console.log('Received file', fieldName, info)
+
             if (fieldName !== 'attachment') {
-              // per busboy docs, drain the file stream and move on
-              console.error(`unexpected file entry '${fieldName}' uploading attachment ${attachmentId} on observation ${observationId}`)
+              console.error(`Unexpected file entry '${fieldName}' uploading attachment ${attachmentId} on observation ${observationId}`)
               stream.resume()
-              return afterUploadStream(sendInvalidRequestStructure)
+              return sendInvalidRequestStructure()
             }
 
             // -------------------------------
@@ -102,50 +91,40 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
             // 6. This ensures pre-disk scanning invariant: Busboy stream → ClamAV → clean stream → storage
             // -------------------------------
 
-            const content: ExoIncomingAttachmentContent = {
-              bytes: stream,
-              mediaType: info.mimeType,
-              name: info.filename,
+            try {
+              const cleanStream = await scanAttachmentWithClamAV(stream)
+
+              const content: ExoIncomingAttachmentContent = {
+                bytes: cleanStream,
+                mediaType: info.mimeType,
+                name: info.filename,
+              }
+              const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = { observationId, attachmentId, content }
+              const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
+              const appRes = await app.storeAttachmentContent(appReq)
+
+              if (appRes.success) {
+                const obs = appRes.success
+                const attachment = obs.attachments.find(x => x.id === appReq.attachmentId)!
+                const attachmentJson = jsonForAttachment(attachment, `${qualifiedBaseUrl(req)}/${observationId}`)
+                console.info(`Successfully stored attachment ${attachmentId} on observation ${observationId}`)
+                return res.json(attachmentJson)
+              }
+
+              if (appRes.error) return next(appRes.error)
+              sendInvalidRequestStructure()
+            } catch (err) {
+              console.error('Error processing attachment upload:', err)
+              return next(err)
             }
-            const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = { observationId, attachmentId, content }
-            const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
-            const appRes = await app.storeAttachmentContent(appReq)
-            if (appRes.success) {
-              const obs = appRes.success
-              const attachment = obs.attachments.find(x => x.id === appReq.attachmentId)!
-              const attachmentJson = jsonForAttachment(attachment, `${qualifiedBaseUrl(req)}/${observationId}`)
-              console.info(`successfully stored attachment ${attachmentId} on observation ${observationId}`)
-              return void(afterUploadStream(() => res.json(attachmentJson)))
-            }
-            if (appRes.error) {
-              const error = appRes.error
-              afterUploadStream(() => next(error))
-            }
-            else {
-              afterUploadStream(sendInvalidRequestStructure)
-            }
-            /*
-            per busboy docs, drain the stream and ignore the contents; necessary
-            for the busboy stream to terminate properly
-            */
-            stream.resume()
           })
           .on('field', (fieldName) => {
-            console.error(`unexpected field ${fieldName} uploading attachment ${attachmentId} on observation ${observationId}`)
-            afterUploadStream(sendInvalidRequestStructure)
+            console.error(`Unexpected field ${fieldName} uploading attachment ${attachmentId}`)
+            sendInvalidRequestStructure()
           })
-          .on('filesLimit', () => {
-            console.error(`too many file parts in upload request for attachment ${attachmentId} on observation ${observationId}`)
-            afterUploadStream(sendInvalidRequestStructure)
-          })
-          .on('fieldsLimit', () => {
-            console.error(`too many field parts in upload request for attachment ${attachmentId} on observation ${observationId}`)
-            afterUploadStream(sendInvalidRequestStructure)
-          })
-          .on('close', () => {
-            req.attachmentUpload?.emit(afterUploadStreamEvent)
-            req.attachmentUpload?.removeAllListeners()
-          })
+          .on('filesLimit', () => sendInvalidRequestStructure())
+          .on('fieldsLimit', () => sendInvalidRequestStructure())
+          .on('close', () => req.attachmentUpload?.removeAllListeners())
         )
       }
     )
@@ -178,10 +157,12 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
       return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
     })
     .delete(async (req, res) => {
-      // TODO: this should go away when ios app is fixed to stop sending delete requests
       res.sendStatus(204)
     })
 
+  // --------------------------------------
+  // Update Observation
+  // --------------------------------------
   routes.route('/:observationId')
     .put(async (req, res, next) => {
       const body = req.body

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -80,130 +80,89 @@ export function ObservationRoutes(
   // Attachment upload / download / delete
   // --------------------------------------
   routes
-  .route('/:observationId/attachments/:attachmentId')
-  .put(async (req, res, next) => {
-    try {
-      console.log('[DEBUG] PUT /attachments handler invoked')
-      const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
-      let handled = false
+    .route('/:observationId/attachments/:attachmentId')
+    .put(async (req, res, next) => {
+      try {
+        const bb = busboy({ headers: req.headers, limits: { files: 1, fields: 0 } })
+        let handled = false
 
-      bb.on('file', async (fieldName, fileStream, info) => {
-        console.log(`[DEBUG] file event received: fieldName=${fieldName}, filename=${info.filename}, mimeType=${info.mimeType}`)
-        if (handled) {
-          console.log('[DEBUG] already handled a file, skipping this one')
-          return fileStream.resume()
-        }
-        handled = true
+        bb.on('file', async (fieldName, fileStream, info) => {
+          if (handled) return fileStream.resume()
+          handled = true
 
-        if (fieldName !== 'attachment') {
-          console.log('[DEBUG] invalid fieldName, expected "attachment"')
-          fileStream.resume()
-          return next(invalidInput(`request must contain only one file part named 'attachment'`))
-        }
-
-        try {
-          // buffer the uploaded file
-          const originalChunks: Buffer[] = []
-          for await (const chunk of fileStream) {
-            console.log(`[DEBUG] buffering chunk: ${chunk.length} bytes`)
-            originalChunks.push(chunk as Buffer)
+          if (fieldName !== 'attachment') {
+            fileStream.resume()
+            return next(invalidInput(`request must contain only one file part named 'attachment'`))
           }
-          const originalBuffer = Buffer.concat(originalChunks)
-          console.log(`[DEBUG] total original buffer length: ${originalBuffer.length}`)
 
-          // scan with ClamAV
-          const passThrough = Readable.from(originalBuffer)
-          let scannedStream: Readable
           try {
-            console.log('[DEBUG] sending file to ClamAV for scanning...')
-            scannedStream = await scanAttachmentWithClamAV(passThrough)
-            console.log('[DEBUG] ClamAV scan completed successfully')
+            // buffer the uploaded file
+            const originalChunks: Buffer[] = []
+            for await (const chunk of fileStream) {
+              originalChunks.push(chunk as Buffer)
+            }
+            const originalBuffer = Buffer.concat(originalChunks)
+
+            // scan with ClamAV (wrap buffer in Readable)
+            let scannedStream: Readable
+            try {
+              scannedStream = await scanAttachmentWithClamAV(Readable.from(originalBuffer))
+            } catch {
+              // virus detected or ClamAV failed
+              return next(
+                invalidInput('Uploaded file contains a virus and cannot be stored.')
+              )
+            }
+
+            // buffer scanned output
+            const scannedChunks: Buffer[] = []
+            for await (const chunk of scannedStream) {
+              scannedChunks.push(chunk as Buffer)
+            }
+            let finalBuffer = Buffer.concat(scannedChunks)
+            if (finalBuffer.length === 0) finalBuffer = originalBuffer
+
+            const { observationId, attachmentId } = req.params
+            const content: ExoIncomingAttachmentContent = {
+              bytes: Readable.from(finalBuffer),
+              mediaType: info.mimeType,
+              name: info.filename
+            }
+
+            const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
+              observationId,
+              attachmentId,
+              content
+            }
+            const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
+            const appRes = await app.storeAttachmentContent(appReq)
+
+            if (appRes.success) {
+              const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
+              const attachmentJson = jsonForAttachment(
+                attachment,
+                `${qualifiedBaseUrl(req)}/${observationId}`
+              )
+              return res.json(attachmentJson)
+            }
+
+            if (appRes.error) return next(appRes.error)
+            next(invalidInput('Attachment could not be stored'))
           } catch (err) {
-            console.warn('[DEBUG] ClamAV rejected file:', err)
-            return next(invalidInput('Uploaded file contains a virus and cannot be stored.'))
+            next(err)
           }
+        })
 
-          scannedStream.on('error', (err) => {
-            console.warn('[DEBUG] Error emitted from scanned stream:', err)
-            return next(invalidInput('Uploaded file contains a virus or could not be scanned.'))
-          })
+        bb.on('field', (name) => next(invalidInput(`unexpected form field: ${name}`)))
+        bb.on('filesLimit', () => next(invalidInput(`too many files`)))
+        bb.on('fieldsLimit', () => next(invalidInput(`too many fields`)))
+        bb.on('error', (err) => next(err))
 
-          // buffer scanned output
-          const scannedChunks: Buffer[] = []
-          for await (const chunk of scannedStream) {
-            console.log(`[DEBUG] buffering scanned chunk: ${chunk.length} bytes`)
-            scannedChunks.push(chunk as Buffer)
-          }
-          let finalBuffer = Buffer.concat(scannedChunks)
-          console.log(`[DEBUG] final buffer length after scanning: ${finalBuffer.length}`)
-
-          if (finalBuffer.length === 0) {
-            console.log('[DEBUG] scanned buffer empty, falling back to original buffer')
-            finalBuffer = originalBuffer
-          }
-
-          const { observationId, attachmentId } = req.params
-          const content: ExoIncomingAttachmentContent = {
-            bytes: Readable.from(finalBuffer),
-            mediaType: info.mimeType,
-            name: info.filename
-          }
-
-          console.log(`[DEBUG] storing attachment: observationId=${observationId}, attachmentId=${attachmentId}`)
-          const appReqParams: Omit<StoreAttachmentContentRequest, 'context'> = {
-            observationId,
-            attachmentId,
-            content
-          }
-          const appReq: StoreAttachmentContentRequest = createAppRequest(req, appReqParams)
-          const appRes = await app.storeAttachmentContent(appReq)
-
-          if (appRes.success) {
-            console.log('[DEBUG] attachment stored successfully')
-            const attachment = appRes.success.attachments.find(x => x.id === appReq.attachmentId)!
-            const attachmentJson = jsonForAttachment(
-              attachment,
-              `${qualifiedBaseUrl(req)}/${observationId}`
-            )
-            return res.json(attachmentJson)
-          }
-
-          if (appRes.error) {
-            console.log('[DEBUG] storeAttachmentContent returned error:', appRes.error)
-            return next(appRes.error)
-          }
-
-          next(invalidInput('Attachment could not be stored'))
-        } catch (err) {
-          console.error('[DEBUG] unexpected error in file handling:', err)
-          return next(err)
-        }
-      })
-
-      bb.on('field', (name) => {
-        console.log(`[DEBUG] unexpected form field received: ${name}`)
-        return next(invalidInput(`unexpected form field: ${name}`))
-      })
-      bb.on('filesLimit', () => {
-        console.log('[DEBUG] files limit exceeded')
-        return next(invalidInput(`too many files`))
-      })
-      bb.on('fieldsLimit', () => {
-        console.log('[DEBUG] fields limit exceeded')
-        return next(invalidInput(`too many fields`))
-      })
-      bb.on('error', (err) => {
-        console.error('[DEBUG] busboy error:', err)
-        return next(err)
-      })
-
-      req.pipe(bb)
-    } catch (err) {
-      console.error('[DEBUG] unexpected error in PUT handler:', err)
-      return next(err)
-    }
-  })
-
+        req.pipe(bb)
+      } catch (err) {
+        next(err)
+      }
+    })
     .get(async (req, res, next) => {
       try {
         const sizeParam = req.query.size
@@ -215,7 +174,7 @@ export function ObservationRoutes(
               .replace(/bytes=/i, '')
               .split('-')
               .map(x => parseInt(x, 10))
-              .filter(x => typeof x === 'number' && !Number.isNaN(x))
+              .filter(x => !Number.isNaN(x))
           : []
 
         const appReq: ReadAttachmentContentRequest = createAppRequest(req, {
@@ -226,19 +185,13 @@ export function ObservationRoutes(
             contentRange.length === 2 ? { start: contentRange[0], end: contentRange[1] } : undefined
         })
         const appRes = await app.readAttachmentContent(appReq)
-        if (appRes.error) {
-          return next(appRes.error)
-        }
+        if (appRes.error) return next(appRes.error)
 
         const content = appRes.success
-        if (!content) {
-          return res.status(500).json({ message: 'unknown application response' })
-        }
+        if (!content) return res.status(500).json({ message: 'unknown application response' })
 
         const { bytesRange } = content
-        const headers: any = {
-          'content-type': String(content.attachment.contentType)
-        }
+        const headers: any = { 'content-type': String(content.attachment.contentType) }
 
         if (content.attachment.size && content.attachment.size > 0) {
           headers['content-length'] = String(
@@ -276,9 +229,8 @@ export function ObservationRoutes(
           .json({ message: 'Body observation ID does not match path observation ID' })
       }
       const mod = exoObservationModFromJson({ ...body, id: observationId })
-      if (mod instanceof Error) {
-        return next(mod)
-      }
+      if (mod instanceof Error) return next(mod)
+
       const appReq: SaveObservationRequest = createAppRequest(req, { observation: mod })
       if (
         Object.prototype.hasOwnProperty.call(body, 'eventId') &&
@@ -306,13 +258,8 @@ export type WebObservation = Omit<ExoObservation, 'attachments' | 'state'> & {
   attachments: WebAttachment[]
 }
 
-export type WebObservationState = ObservationState & {
-  url: string
-}
-
-export type WebAttachment = ExoAttachment & {
-  url?: string
-}
+export type WebObservationState = ObservationState & { url: string }
+export type WebAttachment = ExoAttachment & { url?: string }
 
 export function jsonForObservation(o: ExoObservation, baseUrl: string): WebObservation {
   const obsUrl = `${baseUrl}/${o.id}`

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -119,23 +119,28 @@ export function ObservationRoutes(
               const chunks: Buffer[] = []
               for await (const chunk of fileStream) chunks.push(chunk as Buffer)
               const originalBuffer = Buffer.concat(chunks)
-              let finalBuffer = originalBuffer
+
         
               // ClamAV scan
+              let finalBuffer: Buffer = Buffer.alloc(0)
+
               if (process.env.CLAM_AV_URL) {
                 const maxRetries = 3
                 let attempt = 0
                 let scanSuccess = false
                 let scanErrorMsg = ''
                 let scannedBuffer: Buffer | null = null
-        
+
                 while (attempt < maxRetries && !scanSuccess) {
                   attempt++
                   try {
                     const scannedResult = await scanAttachmentWithClamAV(Readable.from(originalBuffer))
+
                     if (scannedResult.status === 'clean' && scannedResult.stream) {
                       const scannedChunks: Buffer[] = []
-                      for await (const chunk of scannedResult.stream) scannedChunks.push(chunk as Buffer)
+                      for await (const chunk of scannedResult.stream) {
+                        scannedChunks.push(chunk as Buffer)
+                      }
                       scannedBuffer = Buffer.concat(scannedChunks)
                       scanSuccess = true
                     } else {
@@ -144,16 +149,21 @@ export function ObservationRoutes(
                   } catch (err) {
                     scanErrorMsg = 'Virus scanning server unavailable'
                   }
-                  if (!scanSuccess && attempt < maxRetries) await new Promise(r => setTimeout(r, 500))
+
+                  if (!scanSuccess && attempt < maxRetries) {
+                    await new Promise(r => setTimeout(r, 500))
+                  }
                 }
-        
+
                 if (!scanSuccess) {
                   fileStream.resume()
                   uploadErrors.push({ file: info.filename, error: scanErrorMsg })
                   return
                 }
-        
-                if (scannedBuffer) finalBuffer = scannedBuffer
+
+                if (scannedBuffer) {
+                  finalBuffer = scannedBuffer
+                }
               }
         
               // Store attachment

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -103,25 +103,30 @@ export function ObservationRoutes(
             }
             const originalBuffer = Buffer.concat(originalChunks)
 
-            // scan with ClamAV (wrap buffer in Readable)
-            let scannedStream: Readable
-            try {
-              scannedStream = await scanAttachmentWithClamAV(Readable.from(originalBuffer))
-            } catch {
-              // virus detected or ClamAV failed
-              return next(
-                invalidInput('Uploaded file contains a virus and cannot be stored.')
-              )
-            }
+            let finalBuffer = originalBuffer
 
-            // buffer scanned output
-            const scannedChunks: Buffer[] = []
-            for await (const chunk of scannedStream) {
-              scannedChunks.push(chunk as Buffer)
+            // Only scan if ClamAV is configured
+            if (process.env.CLAM_AV_URL) {
+              try {
+                const scannedStream = await scanAttachmentWithClamAV(
+                  Readable.from(originalBuffer)
+                )
+            
+                const scannedChunks: Buffer[] = []
+                for await (const chunk of scannedStream) {
+                  scannedChunks.push(chunk as Buffer)
+                }
+            
+                const scannedBuffer = Buffer.concat(scannedChunks)
+                if (scannedBuffer.length > 0) {
+                  finalBuffer = scannedBuffer
+                }
+              } catch {
+                return next(
+                  invalidInput('Uploaded file contains a virus and cannot be stored.')
+                )
+              }
             }
-            let finalBuffer = Buffer.concat(scannedChunks)
-            if (finalBuffer.length === 0) finalBuffer = originalBuffer
-
             const { observationId, attachmentId } = req.params
             const content: ExoIncomingAttachmentContent = {
               bytes: Readable.from(finalBuffer),

--- a/service/src/adapters/observations/adapters.observations.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.controllers.web.ts
@@ -1,6 +1,7 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import express from 'express'
 import { compatibilityMageAppErrorHandler } from '../adapters.controllers.web'
-import { AllocateObservationId, ExoAttachment, ExoIncomingAttachmentContent, ExoObservation, ExoObservationMod, ObservationRequest, ReadAttachmentContent, ReadAttachmentContentRequest, SaveObservation, SaveObservationRequest, StoreAttachmentContent, StoreAttachmentContentRequest } from '../../app.api/observations/app.api.observations'
+import { AllocateObservationId, ExoAttachment, ExoIncomingAttachmentContent, ExoObservation, ObservationRequest, ReadAttachmentContent, ReadAttachmentContentRequest, SaveObservation, SaveObservationRequest, StoreAttachmentContent, StoreAttachmentContentRequest } from '../../app.api/observations/app.api.observations'
 import { AttachmentStore, EventScopedObservationRepository, ObservationState } from '../../entities/observations/entities.observations'
 import { MageEvent, MageEventId } from '../../entities/events/entities.events'
 import busboy from 'busboy'
@@ -89,6 +90,18 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
               stream.resume()
               return afterUploadStream(sendInvalidRequestStructure)
             }
+
+            // -------------------------------
+            // PLAN FOR PRE-DISK CLAMAV SCAN
+            // -------------------------------
+            // 1. 'stream' is the first point we have the uploaded file bytes (BLOB in memory)
+            // 2. Before writing anything to disk ($MAGE_ATTACHMENT_DIR), pipe 'stream' through ClamAV
+            // 3. Fail fast if ClamAV detects infection: reject request, do NOT persist bytes or metadata
+            // 4. Only after ClamAV scan passes, pass the clean stream to storeAttachmentContent()
+            // 5. storeAttachmentContent() will handle fs.move() to pod filesystem and Mongo metadata commit
+            // 6. This ensures pre-disk scanning invariant: Busboy stream → ClamAV → clean stream → storage
+            // -------------------------------
+
             const content: ExoIncomingAttachmentContent = {
               bytes: stream,
               mediaType: info.mimeType,
@@ -117,7 +130,7 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
             */
             stream.resume()
           })
-          .on('field', (fieldName, content, info) => {
+          .on('field', (fieldName) => {
             console.error(`unexpected field ${fieldName} uploading attachment ${attachmentId} on observation ${observationId}`)
             afterUploadStream(sendInvalidRequestStructure)
           })
@@ -164,7 +177,7 @@ export function ObservationRoutes(app: ObservationAppLayer, attachmentStore: Att
       }
       return content.bytes.pipe(res.writeHead(bytesRange ? 206 : 200, headers))
     })
-    .delete(async (req, res, next) => {
+    .delete(async (req, res) => {
       // TODO: this should go away when ios app is fixed to stop sending delete requests
       res.sendStatus(204)
     })


### PR DESCRIPTION
# Pre-Disk ClamAV Attachment Scanning Epic

## Summary
Finalizes all back-end work for the **pre-disk ClamAV attachment scanning epic**, including Tickets `#1751, #1752, #1753, and #1754 `— all consolidated into this PR for #1755. This is the single source of truth for this epic.

- **Px deployments:** attachments are scanned pre-disk in the Busboy stream before any filesystem or MongoDB writes.  
- **Non-Px deployments:** scans are safely skipped; attachments are passed directly to `storeAttachmentContent()`.  
- All acceptance criteria from Krista and Story 0 lifecycle are satisfied.
- There is NO front-end/UI messaging included in this PR (that will be delivered in the next ticket, #1756)

## Key Features & Behavior

### ClamAV Scan
- Pre-disk scanning occurs in the Busboy stream for Px deployments.  
- Infected files (e.g., `eicar.txt`) are **rejected** with a clear error message.  
- Clean files pass successfully.  
- Non-Px deployments skip scanning safely.

### Attachment Lifecycle
- Fully respects the Story 0 attachment lifecycle.  
- Pre-disk scan occurs **before filesystem writes and MongoDB commits**.  
- Handles **partial attachments** correctly: incomplete uploads trigger proper rejection/error reporting.

### Front-End
- Page updates automatically; no manual refresh required.  
- Users see only success or failure of the attachment; **no ClamAV internal messages are exposed**.

## Pre-Testing / Local Setup

### AWS SSO Login and ClamAV Forwarding

To run the pre-disk ClamAV scan process, ensure the following is in place:

1. **Add the ClamAV environment variable** to `docker-compose.yml` just under `SFTP_PLUGIN_CONFIG_SALT` (around line 38):

`CLAM_AV_URL: tcp://clamav:3310`

1a.  Make certain you export the new required env variable in a current running session terminal window or VS Code terminal: 
`export CLAM_AV_URL="tcp://127.0.0.1:3310"`

2. **AWS SSO Login**  
   - You must have an AWS account for `magegov`.  
   - Open a terminal and run:
`aws sso login --profile magegov`

- Follow the web page flow, including two-factor authentication (Authy, DUO, etc.).

3. **Forward to the PX ClamAV server**:
`kubectl port-forward svc/clamav 3310:3310 -n clamav`

- You should see output like:
```
Forwarding from 127.0.0.1:3310 -> 3310
Forwarding from [::1]:3310 -> 3310
```
- Leave this terminal window running while testing.

## Testing

- Verify that `EICAR.txt` is **rejected**.  
- Verify multiple clean files (PNG, text) are **accepted**.  
- Confirm Px/non-Px behavior matches configuration.  
- End-to-end attachment lifecycle can be verified.  

## Conclusion

This PR includes, consolidates and proves all back-end work for the **pre-disk ClamAV attachment scanning** epic.