### PR TITLE
Update fs-extra dependency

### DIFF
--- a/service/npm-shrinkwrap.json
+++ b/service/npm-shrinkwrap.json
@@ -29,7 +29,7 @@
         "express": "4.21.2",
         "express-session": "1.18.1",
         "file-type": "16.5.4",
-        "fs-extra": "4.0.3",
+        "fs-extra": "11.3.4",
         "geojson": "0.5.0",
         "geojson-validation": "1.0.2",
         "json2csv": "5.0.7",
@@ -6053,13 +6053,17 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -7501,9 +7505,13 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -12347,11 +12355,12 @@
       "license": "MIT"
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {

--- a/service/package.json
+++ b/service/package.json
@@ -49,7 +49,7 @@
     "express": "4.21.2",
     "express-session": "1.18.1",
     "file-type": "16.5.4",
-    "fs-extra": "4.0.3",
+    "fs-extra": "11.3.4",
     "geojson": "0.5.0",
     "geojson-validation": "1.0.2",
     "json2csv": "5.0.7",

--- a/service/src/routes/observations.js
+++ b/service/src/routes/observations.js
@@ -9,7 +9,6 @@ module.exports = function (app, security) {
     archiver = require("archiver"),
     path = require("path"),
     environment = require("../environment/env"),
-    fs = require("fs-extra"),
     moment = require("moment"),
     Team = require("../models/team"),
     access = require("../access"),
@@ -134,8 +133,7 @@ module.exports = function (app, security) {
         return res
           .status(400)
           .send(
-            `Invalid attachment '${
-              attachment.name
+            `Invalid attachment '${attachment.name
             }', type must be one of ${fieldDefinition.allowedAttachmentTypes.join(
               " or "
             )}`
@@ -469,8 +467,8 @@ module.exports = function (app, security) {
               .status(404)
               .send(
                 "Observation with id " +
-                  req.params.observationIdInPath +
-                  " does not exist"
+                req.params.observationIdInPath +
+                " does not exist"
               );
 
           const response = observationXform.transform(


### PR DESCRIPTION
This PR updates the fs-extra package to the latest version. This is a fairly big jump in version so make sure to test to ensure it still works. This package touches Exporting, Icons, User Avatars, Attachments, and KML importing. Verify they still work.