### PR TITLE
SFTP improvements - observation naming & backfill skipping

### DIFF
--- a/plugins/sftp/README.md
+++ b/plugins/sftp/README.md
@@ -1,0 +1,83 @@
+# MAGE SFTP Plugin
+
+Automatically exports MAGE observations to a remote SFTP server as they are created or updated. Designed for operational environments where field data needs to flow into an external system (data warehouse, analysis pipeline, archive) without manual intervention.
+
+---
+
+## How It Works
+
+The plugin runs a background polling loop on a configurable interval (default: 60 seconds). On each tick it:
+
+1. Queries for new or updated observations across active MAGE events
+2. Packages each observation as a `.zip` archive containing a GeoJSON file and any media attachments
+3. Uploads the archive to the configured SFTP server
+4. Records the sync status of each observation in MongoDB
+
+Uploads are tracked individually per observation so failures can be retried and the admin can see the sync state of every record.
+
+---
+
+## Archive Format
+
+Each observation is exported as `{observationId}.zip` containing:
+
+- **`observation.geojson`** — a GeoJSON Feature with:
+  - The observation's geometry
+  - Event name and ID
+  - Submitting user's display name
+  - All form field values, keyed by field title
+  - File paths to any attachments within the zip
+- **`media/{attachmentId}/{filename}`** — one entry per attachment
+
+If an observation has attachments that haven't finished uploading yet, the plugin marks it `PENDING` and retries it on the next cycle until a configurable timeout is reached, at which point it uploads whatever is available.
+
+---
+
+## Sync Status
+
+Every observation processed by the plugin gets a status record in MongoDB:
+
+| Status | Meaning |
+|---|---|
+| `SUCCESS` | Archive uploaded successfully |
+| `FAILED` | Archive creation or upload failed |
+| `PENDING` | Attachments incomplete — will retry |
+| `SKIPPED` | Observation predated the plugin start; not uploaded |
+
+---
+
+## Configuration
+
+Configured through the MAGE admin panel under **Admin → Plugins → SFTP**. Key settings:
+
+| Setting | Description | Default |
+|---|---|---|
+| Enabled | Master on/off switch | `false` |
+| Interval | How often to poll for new observations (seconds) | `60` |
+| Trigger rule | `Create` = new observations only; `CreateAndUpdate` = also re-upload on edits | `CreateAndUpdate` |
+| Attachment timeout | Seconds to wait for attachments before uploading incomplete archive | `60` |
+| Event filter | Sync all events, or include/exclude a specific list | All |
+| SFTP host / port / path | Remote server connection details | — |
+| SFTP username | Login username for the remote server | — |
+
+Authentication uses a private key file. The key is provided via the admin UI and stored on the server; its path is set via the `MAGE_SFTP_KEY_FILE` environment variable.
+
+---
+
+## Package Structure
+
+```
+plugins/sftp/
+├── service/          # Node.js backend — polling loop, SFTP client, MongoDB status tracking
+│   └── src/
+│       ├── index.ts                        Plugin entry point + Express routes
+│       ├── controller/controller.ts        Core sync loop and orchestration
+│       ├── adapters/
+│       │   ├── adapters.sftp.mongoose.ts   MongoDB status model and repository
+│       │   └── adapters.sftp.teams.ts      Teams lookup
+│       ├── configuration/SFTPPluginConfig.ts  Config interface and defaults
+│       └── format/
+│           ├── entities.format.ts          Archive types and factory
+│           └── geojson.ts                  GeoJSON + zip formatter
+└── web/              # Angular admin UI — configuration form served as a plugin tab
+```

--- a/plugins/sftp/service/src/adapters/adapters.sftp.mongoose.ts
+++ b/plugins/sftp/service/src/adapters/adapters.sftp.mongoose.ts
@@ -6,6 +6,7 @@ export enum SftpStatus {
   SUCCESS = 'SUCCESS',
   FAILED = 'FAILED',
   PENDING = 'PENDING',
+  SKIPPED = 'SKIPPED' /** Adding new status to show Admin obsv. was skipped for sftp loading */
 }
 
 const SftpObservationsSchema = new mongoose.Schema({
@@ -44,6 +45,7 @@ export interface SftpObservationRepository {
   isProcessed(eventId: MageEventId, observationId: ObservationId): Promise<Boolean>
   isSyncedAtLastModified(eventId: MageEventId, observationId: ObservationId, lastModified: Date): Promise<boolean>
   postStatus(eventId: MageEventId, observationId: ObservationId, status: SftpStatus, lastObservationModified?: Date): Promise<SftpAttrs | null>
+  markManySkipped(eventId: MageEventId, observationIds: ObservationId[]): Promise<void>
 }
 
 export class MongooseSftpObservationRepository implements SftpObservationRepository {
@@ -102,6 +104,18 @@ export class MongooseSftpObservationRepository implements SftpObservationReposit
     }
     const document = await this.model.findOneAndUpdate({ eventId: eventId, observationId: observationId }, update, { upsert: true })
     return document ? (document.toJSON() as unknown as SftpAttrs) : null
+  }
+
+  async markManySkipped(eventId: MageEventId, observationIds: ObservationId[]): Promise<void> {
+    if (!observationIds.length) return
+    const ops = observationIds.map(observationId => ({
+      updateOne: {
+        filter: { eventId, observationId },
+        update: { $setOnInsert: { eventId, observationId, status: SftpStatus.SKIPPED } },
+        upsert: true
+      }
+    }))
+    await this.model.bulkWrite(ops)
   }
 
 }

--- a/plugins/sftp/service/src/controller/controller.ts
+++ b/plugins/sftp/service/src/controller/controller.ts
@@ -1,6 +1,6 @@
 import { PagingParameters } from '@ngageoint/mage.service/lib/entities/entities.global';
 import { MageEvent, MageEventRepository } from '@ngageoint/mage.service/lib/entities/events/entities.events';
-import { AttachmentStore, Observation, ObservationAttrs, ObservationRepositoryForEvent } from '@ngageoint/mage.service/lib/entities/observations/entities.observations';
+import { AttachmentStore, EventScopedObservationRepository, Observation, ObservationAttrs, ObservationRepositoryForEvent } from '@ngageoint/mage.service/lib/entities/observations/entities.observations';
 import { UserRepository } from "@ngageoint/mage.service/lib/entities/users/entities.users";
 import { PluginStateRepository } from '@ngageoint/mage.service/lib/plugins.api';
 import SFTPClient from 'ssh2-sftp-client';
@@ -9,7 +9,7 @@ import { SFTPPluginConfig, defaultSFTPPluginConfig, EventFilterMode } from '../c
 import { ArchiveFormat, ArchiveStatus, ArchiverFactory, ArchiveResult, TriggerRule } from '../format/entities.format';
 import fs from 'fs';
 import path from 'path';
-import { SftpObservationRepository, SftpStatus, MongooseSftpObservationRepository, SftpObservationModel } from '../adapters/adapters.sftp.mongoose';
+import { SftpAttrs, SftpObservationRepository, SftpStatus, MongooseSftpObservationRepository, SftpObservationModel } from '../adapters/adapters.sftp.mongoose';
 import { MongooseTeamsRepository } from '../adapters/adapters.sftp.teams';
 import { Connection } from 'mongoose';
 
@@ -327,7 +327,7 @@ export class SftpController {
   /**
    * Returns all SFTP sync records for an event, with total counts per status.
    */
-  public async getObservationStatuses(eventId: number, statusFilter?: SftpStatus[]): Promise<{ records: any[], counts: Record<string, number> }> {
+  public async getObservationStatuses(eventId: number, statusFilter?: SftpStatus[]): Promise<{ records: SftpAttrs[], counts: Record<string, number> }> {
     const records = statusFilter?.length
       ? await this.sftpObservationRepository.findAllByStatus(eventId, statusFilter)
       : await this.sftpObservationRepository.findAll(eventId)
@@ -540,12 +540,12 @@ export class SftpController {
   }
 
   // Checks for any observation that predates the plugin start with no sftp record and marks them as 'SKIPPED'
-  private async skipMissedObservations(event: MageEvent, observationRepository: any): Promise<void> {
+  private async skipMissedObservations(event: MageEvent, observationRepository: EventScopedObservationRepository): Promise<void> {
     if (this.startupSkipDone.has(event.id)) return
     this.startupSkipDone.add(event.id)
 
     const existing = await this.sftpObservationRepository.findAll(event.id)
-    const knownIds = new Set(existing.map((r: any) => r.observationId))
+    const knownIds = new Set(existing.map(r => r.observationId))
 
     const skippedIds: string[] = []
     const page: PagingParameters = { pageSize: 500, pageIndex: 0 }

--- a/plugins/sftp/service/src/controller/controller.ts
+++ b/plugins/sftp/service/src/controller/controller.ts
@@ -105,6 +105,18 @@ export class SftpController {
   archiveFactory: ArchiverFactory
 
   /**
+   * Timestamp (ms) when this controller instance was created. Used to prevent
+   * backfilling observations that predate the plugin start.
+   */
+  private readonly pluginStartTime: number = Date.now()
+
+  /**
+   * Tracks which event IDs have already had their pre-start observations marked
+   * SKIPPED, so the scan only runs once per process start per event.
+   */
+  private readonly startupSkipDone = new Set<number>()
+
+  /**
    * Console logger
    */
   private console: Console;
@@ -313,6 +325,30 @@ export class SftpController {
   }
 
   /**
+   * Returns all SFTP sync records for an event, with total counts per status.
+   */
+  public async getObservationStatuses(eventId: number, statusFilter?: SftpStatus[]): Promise<{ records: any[], counts: Record<string, number> }> {
+    const records = statusFilter?.length
+      ? await this.sftpObservationRepository.findAllByStatus(eventId, statusFilter)
+      : await this.sftpObservationRepository.findAll(eventId)
+    const everything = statusFilter?.length
+      ? await this.sftpObservationRepository.findAll(eventId)
+      : records
+    const counts: Record<string, number> = { SUCCESS: 0, FAILED: 0, PENDING: 0, SKIPPED: 0 }
+    for (const r of everything) counts[r.status] = (counts[r.status] ?? 0) + 1
+    return { records, counts }
+  }
+
+  /**
+   * Requeues observations as PENDING so the next poll cycle retries them.
+   */
+  public async requeueObservations(eventId: number, observationIds: string[]): Promise<void> {
+    for (const id of observationIds) {
+      await this.sftpObservationRepository.postStatus(eventId, id, SftpStatus.PENDING)
+    }
+  }
+
+  /**
    * Tests the connection to an SFTP server with the given configuration
    * @param config The SFTP client configuration to test
    * @returns A result object indicating success or failure with a message
@@ -446,6 +482,8 @@ export class SftpController {
   private async processEvent(event: MageEvent, configuration: SFTPPluginConfig) {
     const observationRepository = await this.observationRepository(event.id);
 
+    await this.skipMissedObservations(event, observationRepository)
+
     this.console.debug('fetching pending observations for event ' + event.name);
     const pending = await this.sftpObservationRepository.findAllByStatus(event.id, [SftpStatus.PENDING])
     for (const sftpAttrs of pending) {
@@ -456,7 +494,7 @@ export class SftpController {
     }
 
     const latestSyncedTime = await this.sftpObservationRepository.findLatestSyncedObservationTime(event.id)
-    let queryTime: number = latestSyncedTime ? latestSyncedTime.getTime() : 0
+    let queryTime: number = Math.max(latestSyncedTime?.getTime() ?? 0, this.pluginStartTime)
 
     const page: PagingParameters = {
       pageSize: configuration.pageSize,
@@ -501,6 +539,35 @@ export class SftpController {
     return filtered
   }
 
+  // Checks for any observation that predates the plugin start with no sftp record and marks them as 'SKIPPED'
+  private async skipMissedObservations(event: MageEvent, observationRepository: any): Promise<void> {
+    if (this.startupSkipDone.has(event.id)) return
+    this.startupSkipDone.add(event.id)
+
+    const existing = await this.sftpObservationRepository.findAll(event.id)
+    const knownIds = new Set(existing.map((r: any) => r.observationId))
+
+    const skippedIds: string[] = []
+    const page: PagingParameters = { pageSize: 500, pageIndex: 0 }
+
+    while (true) {
+      const { items } = await observationRepository.findLastModifiedAfter(0, page)
+      if (!items.length) break
+      for (const obs of items) {
+        if (obs.lastModified.getTime() < this.pluginStartTime && !knownIds.has(obs.id)) {
+          skippedIds.push(obs.id)
+        }
+      }
+      if (items.length < page.pageSize) break
+      page.pageIndex++
+    }
+
+    if (skippedIds.length) {
+      await this.sftpObservationRepository.markManySkipped(event.id, skippedIds)
+      this.console.info(`Marked ${skippedIds.length} pre-existing observations as SKIPPED for event ${event.name}`)
+    }
+  }
+
   private async sftpObservation(
     observation: Observation,
     event: MageEvent,
@@ -514,12 +581,8 @@ export class SftpController {
     if (result instanceof ArchiveResult) {
       if (result.status === ArchiveStatus.Complete || (result.status === ArchiveStatus.Incomplete && (observation.lastModified.getTime() + timeout) > Date.now())) {
         try {
-          const teams = await this.teamRepository.findTeamsByUserId(observation.userId);
-          // Filter out events from the teams response and teams that are not in the event
-          const newTeams = teams.filter((team) => team.teamEventId == null && event.teamIds?.map((teamId) => teamId.toString()).includes(team._id.toString()))
-          const teamNames = newTeams.length > 0 ? `${newTeams.map(team => team.name).join('_')}_` : '';
-          const user = await this.userRepository.findById(observation.userId || '')
-          const filename = (`${event.name}_${teamNames}${user?.username || observation.userId}_${observation.id}`)
+          /** File naming is just observation id to reduce clutter */
+          const filename = (`${observation.id}`)
 
           const stream = new PassThrough()
           result.archive.pipe(stream)


### PR DESCRIPTION
Simplifies the SFTP zip archive filename from the verbose {eventName}_{teamName}_{username}_{observationId}
format down to just {observationId}. The full event, team, and user context is already present inside the
GeoJSON, making the filename fragments redundant.

Adds start-forward sync behavior so the plugin no longer attempts to backfill observations that existed before
it started. Observations that fall in the gap between a plugin shutdown and restart are bulk-marked as
SKIPPED rather than left in an ambiguous state. New observations created after startup sync normally. Existing
records (SUCCESS, FAILED) are never overwritten.