### PR TITLE
Iron Bank dev image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 **/node_modules
 **/dist
+**/.angular
+/database

--- a/.github/workflows/dev.container_build.yaml
+++ b/.github/workflows/dev.container_build.yaml
@@ -17,14 +17,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Set IMAGE_TAG
-        run: |
-          if [[ "${{ github.ref_name }}" == "test" ]]; then
-            echo "IMAGE_TAG=test" >> $GITHUB_ENV
-          else
-            echo "IMAGE_TAG=dev" >> $GITHUB_ENV
-          fi
-
       - name: Login to Github Registry ghcr.io
         uses: docker/login-action@v3
         with:
@@ -34,13 +26,15 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG .
+          docker build \
+          -t ghcr.io/${{ github.repository }}/mage:dev \
+          --annotation "org.opencontainers.image.revision=${{ github.sha }}" .
 
       - name: Scan the docker image with Trivy
         uses: aquasecurity/trivy-action@v0.35.0 
         with:
           scan-type: 'image'
-          image-ref: 'ghcr.io/${{ github.repository }}/mage:${{ env.IMAGE_TAG }}'
+          image-ref: 'ghcr.io/${{ github.repository }}/mage:dev'
           ignore-unfixed: true
           format: 'table'
           output: 'trivy-image-report.txt'
@@ -55,6 +49,6 @@ jobs:
           retention-days: 7
 
       - name: Push Image
-        if: github.ref =='refs/heads/test' || github.ref =='refs/heads/develop'
+        if: github.ref =='refs/heads/develop'
         run: |
-          docker push ghcr.io/${{ github.repository }}/mage:$IMAGE_TAG
+          docker push ghcr.io/${{ github.repository }}/mage:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,61 +1,74 @@
-ARG BASE_IMAGE="node:24-slim"
+ARG BUILD_IMAGE="node:24-slim"
+ARG DIST_IMAGE="ghcr.io/ngageoint/mage-server/ironbank/google/distroless13/nodejs-24:nonroot"
+ARG MAGE_HOME="/mage"
+ARG MAGE_SERVER="${MAGE_HOME}/mage-server"
+ARG MAGE_PACKAGES="${MAGE_HOME}/packages"
+ARG MAGE_INSTANCE="${MAGE_HOME}/instance"
 
-FROM $BASE_IMAGE AS node-base
+FROM ${BUILD_IMAGE} AS build-instance
+ARG MAGE_HOME
+ARG MAGE_SERVER
+ARG MAGE_PACKAGES
+ARG MAGE_INSTANCE
+ENV MAGE_HOME=${MAGE_HOME}
+ENV MAGE_SERVER=${MAGE_SERVER}
+ENV MAGE_PACKAGES=${MAGE_PACKAGES}
+ENV MAGE_INSTANCE=${MAGE_INSTANCE}
+RUN mkdir -p ${MAGE_SERVER} ${MAGE_PACKAGES}
+COPY ./ ${MAGE_SERVER}/
 
-FROM node-base AS build-packages
-
-RUN mkdir /packages
-WORKDIR /mage-server
-COPY ./ ./
-
-RUN cd service \
+RUN cd ${MAGE_SERVER}/service \
     && npm ci \
     && npm run build \
-    && cd /packages \
-    && npm pack /mage-server/service
+    && cd ${MAGE_PACKAGES} \
+    && npm pack ${MAGE_SERVER}/service
 
-RUN cd web-app \
+RUN cd ${MAGE_SERVER}/web-app \
     && npm ci \
     && npm run build \
-    && cd /packages \
-    && npm pack /mage-server/web-app/dist/app \
-    && npm pack /mage-server/web-app/dist/core-lib
+    && cd ${MAGE_PACKAGES} \
+    && npm pack ${MAGE_SERVER}/web-app/dist/app \
+    && npm pack ${MAGE_SERVER}/web-app/dist/core-lib
 
-RUN cd plugins/image/service \
+RUN cd ${MAGE_SERVER}/plugins/image/service \
     && npm link ../../../service \
     && npm run build && \
-    cd /packages \
-    && npm pack /mage-server/plugins/image/service
+    cd ${MAGE_PACKAGES} \
+    && npm pack ${MAGE_SERVER}/plugins/image/service
 
-RUN cd plugins/sftp/service \
+RUN cd ${MAGE_SERVER}/plugins/sftp/service \
     && npm link ../../../service \
     && npm run build \
-    && cd /packages \
-    && npm pack /mage-server/plugins/sftp/service
+    && cd ${MAGE_PACKAGES} \
+    && npm pack ${MAGE_SERVER}/plugins/sftp/service
 
-RUN cd plugins/sftp/web \
+RUN cd ${MAGE_SERVER}/plugins/sftp/web \
     && npm link ../../../web-app/dist/core-lib \
     && npm run build \
-    && cd /packages \
-    && npm pack /mage-server/plugins/sftp/web/dist/main
+    && cd ${MAGE_PACKAGES} \
+    && npm pack ${MAGE_SERVER}/plugins/sftp/web/dist/main
 
-RUN cd plugins/arcgis/service \
+RUN cd ${MAGE_SERVER}/plugins/arcgis/service \
     && npm link ../../../service \
     && npm run build \
-    && cd /packages \
-    && npm pack /mage-server/plugins/arcgis/service
+    && cd ${MAGE_PACKAGES} \
+    && npm pack ${MAGE_SERVER}/plugins/arcgis/service
 
-RUN cd plugins/arcgis/web-app \
+RUN cd ${MAGE_SERVER}/plugins/arcgis/web-app \
     && npm link ../../../web-app/dist/core-lib \
     && npm run build \
-    && cd /packages \
-    && npm pack /mage-server/plugins/arcgis/web-app/dist/main
+    && cd ${MAGE_PACKAGES} \
+    && npm pack ${MAGE_SERVER}/plugins/arcgis/web-app/dist/main
 
-FROM node-base AS build-instance
-ENV MAGE_HOME=/home/mage/instance
-WORKDIR ${MAGE_HOME}
-COPY --from=build-packages /packages ${MAGE_HOME}/packages/
-RUN npm install --force --omit dev ${MAGE_HOME}/packages/*.tgz
-RUN ln -s ./node_modules/.bin/mage.service
+WORKDIR ${MAGE_INSTANCE}
+RUN cd ${MAGE_INSTANCE} \
+    && npm install --omit dev --force ${MAGE_PACKAGES}/*.tgz \
+    && ln -s ./node_modules/.bin/mage.service
 
-ENTRYPOINT [ "./mage.service" ]
+FROM ${DIST_IMAGE}
+ARG MAGE_INSTANCE
+ENV MAGE_INSTANCE=${MAGE_INSTANCE}
+COPY --from=build-instance ${MAGE_INSTANCE}/ ${MAGE_INSTANCE}/
+WORKDIR ${MAGE_INSTANCE}
+
+CMD [ "./mage.service" ]


### PR DESCRIPTION
This PR modifies the development Dockerfile to use a hardened base image from the [Iron Bank](https://ironbank.dso.mil/repomap/details;registry1Path=google%252Fdistroless13%252Fnodejs-24?page=1&sort=0&order=1&cardsPerPage=3) image registry.  The image is copied to the GitHub image registry so the repository actions can access the image easily.  This also means that anyone wishing to build the development image locally must [setup](https://github.com/settings/tokens) a GitHub "Classic" personal access token for the Docker CLI to authenticate to ghcr.io.  For example, after copying your token to the clipboard on your Mac, login with the following command.
```
pbpaste | docker login --username <github_user> --password-stdin ghcr.io
```
Then you should be able to build the development image.
```
# from mage-server repository root dir
docker build -t mage:local .
```