### PR TITLE
fix(web-app): fix "go to" snackbar links after admin entity creation

### DIFF
--- a/web-app/src/app/admin/admin-devices/dashboard/devices-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-devices/dashboard/devices-dashboard.component.ts
@@ -138,7 +138,7 @@ export class DeviceDashboardComponent implements OnInit, OnDestroy {
       if (newDevice) {
         this.toastService.show(
           'Device Created',
-          ['../devices', newDevice.id],
+          ['/admin/devices', newDevice.id],
           'Go to Device'
         );
         this.refreshDevices();

--- a/web-app/src/app/admin/admin-event/dashboard/event-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-event/dashboard/event-dashboard.component.ts
@@ -137,8 +137,8 @@ export class EventDashboardComponent implements OnInit, OnDestroy {
       if (newEvent?.id) {
         this.toastService.show(
           'Event Created',
-          ['../events', newEvent.id],
-          'Go To Event'
+          ['/admin/events', newEvent.id],
+          'Go to Event'
         );
         this.refreshEvents();
       }

--- a/web-app/src/app/admin/admin-layers/dashboard/layer-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-layers/dashboard/layer-dashboard.component.ts
@@ -138,7 +138,7 @@ export class LayerDashboardComponent implements OnInit, OnDestroy {
 
       this.toastService.show(
         'Layer Created',
-        ['../layers', newLayer.id],
+        ['/admin/layers', newLayer.id],
         'Go to Layer'
       );
 

--- a/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.spec.ts
+++ b/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.spec.ts
@@ -206,8 +206,8 @@ describe('TeamDashboardComponent', () => {
 
     expect(toastSpy.show).toHaveBeenCalledWith(
       'Team created successfully',
-      ['../teams', createdTeam.id],
-      'View Team'
+      ['/admin/teams', createdTeam.id],
+      'Go to Team'
     );
 
     expect(mockTeamsService.getTeams).toHaveBeenCalled();

--- a/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-teams/dashboard/team-dashboard.component.ts
@@ -135,8 +135,8 @@ export class TeamDashboardComponent implements OnInit, OnDestroy {
       if (newTeam) {
         this.toastService.show(
           'Team created successfully',
-          ['../teams', newTeam.id],
-          'View Team'
+          ['/admin/teams', newTeam.id],
+          'Go to Team'
         );
         this.fetchTeams();
       }

--- a/web-app/src/app/admin/admin-users/dashboard/user-dashboard.component.ts
+++ b/web-app/src/app/admin/admin-users/dashboard/user-dashboard.component.ts
@@ -215,8 +215,8 @@ export class UserDashboardComponent implements OnInit, OnDestroy {
         this.refreshUsers(() => {
           this.toastService.show(
             'User created successfully',
-            ['../users', createdUser.id],
-            'View User'
+            ['/admin/users', createdUser.id],
+            'Go to User'
           );
         });
       });


### PR DESCRIPTION
Snackbar navigation used router-relative paths (e.g. '../events') with no relativeTo context, so Router.navigate resolved them from the root and fell through to the home route instead of the new entity. Switch to absolute /admin/... paths for events, layers, teams, users, and devices, and standardize the action text to "Go to X".