### PR TITLE
Remove webfontloader dependency

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -73,7 +73,6 @@
         "tslib": "2.8.1",
         "ui-select": "0.19.8",
         "underscore": "1.13.6",
-        "webfontloader": "1.6.6",
         "zone.js": "0.11.4",
         "zxcvbn": "4.4.2"
       },
@@ -18309,11 +18308,6 @@
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
       "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
       "optional": true
-    },
-    "node_modules/webfontloader": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.6.tgz",
-      "integrity": "sha512-DnkOs1euvRF+ohMIxYNVaRm8hOJ7fYokVmMIcRKurJzTGz7bMgQOUfV6hWdj3qe/rPErbEh3GQmhDzAP/kKDMg=="
     },
     "node_modules/webpack": {
       "version": "5.75.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -124,7 +124,6 @@
     "tslib": "2.8.1",
     "ui-select": "0.19.8",
     "underscore": "1.13.6",
-    "webfontloader": "1.6.6",
     "zone.js": "0.11.4",
     "zxcvbn": "4.4.2"
   },


### PR DESCRIPTION
This PR removes the webfontloader dependency which is unused in the web app. To test, verify mage builds and the web app looks normal.