### PR TITLE
fix(dev image): remove core-lib dev package and proper permissions for data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ RUN cd ${MAGE_INSTANCE} \
     && ln -s ./node_modules/.bin/mage.service
 
 FROM ${DIST_IMAGE}
+# create the mage data base directory as DIST_IMAGE nonroot user
+WORKDIR /var/lib/mage
 ARG MAGE_INSTANCE
 ENV MAGE_INSTANCE=${MAGE_INSTANCE}
 COPY --from=build-instance ${MAGE_INSTANCE}/ ${MAGE_INSTANCE}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,12 @@ RUN cd ${MAGE_SERVER}/plugins/arcgis/web-app \
 
 WORKDIR ${MAGE_INSTANCE}
 RUN cd ${MAGE_INSTANCE} \
-    && npm install --omit dev --force ${MAGE_PACKAGES}/*.tgz \
+    && npm install --omit dev --force \
+    ${MAGE_PACKAGES}/ngageoint-mage.service-*.tgz \
+    ${MAGE_PACKAGES}/ngageoint-mage.web-app-*.tgz \
+    ${MAGE_PACKAGES}/ngageoint-mage.sftp.*.tgz \
+    ${MAGE_PACKAGES}/ngageoint-mage.arcgis.*.tgz \
+    ${MAGE_PACKAGES}/ngageoint-mage.image.*.tgz \
     && ln -s ./node_modules/.bin/mage.service
 
 FROM ${DIST_IMAGE}


### PR DESCRIPTION
This PR includes the following fixes for the development image Dockerfile.
* Removes the mistakenly installed `mage.web-core-lib` development-only package
* Creates a base data directory with the proper permissions for the nonroot container user where the Mage service saves files like attachments, icons, etc.