### PR TITLE
feat(service): delete observation important flag by null entry

### DIFF
--- a/service/src/adapters/observations/adapters.observations.db.mongoose.ts
+++ b/service/src/adapters/observations/adapters.observations.db.mongoose.ts
@@ -54,8 +54,7 @@ export class MongooseObservationRepository extends BaseMongooseRepository<legacy
         console.warn(`attempted to modify create timestamp on observation ${beforeDoc.id} from ${beforeDoc.createdAt} to ${docSeed.createdAt}`)
         docSeed.createdAt = new Date(beforeDoc.createdAt)
       }
-      //TODO remove any, was as legacy.ObservationDocument
-      beforeDoc = beforeDoc.set(docSeed) as any
+      beforeDoc = beforeDoc.set(docSeed)
     }
     else {
       const idVerified = await this.idModel.findById(dbId)
@@ -189,7 +188,7 @@ function importantFlagAttrsForDoc(doc: legacy.ObservationDocument): ObservationI
       description: docImportant.description
     }
   }
-  return void (0)
+  return undefined
 }
 
 function attachmentAttrsForDoc(doc: legacy.AttachmentDocument): Attachment {

--- a/service/src/entities/observations/entities.observations.ts
+++ b/service/src/entities/observations/entities.observations.ts
@@ -18,7 +18,7 @@ export interface ObservationAttrs extends Feature<Geometry, ObservationFeaturePr
   createdAt: Date
   lastModified: Date
   attachments: readonly Attachment[]
-  important?: Readonly<ObservationImportantFlag> | undefined
+  important?: Readonly<ObservationImportantFlag> | undefined | null
   /**
    * TODO: scalability - potential problem if thousands of users favorite;
    * this should not be returned to the client

--- a/service/test/adapters/observations/adapters.observations.db.mongoose.test.ts
+++ b/service/test/adapters/observations/adapters.observations.db.mongoose.test.ts
@@ -366,6 +366,40 @@ describe('mongoose observation repository', function () {
         expect(count).to.equal(1)
       })
 
+      it('removes previously set important', async function() {
+
+        const putAttrs = copyObservationAttrs(origAttrs)
+        putAttrs.geometry = {
+          type: 'Point',
+          coordinates: [ 12, 34 ]
+        }
+        putAttrs.states = [
+          { name: 'archived', id: PendingEntityId }
+        ]
+        putAttrs.properties.forms = [
+          {
+            id: orig.properties.forms[0].id,
+            formId: event.forms[0].id,
+            field1: 'mod text',
+            field2: 20
+          }
+        ]
+        putAttrs.attachments = []
+        putAttrs.important = null
+        const put = Observation.evaluate(putAttrs, event)
+        const saved = await repo.save(put) as Observation
+        const savedAttrs = copyObservationAttrs(saved)
+        const count = await model.countDocuments()
+
+        expect(saved).to.be.instanceOf(Observation)
+        expect(saved.id).to.equal(orig.id)
+        expect(() => new mongoose.Types.ObjectId(savedAttrs.states[0].id as string)).not.to.throw()
+        expect(savedAttrs.states[0].id).not.to.equal(orig.states[0].id)
+        expect(savedAttrs.lastModified.getTime()).to.be.greaterThanOrEqual(orig.lastModified.getTime())
+        expect(count).to.equal(1)
+        expect(saved.important).to.be.undefined
+      })
+
       it('does not allow changing the create timestamp', async function () {
 
         const modAttrs = copyObservationAttrs(orig)


### PR DESCRIPTION
This PR adds the `null` type to the `ObservationAttrs.important` type union to support deleting the flag with a `null` entry rather than just an omitted or `undefined` entry.