### PR TITLE
fix(service): remove Cloud Foundry (cfenv) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Mage adheres to [Semantic Versioning](http://semver.org/).
 * Replaced `passport-ldapauth` with `ldapts` for LDAP authentication
 * Added Trivy vulnerability scanning of built container images in CI
 * General dependency/vulnerability cleanup: upgraded Express, `geopackage`, `passport-saml`, `form-data`, `multer`; removed `crypto-js` and unused `xpath`/`walk` dependencies
+* Removed legacy Cloud Foundry deployment support. Environment configuration is now read directly from `MAGE_*` env vars
 
 ### Web App
 #### Features

--- a/README.md
+++ b/README.md
@@ -248,14 +248,6 @@ host headers. To do this, execute the following command:
 \Windows\System32\inetsrv\appcmd.exe set config -section:system.webServer/proxy -preserveHostHeader:true /commit:apphost
 ```
 
-#### Cloud Foundry deployment
-
-Mage uses the [cfenv](https://github.com/cloudfoundry-community/node-cfenv) Node module to read settings from Cloud Foundry's
-[environment variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html).  If Cloud Foundry's
-environment variables are present, they will take precedence over any of their counterparts derived from the
-[magerc.sh](environment/env.js) file.  This pertains mostly to defining the connection to the MongoDB server as a bound service
-in Cloud Foundry, for which Cloud Foundry should supply the connection string and credentials in the `VCAP_SERVICES` value.
-
 ### Upgrading Mage server
 
 Upgrading the Mage server essentially consists of the same process as [installing for the first time](#install-mage-server-packages).

--- a/service/npm-shrinkwrap.json
+++ b/service/npm-shrinkwrap.json
@@ -25,7 +25,6 @@
         "base-64": "1.0.0",
         "busboy": "1.6.0",
         "captcha-canvas": "3.4.0",
-        "cfenv": "^1.2.6",
         "commander": "12.0.0",
         "express": "4.22.2",
         "express-session": "1.18.1",
@@ -3168,17 +3167,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "skia-canvas": "^3.0.8"
-      }
-    },
-    "node_modules/cfenv": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/cfenv/-/cfenv-1.2.6.tgz",
-      "integrity": "sha512-nx+bbEvpzWTuASn2Xy64n8oDkhgK4Z+dHhG51RNsPH66vCU08cPiLyRrxJh9ukjtK3AGbVc15NSAMMMrO1rGQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "js-yaml": "4.1.x",
-        "ports": "1.1.x",
-        "underscore": "1.13.x"
       }
     },
     "node_modules/chai": {
@@ -6735,11 +6723,6 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-<<<<<<< Updated upstream
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-=======
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
@@ -6753,7 +6736,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
->>>>>>> Stashed changes
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9433,12 +9415,6 @@
         "splaytree": "^3.1.0"
       }
     },
-    "node_modules/ports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ports/-/ports-1.1.0.tgz",
-      "integrity": "sha512-XmS7dspHnkTXZC75NkG0ti2hLj8aSyg1Izp87/2cWT7QhTo1vdtWsQ4ldp4BEQ/EXqy0s4yTATJUZ3t9RGZVpg==",
-      "license": "Apache 2.0"
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11839,12 +11815,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/service/package.json
+++ b/service/package.json
@@ -46,7 +46,6 @@
     "base-64": "1.0.0",
     "busboy": "1.6.0",
     "captcha-canvas": "3.4.0",
-    "cfenv": "^1.2.6",
     "commander": "12.0.0",
     "express": "4.22.2",
     "express-session": "1.18.1",

--- a/service/src/environment/env.js
+++ b/service/src/environment/env.js
@@ -1,16 +1,8 @@
 const mongodb = require('mongodb')
   , path = require('path')
-  , cfenv = require('cfenv')
   , log = require('winston');
 
-if (!(process.env.MAGE_PORT || process.env.PORT || process.env.CF_INSTANCE_PORT || process.env.VCAP_APP_PORT)) {
-  // bit of whitebox to cfenv lib here, because it provides no
-  // way to override the port value in options at construction,
-  // and uses the ports (https://www.npmjs.com/package/ports) package
-  // to attempt to read or set a default port from a file based on
-  // the current app's name. this always ends up being 6001, and once
-  // ports assigns that, it writes the value out to ~/.ports.json,
-  // which i think is undesirable behavior.
+if (!(process.env.MAGE_PORT || process.env.PORT)) {
   process.env.MAGE_PORT = '4242';
 }
 let x509Key = process.env.MAGE_MONGO_X509_KEY;
@@ -54,41 +46,25 @@ if (process.env.MAGE_MONGO_MAX_POOL_SIZE) {
   maxMongoPoolSize = parseInt(process.env.MAGE_MONGO_POOL_SIZE);
 }
 
-const appEnv = cfenv.getAppEnv({
-  vcap: {
-    services: {
-      "user-provided": [
-        {
-          name: 'MongoInstance',
-          plan: 'unlimited',
-          credentials: {
-            url: process.env.MAGE_MONGO_URL || 'mongodb://127.0.0.1:27017/magedb',
-            minPoolSize: minMongoPoolSize,
-            maxPoolSize: maxMongoPoolSize,
-            replicaSet: process.env.MAGE_MONGO_REPLICA_SET,
-            username: process.env.MAGE_MONGO_USER,
-            password: process.env.MAGE_MONGO_PASSWORD,
-            tls: process.env.MAGE_MONGO_SSL || null,
-            x509Key: x509Key || null,
-            x509Cert: x509Cert || null,
-            x509CaCert: x509CaCert || null,
-            tlsInsecure: process.env.MAGE_MONGO_TLS_INSECURE || null
-          }
-        }
-      ]
-    }
-  }
-});
+const mongoConfig = {
+  url: process.env.MAGE_MONGO_URL || 'mongodb://127.0.0.1:27017/magedb',
+  minPoolSize: minMongoPoolSize,
+  maxPoolSize: maxMongoPoolSize,
+  replicaSet: process.env.MAGE_MONGO_REPLICA_SET,
+  username: process.env.MAGE_MONGO_USER,
+  password: process.env.MAGE_MONGO_PASSWORD,
+  tls: process.env.MAGE_MONGO_SSL || null,
+  x509Key: x509Key || null,
+  x509Cert: x509Cert || null,
+  x509CaCert: x509CaCert || null,
+  tlsInsecure: process.env.MAGE_MONGO_TLS_INSECURE || null
+};
 
-if (appEnv.isLocal) {
-  appEnv.port = [ process.env.MAGE_PORT, process.env.PORT, 4242 ].map(parseInt).find(x => typeof x === 'number' && !isNaN(x));
-}
-
-const mongoConfig = appEnv.getServiceCreds('MongoInstance');
+const port = [ process.env.MAGE_PORT, process.env.PORT, 4242 ].map(parseInt).find(x => typeof x === 'number' && !isNaN(x));
 
 const environment = {
   address: process.env.MAGE_ADDRESS || '0.0.0.0',
-  port: appEnv.port,
+  port: port,
   userBaseDirectory: path.resolve(process.env.MAGE_USER_DIR || '/var/lib/mage/users'),
   iconBaseDirectory: path.resolve(process.env.MAGE_ICON_DIR || '/var/lib/mage/icons'),
   attachmentBaseDirectory: path.resolve(process.env.MAGE_ATTACHMENT_DIR || '/var/lib/mage/attachments'),
@@ -116,8 +92,8 @@ const environment = {
   }
 };
 
-const user = mongoConfig.user || mongoConfig.username;
-const password = mongoConfig.pass || mongoConfig.password;
+const user = mongoConfig.username;
+const password = mongoConfig.password;
 
 if (mongoConfig.x509Key) {
   const mongoTls = String(mongoConfig.tls).toLowerCase() in { "true": 0, "yes": 0, "enabled": 0 };

--- a/service/test/environment/environmentTest.js
+++ b/service/test/environment/environmentTest.js
@@ -24,9 +24,7 @@ describe("environment", function() {
       'MAGE_MONGO_CONN_TIMEOUT',
       'MAGE_MONGO_CONN_RETRY_DELAY',
       'PORT',
-      'ADDRESS',
-      'VCAP_APPLICATION',
-      'VCAP_SERVICES'
+      'ADDRESS'
     ].forEach(key => delete process.env[key]);
   });
 
@@ -155,48 +153,6 @@ describe("environment", function() {
       expect(options).to.have.property('authSource', '$external');
       expect(options).to.have.deep.property('authMechanism', 'MONGODB-X509');
       expect(options).to.not.have.property('user');
-    });
-  });
-
-  describe("in cloud foundry", function() {
-
-    it("loads values from vcap env vars", function() {
-
-      process.env.PORT = '2424';
-      process.env.MAGE_TOKEN_EXPIRATION = '3600';
-      process.env.VCAP_APPLICATION = '{}';
-      process.env.VCAP_SERVICES = JSON.stringify({
-        "user-provided": [
-          {
-            name: 'MongoInstance',
-            credentials: {
-              url: 'mongodb-cf://db.test.mage:27999/magedb_cf',
-              user: 'cloudfoundry',
-              pass: 'foundrycloud',
-              minPoolSize: 99,
-              maxPoolSize: 99
-            }
-          }
-        ]
-      });
-      const environment = proxyquire('../../lib/environment/env', {});
-
-      expect(environment).to.have.property('port', 2424);
-      expect(environment).to.have.property('address', '0.0.0.0');
-      expect(environment).to.have.property('attachmentBaseDirectory', '/var/lib/mage/attachments');
-      expect(environment).to.have.property('iconBaseDirectory', '/var/lib/mage/icons');
-      expect(environment).to.have.property('userBaseDirectory', '/var/lib/mage/users');
-      expect(environment).to.have.property('tokenExpiration', 3600);
-      expect(environment).to.have.property('mongo');
-      const mongo = environment.mongo;
-      expect(mongo).to.have.property('uri', 'mongodb-cf://db.test.mage:27999/magedb_cf');
-      expect(mongo).to.have.property('connectRetryDelay', 5000);
-      expect(mongo).to.have.property('connectTimeout', 300000);
-      const options = mongo.options;
-      expect(options).to.not.have.property('tls');
-      expect(options).to.have.property('minPoolSize', 99);
-      expect(options).to.have.property('maxPoolSize', 99);
-      expect(options).to.have.deep.property('auth', { "username": "cloudfoundry", "password": "foundrycloud" });
     });
   });
 });


### PR DESCRIPTION
cfenv pulled in a vulnerable js-yaml (and unused ports/underscore) for a feature — reading VCAP_APPLICATION/VCAP_SERVICES — that hasn't been documented as supported deployment path in years. Environment config is now read directly from MAGE_* env vars with no cfenv indirection.