### PR TITLE
Cap admin page width and centralize breadcrumb rendering in the shell

### DIFF
--- a/web-app/src/app/admin/admin-authentication/admin-authentication-create/admin-authentication-create.component.html
+++ b/web-app/src/app/admin/admin-authentication/admin-authentication-create/admin-authentication-create.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="create-page">
   <mat-horizontal-stepper [linear]="true" #stepper>
     <mat-step

--- a/web-app/src/app/admin/admin-authentication/admin-authentication-create/admin-authentication-create.component.ts
+++ b/web-app/src/app/admin/admin-authentication/admin-authentication-create/admin-authentication-create.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { TypeChoice } from './admin-create.model';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AuthenticationConfigurationService } from '../../services/admin-authentication-configuration.service';
 import { MatSnackBar as MatSnackBar } from '@angular/material/snack-bar';
 import { Strategy } from '../../admin-authentication/admin-settings.model';
@@ -24,14 +25,13 @@ import {
     standalone: false
 })
 export class AuthenticationCreateComponent implements OnInit, OnDestroy {
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Authentication',
-      icon: 'lock',
-      route: ['../../security']
-    },
-    { title: 'New' }
-  ];
+  breadcrumbs: AdminBreadcrumb[] = [{
+    title: 'Authentication',
+    icon: 'lock',
+    route: ['/admin/security']
+  },{
+    title: 'New'
+  }];
 
   strategy: Strategy & { settings: any } = this.buildDefaultStrategy();
 
@@ -75,7 +75,8 @@ export class AuthenticationCreateComponent implements OnInit, OnDestroy {
     private readonly snackBar: MatSnackBar,
     private readonly router: Router,
     private route: ActivatedRoute,
-    private readonly authenticationConfigurationService: AuthenticationConfigurationService
+    private readonly authenticationConfigurationService: AuthenticationConfigurationService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {
     this.form = this.fb.group({
       title: this.fb.nonNullable.control('', Validators.required),
@@ -101,6 +102,8 @@ export class AuthenticationCreateComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+
     this.titleCtrl.valueChanges
       .pipe(takeUntil(this.destroy$))
       .subscribe((v) => {

--- a/web-app/src/app/admin/admin-authentication/admin-authentication.component.html
+++ b/web-app/src/app/admin/admin-authentication/admin-authentication.component.html
@@ -1,11 +1,11 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions">
     <button matButton="outlined" [routerLink]="['../security/new']" *ngIf="hasAuthConfigEditPermission">
       <mat-icon>add</mat-icon>New Authentication
     </button>
     <button matButton="filled" (click)="save()" [disabled]="!isDirty">Save</button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="auth-page">
   <mat-accordion>

--- a/web-app/src/app/admin/admin-authentication/admin-authentication.component.ts
+++ b/web-app/src/app/admin/admin-authentication/admin-authentication.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { MatSnackBar as MatSnackBar } from '@angular/material/snack-bar';
 import { AdminBreadcrumb } from '../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../admin-breadcrumb/admin-breadcrumb.service';
 import { Strategy } from '../admin-authentication/admin-settings.model';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { AuthenticationDeleteComponent } from './admin-authentication-delete/admin-authentication-delete.component';
@@ -24,12 +25,10 @@ export interface CanComponentDeactivate {
 export class AdminAuthenticationComponent
   implements OnInit, OnDestroy, CanComponentDeactivate
 {
-  readonly breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Authentication',
-      icon: 'lock'
-    }
-  ];
+  readonly breadcrumbs: AdminBreadcrumb[] = [{ title: 'Authentication', icon: 'lock' }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   teams: any[] = [];
   events: any[] = [];
@@ -48,10 +47,14 @@ export class AdminAuthenticationComponent
     private teamsService: AdminTeamsService,
     private eventsService: AdminEventsService,
     private authenticationConfigurationService: AuthenticationConfigurationService,
-    private sessionService: SessionService
+    private sessionService: SessionService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.sessionService.user$
       .pipe(takeUntil(this.destroy$))
       .subscribe((user) => {
@@ -62,6 +65,12 @@ export class AdminAuthenticationComponent
     this.loadInitialData().catch((err) => {
       console.log(err);
     });
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   private async loadInitialData(): Promise<void> {
@@ -259,10 +268,5 @@ export class AdminAuthenticationComponent
     }
 
     return true;
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/web-app/src/app/admin/admin-breadcrumb/admin-breadcrumb.component.scss
+++ b/web-app/src/app/admin/admin-breadcrumb/admin-breadcrumb.component.scss
@@ -1,19 +1,8 @@
-::ng-deep admin {
-  .admin-main-content {
-    &:has(mage-admin-plugin-tab-content) {
-      margin-top: 55px;
-    }
-  }
-}
-
 .breadcrumb-spacer {
   flex: 1;
 }
 
 .admin-breadcrumbs {
-  position: sticky;
-  top: 0;
-  z-index: 100;
   margin-bottom: 8px;
   border-bottom: 1px solid var(--mat-sys-outline-variant);
   font-size: var(--mat-sys-title-medium-size);

--- a/web-app/src/app/admin/admin-breadcrumb/admin-breadcrumb.service.ts
+++ b/web-app/src/app/admin/admin-breadcrumb/admin-breadcrumb.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, TemplateRef } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { AdminBreadcrumb } from './admin-breadcrumb.model';
+
+@Injectable({ providedIn: 'root' })
+export class AdminBreadcrumbService {
+  private breadcrumbsSubject = new BehaviorSubject<AdminBreadcrumb[]>([]);
+  private actionsSubject = new BehaviorSubject<TemplateRef<unknown> | null>(null);
+
+  breadcrumbs$ = this.breadcrumbsSubject.asObservable();
+  actions$ = this.actionsSubject.asObservable();
+
+  setBreadcrumbs(breadcrumbs: AdminBreadcrumb[]): void {
+    this.breadcrumbsSubject.next(breadcrumbs);
+  }
+
+  setActions(template: TemplateRef<unknown> | null): void {
+    this.actionsSubject.next(template);
+  }
+}

--- a/web-app/src/app/admin/admin-dashboard/admin-dashboard.html
+++ b/web-app/src/app/admin/admin-dashboard/admin-dashboard.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="admin-content">
   <div class="top-row">
     <mat-card appearance="raised" class="dashboard-panel-card">

--- a/web-app/src/app/admin/admin-dashboard/admin-dashboard.ts
+++ b/web-app/src/app/admin/admin-dashboard/admin-dashboard.ts
@@ -10,6 +10,7 @@ import type { PageEvent } from '@angular/material/paginator';
 import { Subject, takeUntil } from 'rxjs';
 
 import { AdminBreadcrumb } from '../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../admin-breadcrumb/admin-breadcrumb.service';
 import {
   AdminDeviceService,
   DashboardDevicePageInfo
@@ -58,9 +59,7 @@ export class AdminDashboardComponent implements OnInit, OnDestroy {
 
   private devicePageCache = new Map<number, DashboardDevicePageInfo>();
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Dashboard', icon: 'analytics' }
-  ];
+  breadcrumbs: AdminBreadcrumb[] = [{ title: 'Dashboard', icon: 'analytics' }];
 
   private destroy$ = new Subject<void>();
 
@@ -70,10 +69,13 @@ export class AdminDashboardComponent implements OnInit, OnDestroy {
     private deviceService: AdminDeviceService,
     private userPagingService: UserPagingService,
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+
     this.stateAndData = this.userPagingService.constructDefault();
 
     this.refreshDevices();

--- a/web-app/src/app/admin/admin-devices/dashboard/devices-dashboard.component.html
+++ b/web-app/src/app/admin/admin-devices/dashboard/devices-dashboard.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions">
     <button matButton="filled" *ngIf="hasDeviceCreatePermission" (click)="createDevice()">
       <mat-icon>add</mat-icon>New Device
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="devices-page">
   <mat-card appearance="elevated" class="devices-card">

--- a/web-app/src/app/admin/admin-devices/dashboard/devices-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-devices/dashboard/devices-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { PageEvent as PageEvent } from '@angular/material/paginator';
 import {
@@ -7,6 +7,7 @@ import {
   SearchOptions
 } from '../../services/admin-device.service';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { Device } from '../../../entities/device/device';
 import { CreateDeviceDialogComponent } from '../create-device/create-device.component';
 import { Subject, takeUntil } from 'rxjs';
@@ -38,9 +39,10 @@ export class DeviceDashboardComponent implements OnInit, OnDestroy {
 
   deviceStatusFilter: 'all' | 'registered' | 'unregistered' = 'all';
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Devices', icon: 'devices' }
-  ];
+  breadcrumbs: AdminBreadcrumb[] = [{ title: 'Devices', icon: 'devices' }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   private destroy$ = new Subject<void>();
 
@@ -48,15 +50,20 @@ export class DeviceDashboardComponent implements OnInit, OnDestroy {
     private modal: MatDialog,
     private deviceService: AdminDeviceService,
     private sessionService: SessionService,
-    private toastService: AdminToastService
+    private toastService: AdminToastService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.subscribeToUser();
     this.refreshDevices();
   }
 
   ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/web-app/src/app/admin/admin-devices/device-details/device-details.component.html
+++ b/web-app/src/app/admin/admin-devices/device-details/device-details.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="device && hasDeletePermission">
     <button matButton="outlined" class="delete-device-button" (click)="confirmDeleteDevice()">
       <mat-icon fontSet="material-symbols-outlined">delete</mat-icon>Delete
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="device-page" *ngIf="device">
   <div class="error-alert" *ngIf="error">

--- a/web-app/src/app/admin/admin-devices/device-details/device-details.component.ts
+++ b/web-app/src/app/admin/admin-devices/device-details/device-details.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { DeleteDeviceComponent } from '../delete-device/delete-device.component';
 import { CreateDeviceDialogComponent } from '../create-device/create-device.component';
 import { Device } from '../../../entities/device/device';
@@ -15,7 +16,7 @@ import { SessionService } from 'mage-web-app/http/session.service';
     styleUrls: ['./device-details.component.scss'],
     standalone: false
 })
-export class DeviceDetailsComponent implements OnInit {
+export class DeviceDetailsComponent implements OnInit, OnDestroy {
   device: Device | null = null;
 
   currentUserDisplayName: string | null = null;
@@ -23,13 +24,21 @@ export class DeviceDetailsComponent implements OnInit {
   hasUpdatePermission = false;
   hasDeletePermission = false;
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Devices',
-      icon: 'devices',
-      route: ['../devices']
-    }
-  ];
+  #breadcrumbs: AdminBreadcrumb[] = [{
+    title: 'Devices',
+    icon: 'devices',
+    route: ['/admin/devices']
+  }];
+  set breadcrumbs(value: AdminBreadcrumb[]) {
+    this.#breadcrumbs = value;
+    this.breadcrumbService.setBreadcrumbs(value);
+  }
+  get breadcrumbs(): AdminBreadcrumb[] {
+    return this.#breadcrumbs;
+  }
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   saving = false;
   error: string | null = null;
@@ -39,10 +48,14 @@ export class DeviceDetailsComponent implements OnInit {
     private router: Router,
     private dialog: MatDialog,
     private deviceService: AdminDeviceService,
-    private sessionService: SessionService
+    private sessionService: SessionService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     const deviceId = this.route.snapshot.paramMap.get('deviceId');
     if (!deviceId) {
       this.error = 'Missing deviceId route param';
@@ -58,6 +71,10 @@ export class DeviceDetailsComponent implements OnInit {
     this.loadDevice(deviceId);
   }
 
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
+  }
+
   private loadDevice(deviceId: string): void {
     this.deviceService.getDeviceById(deviceId).subscribe({
       next: (device: Device) => {
@@ -71,14 +88,13 @@ export class DeviceDetailsComponent implements OnInit {
 
   private applyDevice(device: Device): void {
     this.device = device;
-    this.breadcrumbs = [
-      {
-        title: 'Devices',
-        icon: 'devices',
-        route: ['../']
-      },
-      { title: device?.uid || 'Device' }
-    ];
+    this.breadcrumbs = [{
+      title: 'Devices',
+      icon: 'devices',
+      route: ['/admin/devices']
+    },{
+      title: device?.uid || 'Device'
+    }];
 
     this.currentUserDisplayName = device?.user?.displayName || null;
   }

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/form-details.component.html
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/form-details.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="form-page" *ngIf="event">
 
   <mat-stepper *ngIf="creatingNewForm" linear #formStepper class="create-form-stepper">

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/form-details.component.ts
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/form-details.component.ts
@@ -10,6 +10,7 @@ import { SessionService } from 'mage-web-app/http/session.service';
 
 import { Event as MageEvent } from 'mage-web-app/filter/filter.types';
 import { AdminBreadcrumb } from '../../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../../admin-breadcrumb/admin-breadcrumb.service';
 import {
   ObservationFeedHelper,
   Observation,
@@ -63,7 +64,15 @@ export class FormDetailsComponent implements OnInit {
   token: string | null = null;
   saving = false;
   generalFormSubmitted = false;
-  breadcrumbs: AdminBreadcrumb[] = [];
+
+  private _breadcrumbs: AdminBreadcrumb[] = [];
+  set breadcrumbs(value: AdminBreadcrumb[]) {
+    this._breadcrumbs = value;
+    this.breadcrumbService.setBreadcrumbs(value);
+  }
+  get breadcrumbs(): AdminBreadcrumb[] {
+    return this._breadcrumbs;
+  }
 
   creatingNewForm = false;
 
@@ -117,7 +126,8 @@ export class FormDetailsComponent implements OnInit {
     private eventsService: AdminEventsService,
     private sessionService: SessionService,
     private dialog: MatDialog,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private breadcrumbService: AdminBreadcrumbService
   ) { }
 
   ngOnInit(): void {
@@ -127,6 +137,13 @@ export class FormDetailsComponent implements OnInit {
     this.formId = this.route.snapshot.paramMap.get('formId');
     this.creatingNewForm = !this.formId;
 
+    this.breadcrumbs = [{
+      title: 'Events',
+      icon: 'event',
+      route: ['/admin/events']
+    }, {
+      title: this.formId ? 'Edit Form' : 'New Form'
+    }];
 
     if (!this.eventId) return;
 
@@ -134,20 +151,16 @@ export class FormDetailsComponent implements OnInit {
       next: (event) => {
         this.event = event;
 
-        this.breadcrumbs = [
-          {
-            title: 'Events',
-            icon: 'event',
-            route: ['../../../']
-          },
-          {
-            title: event.name,
-            route: ['../../../', String(event?.id ?? '')]
-          },
-          {
-            title: this.formId ? 'Edit Form' : 'New Form'
-          }
-        ];
+        this.breadcrumbs = [{
+          title: 'Events',
+          icon: 'event',
+          route: ['/admin/events']
+        }, {
+          title: event.name,
+          route: ['/admin/events', String(event?.id ?? '')]
+        }, {
+          title: this.formId ? 'Edit Form' : 'New Form'
+        }];
 
         if (this.formId && event.forms) {
           const existingForm = event.forms.find(
@@ -158,6 +171,7 @@ export class FormDetailsComponent implements OnInit {
             if (!this.form.fields) this.form.fields = [];
             if (!this.form.userFields) this.form.userFields = [];
             this.breadcrumbs[2].title = existingForm.name || 'Edit Form';
+            this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
           }
         } else {
           this.form = {

--- a/web-app/src/app/admin/admin-event/dashboard/event-dashboard.component.html
+++ b/web-app/src/app/admin/admin-event/dashboard/event-dashboard.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="hasEventCreatePermission">
     <button matButton="filled" (click)="createEvent()">
       <mat-icon>add</mat-icon>New Event
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="events-page">
   <mat-card appearance="elevated" class="events-card">

--- a/web-app/src/app/admin/admin-event/dashboard/event-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-event/dashboard/event-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener, TemplateRef, ViewChild } from '@angular/core';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { PageEvent as PageEvent } from '@angular/material/paginator';
 
@@ -9,6 +9,7 @@ import {
 } from '../../services/admin-events.service';
 
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { Event } from 'mage-web-app/filter/filter.types';
 import { CreateEventDialogComponent } from '../create-event/create-event.component';
 import { AdminToastService } from '../../services/admin-toast.service';
@@ -20,7 +21,7 @@ import { SessionService } from 'mage-web-app/http/session.service';
     styleUrls: ['./event-dashboard.component.scss'],
     standalone: false
 })
-export class EventDashboardComponent implements OnInit {
+export class EventDashboardComponent implements OnInit, OnDestroy {
   events: EventsResponse | null = null;
   filteredEvents: Event[] = [];
 
@@ -43,20 +44,29 @@ export class EventDashboardComponent implements OnInit {
 
   eventStatusFilter: 'all' | 'active' | 'complete' = 'all';
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Events', icon: 'event' }
-  ];
+  breadcrumbs: AdminBreadcrumb[] = [{ title: 'Events', icon: 'event' }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   constructor(
     private modal: MatDialog,
     private eventService: AdminEventsService,
     private sessionService: SessionService,
-    private toastService: AdminToastService
+    private toastService: AdminToastService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.refreshEvents();
     this.updateResponsiveLayout();
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
   }
 
   refreshEvents(): void {

--- a/web-app/src/app/admin/admin-event/event-details/event-details.component.html
+++ b/web-app/src/app/admin/admin-event/event-details/event-details.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="event && hasDeletePermission">
     <button matButton="outlined" class="delete-event-button" type="button" (click)="deleteEvent()">
       <mat-icon fontSet="material-symbols-outlined">delete</mat-icon>Delete
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="event-page" *ngIf="event">
   <mat-card appearance="outlined" class="details-card">

--- a/web-app/src/app/admin/admin-event/event-details/event-details.component.ts
+++ b/web-app/src/app/admin/admin-event/event-details/event-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { PageEvent as PageEvent } from '@angular/material/paginator';
@@ -10,6 +10,7 @@ import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 
 import { Event as MageEvent, Layer } from 'mage-web-app/filter/filter.types';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AdminEventsService } from '../../services/admin-events.service';
 import { User as MageUser } from '@ngageoint/mage.web-core-lib/user';
 import { Team } from '../../admin-teams/team';
@@ -54,13 +55,21 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   event: ExtendedEvent | null = null;
   eventTeam: Team | null = null;
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Events',
-      icon: 'event',
-      route: ['../']
-    }
-  ];
+  private _breadcrumbs: AdminBreadcrumb[] = [{
+    title: 'Events',
+    icon: 'event',
+    route: ['/admin/events']
+  }];
+  set breadcrumbs(value: AdminBreadcrumb[]) {
+    this._breadcrumbs = value;
+    this.breadcrumbService.setBreadcrumbs(value);
+  }
+  get breadcrumbs(): AdminBreadcrumb[] {
+    return this._breadcrumbs;
+  }
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   hasReadPermission = false;
   hasUpdatePermission = false;
@@ -104,10 +113,14 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     const eventId = this.route.snapshot.paramMap.get('eventId') || this.route.snapshot.paramMap.get('id');
 
     if (!eventId) {
@@ -137,6 +150,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
           this.loadLayers();
 
           this.breadcrumbs.push({ title: this.event?.name || 'Event' });
+          this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
         },
         error: (error) => {
           console.error('Error loading event:', error);
@@ -149,6 +163,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
     this.destroy$.next();
     this.destroy$.complete();
   }
@@ -533,10 +548,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
       if (!updatedEvent) return;
 
       this.event = updatedEvent;
-      this.breadcrumbs = [
-        { title: 'Events', icon: 'event', route: ['../'] },
-        { title: this.event?.name || 'Event' }
-      ];
+      this.breadcrumbs = [{ title: 'Events', icon: 'event', route: ['/admin/events'] }, { title: this.event?.name || 'Event' }];
     });
   }
 

--- a/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed-edit/admin-feed-edit.component.html
+++ b/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed-edit/admin-feed-edit.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="feed-edit-page">
   <div class="header" *ngIf="editState.originalFeed">
     <mage-static-icon-img class="icon" *ngIf="editState.originalFeed?.icon" [iconRef]="editState.originalFeed?.icon"></mage-static-icon-img>

--- a/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed-edit/admin-feed-edit.component.ts
+++ b/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed-edit/admin-feed-edit.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Service } from '@ngageoint/mage.web-core-lib/feed';
 import { AdminBreadcrumb } from '../../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../../admin-breadcrumb/admin-breadcrumb.service';
 import { FeedEditState, FeedMetaData } from './feed-edit.model';
 import { FeedEditService } from './feed-edit.service';
 
@@ -13,13 +14,18 @@ import { FeedEditService } from './feed-edit.service';
     standalone: false
 })
 export class AdminFeedEditComponent implements OnInit {
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Feeds',
-      icon: 'rss_feed',
-      route: ['/admin/feeds']
-    }
-  ];
+  private _breadcrumbs: AdminBreadcrumb[] = [{
+    title: 'Feeds',
+    icon: 'rss_feed',
+    route: ['/admin/feeds']
+  }];
+  set breadcrumbs(value: AdminBreadcrumb[]) {
+    this._breadcrumbs = value;
+    this.breadcrumbService.setBreadcrumbs(value);
+  }
+  get breadcrumbs(): AdminBreadcrumb[] {
+    return this._breadcrumbs;
+  }
 
   step = 0;
   hasFeedDeletePermission = false;
@@ -41,7 +47,8 @@ export class AdminFeedEditComponent implements OnInit {
   constructor(
     private feedEdit: FeedEditService,
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private breadcrumbService: AdminBreadcrumbService
   ) {
     this.feedId = this.route.snapshot.paramMap.get('feedId');
 
@@ -49,11 +56,13 @@ export class AdminFeedEditComponent implements OnInit {
       this.breadcrumbs = this.breadcrumbs.concat([{ title: '' }, { title: 'Edit' }]);
     } else {
       this.breadcrumbs.push({ title: 'New' });
-      console.log(this.breadcrumbs)
+      this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
     }
   }
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+
     this.feedEdit.state$.subscribe((x) => {
       const nextOriginalFeed = x.originalFeed;
 
@@ -62,6 +71,7 @@ export class AdminFeedEditComponent implements OnInit {
           title: nextOriginalFeed.title,
           route: ['/admin/feeds', nextOriginalFeed.id]
         };
+        this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
         this.step = 1;
       }
 

--- a/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed.component.html
+++ b/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="feed">
     <button *ngIf="hasFeedDeletePermission" matButton="outlined" type="button" class="delete-feed-button" (click)="deleteFeed()">
       <mat-icon fontSet="material-symbols-outlined">delete</mat-icon>Delete
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="feed-page" *ngIf="feedLoaded | async; else loading">
   <mat-card appearance="outlined" class="details-card">

--- a/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed.component.ts
+++ b/web-app/src/app/admin/admin-feeds/admin-feed/admin-feed.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import {
@@ -18,6 +18,7 @@ import {
   animate
 } from '@angular/animations';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AdminFeedDeleteComponent } from './admin-feed-delete/admin-feed-delete.component';
 import { AdminEventsService } from '../../services/admin-events.service';
 import { EventService } from '../../../event/event.service';
@@ -50,14 +51,15 @@ import { SessionService } from 'mage-web-app/http/session.service';
     ],
     standalone: false
 })
-export class AdminFeedComponent implements OnInit {
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Feeds',
-      icon: 'rss_feed',
-      route: ['/admin/feeds']
-    }
-  ];
+export class AdminFeedComponent implements OnInit, OnDestroy {
+  breadcrumbs: AdminBreadcrumb[] = [{
+    title: 'Feeds',
+    icon: 'rss_feed',
+    route: ['/admin/feeds']
+  }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   feedsRoute: any[] = ['../../feeds'];
   feedEditRoute: any[] | null = null;
@@ -108,12 +110,20 @@ export class AdminFeedComponent implements OnInit {
     private snackBar: MatSnackBar,
     private eventsService: AdminEventsService,
     private sessionService: SessionService,
-    private eventService: EventService
+    private eventService: EventService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.feedId = this.route.snapshot.paramMap.get('feedId');
     this.initFeed();
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
   }
 
   private initFeed(): void {
@@ -122,16 +132,14 @@ export class AdminFeedComponent implements OnInit {
     this.feedService.fetchFeed(this.feedId).subscribe((feed) => {
       this.feed = feed;
 
-      this.breadcrumbs = [
-        {
-          title: 'Feeds',
-          icon: 'rss_feed',
-          route: ['/admin/feeds']
-        },
-        {
-          title: this.feed.title
-        }
-      ];
+      this.breadcrumbs = [{
+        title: 'Feeds',
+        icon: 'rss_feed',
+        route: ['/admin/feeds']
+      },{
+        title: this.feed.title
+      }];
+      this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
 
       this.feedEditRoute = ['../feedEdit', this.feed.id];
 

--- a/web-app/src/app/admin/admin-feeds/admin-feeds.component.html
+++ b/web-app/src/app/admin/admin-feeds/admin-feeds.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="hasFeedCreatePermission">
     <button matButton="filled" [routerLink]="['./new']">
       <mat-icon>add</mat-icon>New Feed
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="feeds-page">
   <mat-card appearance="outlined" class="feeds-card">

--- a/web-app/src/app/admin/admin-feeds/admin-feeds.component.ts
+++ b/web-app/src/app/admin/admin-feeds/admin-feeds.component.ts
@@ -1,11 +1,12 @@
 import _ from 'underscore'
-import { Component, OnInit } from '@angular/core'
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core'
 import { Feed, Service, FeedService } from '@ngageoint/mage.web-core-lib/feed'
 import { MatDialog as MatDialog } from '@angular/material/dialog'
 import { forkJoin } from 'rxjs'
 import { AdminFeedDeleteComponent } from './admin-feed/admin-feed-delete/admin-feed-delete.component'
 import { AdminServiceDeleteComponent } from './admin-service/admin-service-delete/admin-service-delete.component'
 import { AdminBreadcrumb } from '../admin-breadcrumb/admin-breadcrumb.model'
+import { AdminBreadcrumbService } from '../admin-breadcrumb/admin-breadcrumb.service'
 import { SessionService } from 'mage-web-app/http/session.service'
 
 @Component({
@@ -14,11 +15,14 @@ import { SessionService } from 'mage-web-app/http/session.service'
     styleUrls: ['./admin-feeds.component.scss'],
     standalone: false
 })
-export class AdminFeedsComponent implements OnInit {
+export class AdminFeedsComponent implements OnInit, OnDestroy {
   breadcrumbs: AdminBreadcrumb[] = [{
     title: 'Feeds',
     icon: 'rss_feed',
   }]
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>
 
   services: Service[] = []
   private _services: Service[] = []
@@ -36,7 +40,8 @@ export class AdminFeedsComponent implements OnInit {
   constructor(
     private feedService: FeedService,
     public dialog: MatDialog,
-    private sessionService: SessionService
+    private sessionService: SessionService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   get hasServiceDeletePermission(): boolean {
@@ -56,6 +61,9 @@ export class AdminFeedsComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs)
+    this.breadcrumbService.setActions(this.breadcrumbActions)
+
     forkJoin({
       services: this.feedService.fetchServices(),
       feeds: this.feedService.fetchAllFeeds()
@@ -65,7 +73,11 @@ export class AdminFeedsComponent implements OnInit {
     
       this._feeds = (feeds ?? []).sort(this.sortByTitle)
       this.feeds = this._feeds.slice()
-    })    
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null)
   }
 
   onFeedSearchChange(): void {

--- a/web-app/src/app/admin/admin-feeds/admin-service/admin-service.component.html
+++ b/web-app/src/app/admin/admin-feeds/admin-service/admin-service.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="service">
     <button *ngIf="hasServiceDeletePermission" matButton="outlined" type="button" class="delete-button" (click)="deleteService()">
       <mat-icon fontSet="material-symbols-outlined">delete</mat-icon>Delete
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="service-page" *ngIf="service && serviceType; else loading">
   <mat-card appearance="outlined" class="details-card">

--- a/web-app/src/app/admin/admin-feeds/admin-service/admin-service.component.ts
+++ b/web-app/src/app/admin/admin-feeds/admin-service/admin-service.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { forkJoin } from 'rxjs';
@@ -10,6 +10,7 @@ import {
 } from '@ngageoint/mage.web-core-lib/feed';
 
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AdminServiceDeleteComponent } from './admin-service-delete/admin-service-delete.component';
 import { SessionService } from 'mage-web-app/http/session.service';
 
@@ -19,14 +20,15 @@ import { SessionService } from 'mage-web-app/http/session.service';
     styleUrls: ['./admin-service.component.scss'],
     standalone: false
 })
-export class AdminServiceComponent implements OnInit {
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Feeds',
-      icon: 'rss_feed',
-      route: ['/admin/feeds']
-    }
-  ];
+export class AdminServiceComponent implements OnInit, OnDestroy {
+  breadcrumbs: AdminBreadcrumb[] = [{
+    title: 'Feeds',
+    icon: 'rss_feed',
+    route: ['/admin/feeds']
+  }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   service!: Service;
   serviceType!: ServiceType;
@@ -54,10 +56,14 @@ export class AdminServiceComponent implements OnInit {
     private feedService: FeedService,
     private route: ActivatedRoute,
     public dialog: MatDialog,
-    private sessionService: SessionService
+    private sessionService: SessionService,
+    private breadcrumbService: AdminBreadcrumbService
   ) { }
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.serviceId = this.route.snapshot.paramMap.get('serviceId');
     if (!this.serviceId) return;
 
@@ -71,6 +77,7 @@ export class AdminServiceComponent implements OnInit {
       this.breadcrumbs.push({
         title: this.service.title,
       });
+      this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
 
       const serviceType: ServiceType = this.service.serviceType as ServiceType;
 
@@ -96,6 +103,10 @@ export class AdminServiceComponent implements OnInit {
 
       });
     });
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
   }
 
   deleteService(): void {

--- a/web-app/src/app/admin/admin-layers/dashboard/layer-dashboard.component.html
+++ b/web-app/src/app/admin/admin-layers/dashboard/layer-dashboard.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="hasLayerCreatePermission">
     <button matButton="filled" (click)="newLayer()">
       <mat-icon>add</mat-icon>New Layer
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="layers-page">
   <mat-card appearance="elevated" class="layers-card">

--- a/web-app/src/app/admin/admin-layers/dashboard/layer-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-layers/dashboard/layer-dashboard.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { PageEvent as PageEvent } from '@angular/material/paginator';
 import { LayersService, Layer } from '../layers.service';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { CreateLayerDialogComponent } from '../create-layer/create-layer.component';
 import { AdminToastService } from '../../services/admin-toast.service';
 import { layerIconName } from '../../../entities/layer/layer';
@@ -14,7 +15,7 @@ import { SessionService } from 'mage-web-app/http/session.service';
     styleUrls: ['./layer-dashboard.component.scss'],
     standalone: false
 })
-export class LayerDashboardComponent implements OnInit {
+export class LayerDashboardComponent implements OnInit, OnDestroy {
   layers: Layer[] = [];
   filteredLayers: Layer[] = [];
 
@@ -30,19 +31,28 @@ export class LayerDashboardComponent implements OnInit {
     return this.sessionService.hasPermission('CREATE_LAYER');
   }
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Layers', icon: 'map' }
-  ];
+  breadcrumbs: AdminBreadcrumb[] = [{ title: 'Layers', icon: 'map' }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   constructor(
     private modal: MatDialog,
     private layersService: LayersService,
     private sessionService: SessionService,
-    private toastService: AdminToastService
+    private toastService: AdminToastService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.refreshLayers();
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
   }
 
   refreshLayers(): void {

--- a/web-app/src/app/admin/admin-layers/layer-details/layer-details.component.html
+++ b/web-app/src/app/admin/admin-layers/layer-details/layer-details.component.html
@@ -1,4 +1,4 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="layer && (hasLayerEditPermission || hasLayerDeletePermission)">
     <button matButton="outlined" *ngIf="isLayerFileBased() && hasLayerEditPermission" (click)="downloadLayer()"
       [disabled]="(layer.type === 'GeoPackage' && layer.state === 'processing') || layer.validating">
@@ -8,7 +8,7 @@
       <mat-icon fontSet="material-symbols-outlined">delete</mat-icon>Delete
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="loading-state" *ngIf="loading && !layer">
   <mat-spinner></mat-spinner>

--- a/web-app/src/app/admin/admin-layers/layer-details/layer-details.component.ts
+++ b/web-app/src/app/admin/admin-layers/layer-details/layer-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { MatSnackBar as MatSnackBar } from '@angular/material/snack-bar';
@@ -9,6 +9,7 @@ import { HttpClient } from '@angular/common/http';
 import { LayersService, Layer } from '../layers.service';
 import { AdminEventsService } from '../../services/admin-events.service';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import {
   SearchModalComponent,
   SearchModalData,
@@ -53,14 +54,22 @@ interface PagedResult<T> {
     styleUrls: ['./layer-details.component.scss'],
     standalone: false
 })
-export class LayerDetailsComponent implements OnInit {
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Layers',
-      icon: 'map',
-      route: ['../']
-    }
-  ];
+export class LayerDetailsComponent implements OnInit, OnDestroy {
+  private _breadcrumbs: AdminBreadcrumb[] = [{
+    title: 'Layers',
+    icon: 'map',
+    route: ['/admin/layers']
+  }];
+  set breadcrumbs(value: AdminBreadcrumb[]) {
+    this._breadcrumbs = value;
+    this.breadcrumbService.setBreadcrumbs(value);
+  }
+  get breadcrumbs(): AdminBreadcrumb[] {
+    return this._breadcrumbs;
+  }
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   layer?: Layer;
   layerEvents: Event[] = [];
@@ -103,10 +112,14 @@ export class LayerDetailsComponent implements OnInit {
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
     private http: HttpClient,
-    private sessionService: SessionService
+    private sessionService: SessionService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     const layerId = this.route.snapshot.paramMap.get('layerId');
     if (!layerId) {
       console.error('No layerId found in route params');
@@ -118,6 +131,10 @@ export class LayerDetailsComponent implements OnInit {
     this.loadLayer(layerId);
   }
 
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
+  }
+
   private loadLayer(layerId: string): void {
     this.loading = true;
     this.layersService.getLayerById(layerId).subscribe({
@@ -125,10 +142,7 @@ export class LayerDetailsComponent implements OnInit {
         this.layer = layer;
         this.loading = false;
 
-        this.breadcrumbs = [
-          this.breadcrumbs[0],
-          { title: layer.name || 'Layer Details' }
-        ];
+        this.breadcrumbs = [this.breadcrumbs[0], { title: layer.name || 'Layer Details' }];
 
         if (this.layer.state !== 'available') {
           setTimeout(() => this.checkLayerProcessingStatus(), 1000);
@@ -347,10 +361,7 @@ export class LayerDetailsComponent implements OnInit {
       if (!updatedLayer) return;
 
       this.layer = { ...this.layer!, ...updatedLayer };
-      this.breadcrumbs = [
-        this.breadcrumbs[0],
-        { title: this.layer.name || 'Layer Details' }
-      ];
+      this.breadcrumbs = [this.breadcrumbs[0], { title: this.layer.name || 'Layer Details' }];
       this.updateUrlLayers();
       this.snackBar.open('Layer updated successfully', undefined, { duration: 2000 });
     });

--- a/web-app/src/app/admin/admin-map/admin-map.component.html
+++ b/web-app/src/app/admin/admin-map/admin-map.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="map-page">
   <mat-card appearance="elevated" class="map-card">
     <mat-card-header>

--- a/web-app/src/app/admin/admin-map/admin-map.component.ts
+++ b/web-app/src/app/admin/admin-map/admin-map.component.ts
@@ -1,8 +1,9 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { MatSnackBar as MatSnackBar } from '@angular/material/snack-bar';
 
 import { AdminBreadcrumb } from '../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../admin-breadcrumb/admin-breadcrumb.service';
 import { MapSettingsService } from '../../../app/map/settings/map.settings.service';
 import { MapSettings } from '../../../app/entities/map/entities.map';
 
@@ -15,12 +16,10 @@ type WebSearchType = 'NONE' | 'NOMINATIM';
     styleUrls: ['./admin-map.component.scss'],
     standalone: false
 })
-export class AdminMapComponent {
+export class AdminMapComponent implements OnInit {
   @ViewChild('mapForm') mapForm!: NgForm;
 
-  readonly breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Map', icon: 'public' }
-  ];
+  readonly breadcrumbs: AdminBreadcrumb[] = [{ title: 'Map', icon: 'public' }];
 
   mobileSearchType: MobileSearchType | null = 'NONE';
   mobileSearchOptions: MobileSearchType[] = ['NONE', 'NATIVE', 'NOMINATIM'];
@@ -33,7 +32,8 @@ export class AdminMapComponent {
 
   constructor(
     private mapSettingsService: MapSettingsService,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private breadcrumbService: AdminBreadcrumbService
   ) {
     this.mapSettingsService.getMapSettings().subscribe({
       next: (settings: MapSettings | null | undefined) => {
@@ -58,6 +58,10 @@ export class AdminMapComponent {
         this.snackBar.open(message, undefined, { duration: 3000 });
       }
     });
+  }
+
+  ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
   }
 
   save(): void {

--- a/web-app/src/app/admin/admin-plugins/host/plugins-host.component.html
+++ b/web-app/src/app/admin/admin-plugins/host/plugins-host.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="plugin-host">
   <div *ngIf="loading" class="plugin-loading">Loading plugin…</div>
   <div *ngIf="error" class="plugin-error">{{ error }}</div>

--- a/web-app/src/app/admin/admin-plugins/host/plugins-host.component.ts
+++ b/web-app/src/app/admin/admin-plugins/host/plugins-host.component.ts
@@ -11,6 +11,7 @@ import { Subject, takeUntil } from 'rxjs';
 
 import { PluginService } from '../../plugin/plugin.service';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 
 @Component({
     selector: 'mage-plugins-host',
@@ -25,21 +26,26 @@ export class PluginHostComponent implements OnInit, OnDestroy {
   loading = true;
   error: string | null = null;
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Plugin',
-      icon: 'extension'
-    }
-  ];
+  private _breadcrumbs: AdminBreadcrumb[] = [{ title: 'Plugin', icon: 'extension' }];
+  set breadcrumbs(value: AdminBreadcrumb[]) {
+    this._breadcrumbs = value;
+    this.breadcrumbService.setBreadcrumbs(value);
+  }
+  get breadcrumbs(): AdminBreadcrumb[] {
+    return this._breadcrumbs;
+  }
 
   private destroy$ = new Subject<void>();
 
   constructor(
     private route: ActivatedRoute,
-    private pluginService: PluginService
+    private pluginService: PluginService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+
     this.route.paramMap
       .pipe(takeUntil(this.destroy$))
       .subscribe(async (params) => {
@@ -63,12 +69,10 @@ export class PluginHostComponent implements OnInit, OnDestroy {
           const hooks: any = plugin.MAGE_WEB_HOOKS;
           const tab = hooks.adminTab;
 
-          this.breadcrumbs = [
-            {
-              title: tab?.title ?? pluginId,
-              icon: tab?.icon?.icon ?? 'extension'
-            }
-          ];
+          this.breadcrumbs = [{
+            title: tab?.title ?? pluginId,
+            icon: tab?.icon?.icon ?? 'extension'
+          }];
 
           let entry: Type<any> | undefined =
             hooks.rootComponent ?? hooks.entryComponent;

--- a/web-app/src/app/admin/admin-settings/contact-info/contact-info.component.html
+++ b/web-app/src/app/admin/admin-settings/contact-info/contact-info.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="settings-page">
   <mat-card appearance="elevated" class="settings-card">
     <mat-card-content>

--- a/web-app/src/app/admin/admin-settings/contact-info/contact-info.component.ts
+++ b/web-app/src/app/admin/admin-settings/contact-info/contact-info.component.ts
@@ -5,6 +5,7 @@ import { MatDialog as MatDialog } from '@angular/material/dialog';
 
 import { SettingsService } from '../settings.service';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AdminSettingsUnsavedComponent } from '../admin-settings-unsaved/admin-settings-unsaved.component';
 
 @Component({
@@ -14,9 +15,7 @@ import { AdminSettingsUnsavedComponent } from '../admin-settings-unsaved/admin-s
   standalone: false
 })
 export class ContactInfoComponent implements OnInit {
-  readonly breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Contact Info', icon: 'contact_support' }
-  ];
+  readonly breadcrumbs: AdminBreadcrumb[] = [{ title: 'Contact Info', icon: 'contact_support' }];
 
   contactinfo = {
     phone: '',
@@ -29,10 +28,13 @@ export class ContactInfoComponent implements OnInit {
   constructor(
     private settingsService: SettingsService,
     private snackBar: MatSnackBar,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+
     this.settingsService
       .get('contactinfo')
       .pipe(take(1))

--- a/web-app/src/app/admin/admin-settings/security-banner/security-banner.component.html
+++ b/web-app/src/app/admin/admin-settings/security-banner/security-banner.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="settings-page">
   <mat-card appearance="elevated" class="settings-card">
     <mat-card-content>

--- a/web-app/src/app/admin/admin-settings/security-banner/security-banner.component.ts
+++ b/web-app/src/app/admin/admin-settings/security-banner/security-banner.component.ts
@@ -14,6 +14,7 @@ import { Banner } from './security-banner.model';
 import { ColorPickerComponent } from '../../../../app/color-picker/color-picker.component';
 import { SettingsService } from '../settings.service';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AdminSettingsUnsavedComponent } from '../admin-settings-unsaved/admin-settings-unsaved.component';
 
 @Component({
@@ -23,9 +24,7 @@ import { AdminSettingsUnsavedComponent } from '../admin-settings-unsaved/admin-s
   standalone: false
 })
 export class SecurityBannerComponent implements OnInit, AfterViewInit, OnDestroy {
-  readonly breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Banner', icon: 'page_header' }
-  ];
+  readonly breadcrumbs: AdminBreadcrumb[] = [{ title: 'Banner', icon: 'page_header' }];
 
   banner: Banner = {
     headerTextColor: '#000000',
@@ -52,10 +51,13 @@ export class SecurityBannerComponent implements OnInit, AfterViewInit, OnDestroy
   constructor(
     private settingsService: SettingsService,
     private snackBar: MatSnackBar,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+
     this.settingsService
       .get('banner')
       .pipe(takeUntil(this.destroy$))

--- a/web-app/src/app/admin/admin-settings/security-disclaimer/security-disclaimer.component.html
+++ b/web-app/src/app/admin/admin-settings/security-disclaimer/security-disclaimer.component.html
@@ -1,5 +1,3 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs"></admin-breadcrumb>
-
 <div class="settings-page">
   <mat-card appearance="elevated" class="settings-card">
     <mat-card-content>

--- a/web-app/src/app/admin/admin-settings/security-disclaimer/security-disclaimer.component.ts
+++ b/web-app/src/app/admin/admin-settings/security-disclaimer/security-disclaimer.component.ts
@@ -6,6 +6,7 @@ import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { Disclaimer } from './security-disclaimer.model';
 import { SettingsService } from '../settings.service';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AdminSettingsUnsavedComponent } from '../admin-settings-unsaved/admin-settings-unsaved.component';
 
 @Component({
@@ -15,9 +16,7 @@ import { AdminSettingsUnsavedComponent } from '../admin-settings-unsaved/admin-s
   standalone: false
 })
 export class SecurityDisclaimerComponent implements OnInit {
-  readonly breadcrumbs: AdminBreadcrumb[] = [
-    { title: 'Disclaimer', icon: 'verified' }
-  ];
+  readonly breadcrumbs: AdminBreadcrumb[] = [{ title: 'Disclaimer', icon: 'verified' }];
 
   disclaimer: Disclaimer = {
     show: false,
@@ -30,10 +29,13 @@ export class SecurityDisclaimerComponent implements OnInit {
   constructor(
     private settingsService: SettingsService,
     private snackBar: MatSnackBar,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+
     this.settingsService
       .get('disclaimer')
       .pipe(take(1))

--- a/web-app/src/app/admin/admin-shell/admin.component.html
+++ b/web-app/src/app/admin/admin-shell/admin.component.html
@@ -10,7 +10,11 @@
     ></admin-navigation>
   </mat-sidenav>
 
-  <mat-sidenav-content>
+  <mat-sidenav-content class="admin-sidenav-content">
+    <admin-breadcrumb [breadcrumbs]="(breadcrumbService.breadcrumbs$ | async) ?? []">
+      <ng-container *ngTemplateOutlet="breadcrumbService.actions$ | async"></ng-container>
+    </admin-breadcrumb>
+
     <div class="admin-main-content" #adminMainContent>
       <router-outlet></router-outlet>
     </div>

--- a/web-app/src/app/admin/admin-shell/admin.component.scss
+++ b/web-app/src/app/admin/admin-shell/admin.component.scss
@@ -21,10 +21,17 @@
   overscroll-behavior: contain;
 }
 
-.admin-main-content {
+.admin-sidenav-content {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+.admin-main-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
 }

--- a/web-app/src/app/admin/admin-shell/admin.component.ts
+++ b/web-app/src/app/admin/admin-shell/admin.component.ts
@@ -15,6 +15,7 @@ import { PluginService } from '../plugin/plugin.service';
 import { UserPagingService } from '../services/user-paging.service';
 import { DeviceService } from '../admin-devices/device.service';
 import { SidenavService } from './sidenav.service';
+import { AdminBreadcrumbService } from '../admin-breadcrumb/admin-breadcrumb.service';
 
 @Component({
     selector: 'admin',
@@ -58,7 +59,8 @@ export class AdminComponent implements OnInit, AfterViewInit, OnDestroy {
     private userPaging: UserPagingService,
     private deviceService: DeviceService,
     private breakpointObserver: BreakpointObserver,
-    private sidenavService: SidenavService
+    private sidenavService: SidenavService,
+    public breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
@@ -116,6 +118,8 @@ export class AdminComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.breadcrumbService.setBreadcrumbs([]);
+    this.breadcrumbService.setActions(null);
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.html
+++ b/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions">
     <button matButton="filled" *ngIf="hasTeamCreatePermission" (click)="createTeam()">
       <mat-icon>add</mat-icon>New Team
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="teams-page">
   <mat-card appearance="elevated" class="teams-card">

--- a/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { PageEvent as PageEvent } from '@angular/material/paginator';
 import { Team } from '../team';
@@ -7,6 +7,7 @@ import { takeUntil } from 'rxjs/operators';
 import { AdminTeamsService } from '../../services/admin-teams-service';
 import { CreateTeamDialogComponent } from '../create-team/create-team.component';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { AdminToastService } from '../../services/admin-toast.service';
 import { SessionService } from 'mage-web-app/http/session.service';
 
@@ -28,12 +29,10 @@ export class TeamDashboardComponent implements OnInit, OnDestroy {
   pageIndex = 0;
   pageSizeOptions = [5, 10, 25];
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Teams',
-      icon: 'groups'
-    }
-  ];
+  breadcrumbs: AdminBreadcrumb[] = [{ title: 'Teams', icon: 'groups' }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   get hasTeamCreatePermission(): boolean {
     return this.sessionService.hasPermission('CREATE_TEAM');
@@ -45,13 +44,17 @@ export class TeamDashboardComponent implements OnInit, OnDestroy {
     private modal: MatDialog,
     private teamService: AdminTeamsService,
     private sessionService: SessionService,
-    private toastService: AdminToastService
+    private toastService: AdminToastService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   /**
    * Fetches the initial set of teams when the component loads
    */
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.fetchTeams();
   }
 
@@ -59,6 +62,7 @@ export class TeamDashboardComponent implements OnInit, OnDestroy {
    * Component destruction lifecycle hook
    */
   ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/web-app/src/app/admin/admin-teams/team-details/team-details.component.html
+++ b/web-app/src/app/admin/admin-teams/team-details/team-details.component.html
@@ -1,10 +1,10 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="team && hasDeletePermission">
     <button matButton="outlined" class="delete-team-button" (click)="deleteTeam()">
       <mat-icon fontSet="material-symbols-outlined">delete</mat-icon>Delete
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="team-page" *ngIf="team">
   <mat-card appearance="outlined" class="details-card">

--- a/web-app/src/app/admin/admin-teams/team-details/team-details.component.ts
+++ b/web-app/src/app/admin/admin-teams/team-details/team-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -22,6 +22,7 @@ import {
   SearchModalColumn
 } from '../../search-modal/search-modal.component';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { SessionService } from 'mage-web-app/http/session.service';
 
 @Component({
@@ -63,11 +64,21 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   totalEvents = 0;
   eventsPageSize = 5;
 
-  breadcrumbs: AdminBreadcrumb[] = [{
+  private _breadcrumbs: AdminBreadcrumb[] = [{
     title: 'Teams',
     icon: 'groups',
-    route: ['../']
+    route: ['/admin/teams']
   }];
+  set breadcrumbs(value: AdminBreadcrumb[]) {
+    this._breadcrumbs = value;
+    this.breadcrumbService.setBreadcrumbs(value);
+  }
+  get breadcrumbs(): AdminBreadcrumb[] {
+    return this._breadcrumbs;
+  }
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   private asId(value: any): string {
     if (!value) return '';
@@ -83,10 +94,14 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     private snackBar: MatSnackBar,
     private sessionService: SessionService,
     private teamService: AdminTeamsService,
-    private eventsService: AdminEventsService
+    private eventsService: AdminEventsService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.route.paramMap.subscribe((params) => {
       this.teamId = params.get('teamId') || '';
       if (!this.teamId) return;
@@ -96,6 +111,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
     this.snackBar.dismiss();
   }
 
@@ -122,10 +138,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       this.getMembers();
       this.getTeamEvents();
 
-      this.breadcrumbs = [
-        { title: 'Teams', icon: 'groups', route: ['../'] },
-        { title: this.team?.name || 'Team' }
-      ];
+      this.breadcrumbs = [{ title: 'Teams', icon: 'groups', route: ['/admin/teams'] }, { title: this.team?.name || 'Team' }];
     });
   }
 
@@ -201,10 +214,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       if (!updatedTeam) return;
 
       this.team = updatedTeam;
-      this.breadcrumbs = [
-        { title: 'Teams', icon: 'groups', route: ['../'] },
-        { title: this.team?.name || 'Team' }
-      ];
+      this.breadcrumbs = [{ title: 'Teams', icon: 'groups', route: ['/admin/teams'] }, { title: this.team?.name || 'Team' }];
     });
   }
 

--- a/web-app/src/app/admin/admin-users/dashboard/user-dashboard.component.html
+++ b/web-app/src/app/admin/admin-users/dashboard/user-dashboard.component.html
@@ -1,4 +1,4 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions">
     <button matButton="outlined" class="import-users-button" *ngIf="hasUserCreatePermission" (click)="openImportModal()">
       <mat-icon fontSet="material-symbols-outlined">upload</mat-icon>Import Users
@@ -7,7 +7,7 @@
       <mat-icon>add</mat-icon>New User
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="users-page">
 

--- a/web-app/src/app/admin/admin-users/dashboard/user-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-users/dashboard/user-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { PageEvent as PageEvent } from '@angular/material/paginator';
 import { EMPTY, Subject } from 'rxjs';
@@ -12,6 +12,7 @@ import { BulkUserComponent } from '../bulk-user/bulk-user.component';
 import { AdminTeamsService } from '../../services/admin-teams-service';
 import { Team } from '../../admin-teams/team';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 import { UserService } from '../../../user/user.service';
 import { AdminToastService } from '../../services/admin-toast.service';
 import { SessionService } from 'mage-web-app/http/session.service';
@@ -48,12 +49,10 @@ export class UserDashboardComponent implements OnInit, OnDestroy {
   roles: Role[] = [];
   teams: Team[] = [];
 
-  breadcrumbs: AdminBreadcrumb[] = [
-    {
-      title: 'Users',
-      icon: 'person'
-    }
-  ];
+  breadcrumbs: AdminBreadcrumb[] = [{ title: 'Users', icon: 'person' }];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   userStatusFilter: 'all' | 'active' | 'inactive' | 'disabled' = 'all';
 
@@ -67,18 +66,23 @@ export class UserDashboardComponent implements OnInit, OnDestroy {
     private teamService: AdminTeamsService,
     private sessionService: SessionService,
     private userPagingService: UserPagingService,
-    private toastService: AdminToastService
+    private toastService: AdminToastService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {
     this.stateAndData = this.userPagingService.constructDefault();
   }
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.refreshUsers();
     this.loadRoles();
     this.fetchTeams();
   }
 
   ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/web-app/src/app/admin/admin-users/user-details/user-details-edit/user-details-edit.component.html
+++ b/web-app/src/app/admin/admin-users/user-details/user-details-edit/user-details-edit.component.html
@@ -1,4 +1,4 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions">
     <button matButton="outlined" class="cancel-button" type="button" (click)="cancelled.emit()" [disabled]="saving">
       <mat-icon fontSet="material-symbols-outlined">close</mat-icon>
@@ -9,7 +9,7 @@
       Save
     </button>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="user-page">
 <mat-card appearance="outlined" class="details-card">

--- a/web-app/src/app/admin/admin-users/user-details/user-details-edit/user-details-edit.component.ts
+++ b/web-app/src/app/admin/admin-users/user-details/user-details-edit/user-details-edit.component.ts
@@ -2,10 +2,13 @@ import {
   Component,
   DestroyRef,
   OnInit,
+  OnChanges,
+  SimpleChanges,
   Input,
   Output,
   EventEmitter,
   ElementRef,
+  TemplateRef,
   ViewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -14,6 +17,7 @@ import { UserService } from '../../../../user/user.service';
 import { User } from '../../user';
 import { userAvatarUrl, userIconUrl } from '../../../../entities/user/user';
 import { AdminBreadcrumb } from '../../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../../admin-breadcrumb/admin-breadcrumb.service';
 import { SessionService } from 'mage-web-app/http/session.service';
 
 interface EditableUser extends User {
@@ -32,9 +36,12 @@ interface IconMetadata {
     styleUrls: ['./user-details-edit.component.scss'],
     standalone: false
 })
-export class UserDetailsEditComponent implements OnInit {
+export class UserDetailsEditComponent implements OnInit, OnChanges {
   @Input() user!: User;
   @Input() breadcrumbs: AdminBreadcrumb[] = [];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   @Output() saved = new EventEmitter<User>();
   @Output() cancelled = new EventEmitter<void>();
@@ -60,10 +67,14 @@ export class UserDetailsEditComponent implements OnInit {
   constructor(
     private userService: UserService,
     private sessionService: SessionService,
-    private destroyRef: DestroyRef
+    private destroyRef: DestroyRef,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.editUser = { ...this.user } as EditableUser;
 
     const anyUser: any = this.user;
@@ -92,6 +103,12 @@ export class UserDetailsEditComponent implements OnInit {
         this.roles = roles;
         this.setSelectedRoleFromUser();
       });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['breadcrumbs']) {
+      this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    }
   }
 
   getPhoneNumber(): string {

--- a/web-app/src/app/admin/admin-users/user-details/user-details-view/user-details-view.component.html
+++ b/web-app/src/app/admin/admin-users/user-details/user-details-view/user-details-view.component.html
@@ -1,4 +1,4 @@
-<admin-breadcrumb [breadcrumbs]="breadcrumbs">
+<ng-template #breadcrumbActions>
   <div class="nav-actions" *ngIf="user && hasUserDeletePermission">
     <ng-container *ngIf="hasUserEditPermission">
       <button matButton="outlined" class="delete-user-button" (click)="confirmDeleteUser()">
@@ -6,7 +6,7 @@
       </button>
     </ng-container>
   </div>
-</admin-breadcrumb>
+</ng-template>
 
 <div class="user-page" *ngIf="user">
   <mat-card appearance="outlined" class="details-card">

--- a/web-app/src/app/admin/admin-users/user-details/user-details-view/user-details-view.component.ts
+++ b/web-app/src/app/admin/admin-users/user-details/user-details-view/user-details-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, EventEmitter, Input, OnInit, OnDestroy, Output } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, OnInit, OnDestroy, OnChanges, Output, SimpleChanges, TemplateRef, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatTableDataSource } from '@angular/material/table';
 import { PageEvent } from '@angular/material/paginator';
@@ -15,6 +15,7 @@ import { ChangePasswordComponent } from '../../change-password/change-password.c
 import { User } from '../../user';
 import { userAvatarUrl, userIconUrl } from '../../../../entities/user/user';
 import { AdminBreadcrumb } from '../../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../../admin-breadcrumb/admin-breadcrumb.service';
 import { SessionService } from 'mage-web-app/http/session.service';
 
 @Component({
@@ -23,9 +24,12 @@ import { SessionService } from 'mage-web-app/http/session.service';
     styleUrls: ['./user-details-view.component.scss'],
     standalone: false
 })
-export class UserDetailsViewComponent implements OnInit, OnDestroy {
+export class UserDetailsViewComponent implements OnInit, OnChanges, OnDestroy {
   @Input() user!: User;
   @Input() breadcrumbs: AdminBreadcrumb[] = [];
+
+  @ViewChild('breadcrumbActions', { static: true })
+  breadcrumbActions!: TemplateRef<unknown>;
 
   @Output() editRequested = new EventEmitter<void>();
   @Output() userChanged = new EventEmitter<User>();
@@ -63,10 +67,14 @@ export class UserDetailsViewComponent implements OnInit, OnDestroy {
     private snackBar: MatSnackBar,
     private router: Router,
     private route: ActivatedRoute,
-    private destroyRef: DestroyRef
+    private destroyRef: DestroyRef,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
+    this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    this.breadcrumbService.setActions(this.breadcrumbActions);
+
     this.sessionService.user$
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe((myself) => {
@@ -75,6 +83,12 @@ export class UserDetailsViewComponent implements OnInit, OnDestroy {
 
     this.loadUserTeams();
     this.loadUserEvents();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['breadcrumbs']) {
+      this.breadcrumbService.setBreadcrumbs(this.breadcrumbs);
+    }
   }
 
   ngOnDestroy(): void {

--- a/web-app/src/app/admin/admin-users/user-details/user-details.component.ts
+++ b/web-app/src/app/admin/admin-users/user-details/user-details.component.ts
@@ -5,6 +5,7 @@ import { map, Subject, takeUntil } from 'rxjs';
 import { UserService } from '../../../user/user.service';
 import { User } from '../user';
 import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
+import { AdminBreadcrumbService } from '../../admin-breadcrumb/admin-breadcrumb.service';
 
 @Component({
     selector: 'mage-user-details',
@@ -16,22 +17,26 @@ import { AdminBreadcrumb } from '../../admin-breadcrumb/admin-breadcrumb.model';
  * Admin component for viewing and managing a user's details, teams, events, devices, logins, and credentials.
  */
 export class UserDetailsComponent implements OnInit, OnDestroy {
-  user?: User;
+  private _user?: User;
+  set user(value: User | undefined) {
+    this._user = value;
+    this.breadcrumbs = [{ title: 'Users', icon: 'person', route: ['/admin/users'] }, { title: value?.displayName || 'Unknown User' }];
+  }
+  get user(): User | undefined {
+    return this._user;
+  }
+
   error: string | null = null;
   isEditingUser = false;
 
   private destroy$ = new Subject<void>();
 
-  get breadcrumbs(): AdminBreadcrumb[] {
-    return [
-      { title: 'Users', icon: 'person', route: ['../'] },
-      { title: this.user?.displayName || 'Unknown User' }
-    ];
-  }
+  breadcrumbs: AdminBreadcrumb[] = [{ title: 'Users', icon: 'person', route: ['/admin/users'] }, { title: 'Unknown User' }];
 
   constructor(
     private route: ActivatedRoute,
-    private userService: UserService
+    private userService: UserService,
+    private breadcrumbService: AdminBreadcrumbService
   ) {}
 
   ngOnInit(): void {
@@ -47,6 +52,12 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
         }
         this.initForUser(userId);
       });
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.setActions(null);
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   private initForUser(userId: string): void {
@@ -82,10 +93,5 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
 
   onEditCancelled(): void {
     this.isEditingUser = false;
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/web-app/src/styles.scss
+++ b/web-app/src/styles.scss
@@ -26,6 +26,15 @@ app {
   overflow: hidden;
 }
 
+// Caps the width of every admin page's routed content. .admin-main-content is a flex
+// container, so this child is auto-blockified regardless of the page's own :host display,
+// meaning max-width takes effect without needing to override that component's own layout.
+.admin-main-content > *:not(router-outlet) {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
 // Angular Material sets display: block and align-self: flex-start on the trailing meta slot for
 // multi-line list items with leading icons. Override to keep the slot centered.
 mat-nav-list .mdc-list-item--with-leading-icon.mdc-list-item--with-trailing-meta.mdc-list-item--with-two-lines .mdc-list-item__end,


### PR DESCRIPTION
Move <admin-breadcrumb> out of each admin page into the shell, driven by a new AdminBreadcrumbService, so a single global CSS rule can cap every admin page at 1200px without per-page styles.