### PR TITLE
Update yaml to 2.8.3 for Mage Service

### DIFF
--- a/service/npm-shrinkwrap.json
+++ b/service/npm-shrinkwrap.json
@@ -58,7 +58,7 @@
         "wms-capabilities": "0.6.0",
         "xmlbuilder2": "3.1.1",
         "xpath": "0.0.34",
-        "yaml": "2.8.2"
+        "yaml": "2.8.3"
       },
       "bin": {
         "mage.service": "bin/mage.service.js"
@@ -12868,9 +12868,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/service/npm-shrinkwrap.json
+++ b/service/npm-shrinkwrap.json
@@ -58,7 +58,7 @@
         "wms-capabilities": "0.6.0",
         "xmlbuilder2": "3.1.1",
         "xpath": "0.0.34",
-        "yaml": "1.10.2"
+        "yaml": "2.8.2"
       },
       "bin": {
         "mage.service": "bin/mage.service.js"
@@ -12868,12 +12868,18 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/service/package.json
+++ b/service/package.json
@@ -78,7 +78,7 @@
     "wms-capabilities": "0.6.0",
     "xmlbuilder2": "3.1.1",
     "xpath": "0.0.34",
-    "yaml": "1.10.2"
+    "yaml": "2.8.2"
   },
   "devDependencies": {
     "@fluffy-spoon/substitute": "1.208.0",

--- a/service/package.json
+++ b/service/package.json
@@ -78,7 +78,7 @@
     "wms-capabilities": "0.6.0",
     "xmlbuilder2": "3.1.1",
     "xpath": "0.0.34",
-    "yaml": "2.8.2"
+    "yaml": "2.8.3"
   },
   "devDependencies": {
     "@fluffy-spoon/substitute": "1.208.0",


### PR DESCRIPTION
This pr update the yaml module to the latest version. This impacts the openapi endpoint. To test, hit the `/api/docs/openapi.yaml` endpoint.