### PR TITLE
Revert docker-compose.yml to bitnami/mongodb:6.0.13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   mage-db:
-    image: bitnami/mongodb:6.0.13
+    image: mongo:6.0.27
     # Uncomment the following ports block to allow the mongo client on your
     # host machine to connect to MongoDB in the Docker container.
     # ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
 version: "3"
 services:
   mage-db:
-    image: mongo:6.0.4
-    container_name: mage-db
+    image: bitnami/mongodb:6.0.13
+    # Uncomment the following ports block to allow the mongo client on your
+    # host machine to connect to MongoDB in the Docker container.
+    # ports:
+    #   - 27017:27017
     ports:
       - 27017:27017
     volumes:
@@ -32,6 +35,20 @@ services:
       SFTP_PLUGIN_CONFIG_SALT: "A0E6D3B4-25BD-4DD6-BBC9-B367931966AB"
       CLAM_AV_URL: tcp://host.docker.internal:3310 # Mac host connection for ClamAV
     restart: unless-stopped
+
+  # Uncomment the following block to enable the TLS reverse proxy.  You will
+  # also need to generate the key and certificate as the README describes.
+  # mage-web-proxy:
+  #   image: nginx
+  #   volumes:
+  #     - ./web/nginx.conf:/etc/nginx/nginx.conf
+  #     - ./web/mage-web.crt:/etc/nginx/ssl/web.crt
+  #     - ./web/mage-web.key:/etc/nginx/ssl/web.key
+  #   ports:
+  #     - 4280:80
+  #     - 4243:4243
+  #   networks:
+  #     - mage.net
 
 networks:
   mage.net:


### PR DESCRIPTION
## Hotfix: Restore docker-compose.yml to correct MongoDB image and comments

### Problem
The merge of PR #408 (predisk-scanning-1756) inadvertently changed the MongoDB image from `bitnami/mongodb:6.0.13` to `mongo:6.0.4` and removed two useful comment blocks from `docker-compose.yml`.

### Changes
- Reverted MongoDB image back to `bitnami/mongodb:6.0.13`
- Removed `container_name: mage-db` (was not in develop)
- Restored comment block explaining how to enable the MongoDB port for local client access
- Restored comment block for the optional TLS reverse proxy configuration

### Impact
- No functional code changes
- No effect on attachment scanning work
- Restores `docker-compose.yml` to its correct pre-merge state