### PR TITLE
feat(web-app): show upload progress when creating a GeoPackage layer

### DIFF
--- a/web-app/src/app/admin/admin-layers/create-layer/create-layer.component.html
+++ b/web-app/src/app/admin/admin-layers/create-layer/create-layer.component.html
@@ -38,11 +38,18 @@
     </div>
 
     <div *ngIf="layerForm.get('type')?.value === 'GeoPackage' && !isEditMode" class="geopackage-section">
-      <button matButton="outlined" type="button" (click)="fileInput.click()">
+      <button matButton="outlined" type="button" (click)="fileInput.click()" [disabled]="uploading">
         <mat-icon fontSet="material-symbols-outlined">upload</mat-icon>
         {{ geopackageFileName || 'Upload GeoPackage' }}
       </button>
       <input #fileInput type="file" class="file-input" accept=".gpkg" (change)="onGeoPackageFileSelected($event)">
+
+      <mat-progress-bar
+        *ngIf="uploading"
+        class="upload-progress"
+        [mode]="uploadProgress === null ? 'indeterminate' : 'determinate'"
+        [value]="uploadProgress"
+      ></mat-progress-bar>
     </div>
   </form>
 </mat-dialog-content>
@@ -53,6 +60,6 @@
 </div>
 
 <mat-dialog-actions>
-  <button matButton type="button" (click)="cancel()">Cancel</button>
-  <button matButton="filled" type="button" (click)="save()" [disabled]="canSave">{{ isEditMode ? 'Save Layer' : 'Create Layer' }}</button>
+  <button matButton type="button" (click)="cancel()" [disabled]="uploading">Cancel</button>
+  <button matButton="filled" type="button" (click)="save()" [disabled]="canSave">{{ uploading ? (uploadProgress === null ? 'Processing…' : 'Uploading ' + uploadProgress + '%') : (isEditMode ? 'Save Layer' : 'Create Layer') }}</button>
 </mat-dialog-actions>

--- a/web-app/src/app/admin/admin-layers/create-layer/create-layer.component.spec.ts
+++ b/web-app/src/app/admin/admin-layers/create-layer/create-layer.component.spec.ts
@@ -1,0 +1,188 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import {
+  MatDialogModule as MatDialogModule,
+  MatDialogRef as MatDialogRef,
+  MAT_DIALOG_DATA as MAT_DIALOG_DATA
+} from '@angular/material/dialog';
+import { HttpEventType } from '@angular/common/http';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatFormFieldModule as MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule as MatInputModule } from '@angular/material/input';
+import { MatSelectModule as MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressBarModule as MatProgressBarModule } from '@angular/material/progress-bar';
+import { Subject, of, throwError } from 'rxjs';
+
+import { CreateLayerDialogComponent } from './create-layer.component';
+import { LayersService } from '../layers.service';
+
+describe('CreateLayerDialogComponent', () => {
+  let component: CreateLayerDialogComponent;
+  let fixture: ComponentFixture<CreateLayerDialogComponent>;
+  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<CreateLayerDialogComponent>>;
+  let layersServiceSpy: jasmine.SpyObj<LayersService>;
+
+  function createComponent(data: { layer: any } = { layer: {} }) {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+    layersServiceSpy = jasmine.createSpyObj('LayersService', [
+      'getLayers',
+      'createLayer',
+      'updateLayer'
+    ]);
+    layersServiceSpy.getLayers.and.returnValue(of([]));
+
+    TestBed.configureTestingModule({
+      declarations: [CreateLayerDialogComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [
+        ReactiveFormsModule,
+        FormsModule,
+        MatDialogModule,
+        NoopAnimationsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatIconModule,
+        MatCheckboxModule,
+        MatProgressBarModule
+      ],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: LayersService, useValue: layersServiceSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateLayerDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  function fillGeoPackageForm() {
+    component.layerForm.patchValue({ name: 'My Layer', type: 'GeoPackage' });
+    component.geopackageFile = new File(['content'], 'test.gpkg');
+    component.geopackageFileName = 'test.gpkg';
+  }
+
+  it('should create', () => {
+    createComponent();
+    expect(component).toBeTruthy();
+  });
+
+  describe('save with GeoPackage upload', () => {
+    beforeEach(() => createComponent());
+
+    it('should set uploading state and reset progress to 0 when the request starts', () => {
+      fillGeoPackageForm();
+      layersServiceSpy.createLayer.and.returnValue(new Subject());
+
+      component.save();
+
+      expect(component.uploading).toBeTrue();
+      expect(component.uploadProgress).toBe(0);
+      expect(component.canSave).toBeTrue();
+    });
+
+    it('should update uploadProgress as UploadProgress events arrive', () => {
+      fillGeoPackageForm();
+      const events = new Subject<any>();
+      layersServiceSpy.createLayer.and.returnValue(events);
+
+      component.save();
+
+      events.next({ type: HttpEventType.UploadProgress, loaded: 25, total: 100 });
+      expect(component.uploadProgress).toBe(25);
+
+      events.next({ type: HttpEventType.UploadProgress, loaded: 75, total: 100 });
+      expect(component.uploadProgress).toBe(75);
+    });
+
+    it('should set uploadProgress to null when total is unknown', () => {
+      fillGeoPackageForm();
+      const events = new Subject<any>();
+      layersServiceSpy.createLayer.and.returnValue(events);
+
+      component.save();
+
+      events.next({ type: HttpEventType.UploadProgress, loaded: 25, total: undefined });
+      expect(component.uploadProgress).toBeNull();
+    });
+
+    it('should close the dialog with the created layer on Response and clear uploading', () => {
+      fillGeoPackageForm();
+      const events = new Subject<any>();
+      layersServiceSpy.createLayer.and.returnValue(events);
+
+      component.save();
+
+      const newLayer = { id: 1, name: 'My Layer', type: 'GeoPackage' };
+      events.next({ type: HttpEventType.Response, body: newLayer });
+
+      expect(component.uploading).toBeFalse();
+      expect(dialogRefSpy.close).toHaveBeenCalledWith(newLayer);
+    });
+
+    it('should show a unique-name error on 400 with a name validation error', () => {
+      fillGeoPackageForm();
+      layersServiceSpy.createLayer.and.returnValue(
+        throwError(() => ({
+          status: 400,
+          error: { errors: { name: { type: 'unique', message: 'Name already in use' } } }
+        }))
+      );
+
+      component.save();
+
+      expect(component.uploading).toBeFalse();
+      expect(component.uploadProgress).toBeNull();
+      expect(component.errorMessage).toBe('Name already in use');
+    });
+
+    it('should show the server message on 409 conflict', () => {
+      fillGeoPackageForm();
+      layersServiceSpy.createLayer.and.returnValue(
+        throwError(() => ({ status: 409, error: 'Layer name conflict' }))
+      );
+
+      component.save();
+
+      expect(component.errorMessage).toBe('Layer name conflict');
+    });
+
+    it('should show a generic error for unexpected failures', () => {
+      fillGeoPackageForm();
+      layersServiceSpy.createLayer.and.returnValue(
+        throwError(() => ({ status: 500, error: {} }))
+      );
+
+      component.save();
+
+      expect(component.errorMessage).toBe('Failed to create layer. Please try again.');
+    });
+
+    it('should require a GeoPackage file before saving', () => {
+      component.layerForm.patchValue({ name: 'My Layer', type: 'GeoPackage' });
+      component.geopackageFile = null;
+
+      component.save();
+
+      expect(component.errorMessage).toBe('Please select a GeoPackage file.');
+      expect(layersServiceSpy.createLayer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('canSave', () => {
+    beforeEach(() => createComponent());
+
+    it('should be disabled while an upload is in progress', () => {
+      fillGeoPackageForm();
+      expect(component.canSave).toBeFalse();
+
+      component.uploading = true;
+      expect(component.canSave).toBeTrue();
+    });
+  });
+});

--- a/web-app/src/app/admin/admin-layers/create-layer/create-layer.component.ts
+++ b/web-app/src/app/admin/admin-layers/create-layer/create-layer.component.ts
@@ -8,6 +8,7 @@ import {
   ValidationErrors,
   AsyncValidatorFn
 } from '@angular/forms';
+import { HttpEventType } from '@angular/common/http';
 import { LayersService, Layer } from '../layers.service';
 import { Observable, of } from 'rxjs';
 import { map, catchError, debounceTime, first } from 'rxjs/operators';
@@ -24,6 +25,8 @@ export class CreateLayerDialogComponent {
   errorMessage = '';
   geopackageFile: File | null = null;
   geopackageFileName = '';
+  uploading = false;
+  uploadProgress: number | null = null;
 
   isEditMode: boolean;
 
@@ -192,11 +195,24 @@ export class CreateLayerDialogComponent {
       }
     }
 
+    this.uploading = true;
+    this.uploadProgress = 0;
+
     this.layersService.createLayer(layerData).subscribe({
-      next: (newLayer) => {
-        this.dialogRef.close(newLayer);
+      next: (event) => {
+        if (event.type === HttpEventType.UploadProgress) {
+          this.uploadProgress = event.total
+            ? Math.round((100 * event.loaded) / event.total)
+            : null;
+        } else if (event.type === HttpEventType.Response) {
+          this.uploading = false;
+          this.dialogRef.close(event.body);
+        }
       },
       error: ({ status, error }) => {
+        this.uploading = false;
+        this.uploadProgress = null;
+
         if (status === 400 && error?.errors) {
           const fieldErrors = error.errors;
           if (fieldErrors.name?.type === 'unique') {
@@ -258,6 +274,8 @@ export class CreateLayerDialogComponent {
   }
 
   get canSave(): boolean {
+    if (this.uploading) return true;
+
     const nameControl = this.layerForm.get('name');
     const type = this.isEditMode
       ? this.data.layer?.type

--- a/web-app/src/app/admin/admin-layers/layers.service.ts
+++ b/web-app/src/app/admin/admin-layers/layers.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpEvent, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -79,8 +79,11 @@ export class LayersService {
         return this.http.put<Layer>(`/api/layers/${id}`, layer);
     }
 
-    createLayer(layer: Partial<Layer> | FormData): Observable<Layer> {
-        return this.http.post<Layer>('/api/layers', layer);
+    createLayer(layer: Partial<Layer> | FormData): Observable<HttpEvent<Layer>> {
+        return this.http.post<Layer>('/api/layers', layer, {
+            reportProgress: true,
+            observe: 'events'
+        });
     }
 
     getLayerCount(): Observable<{ count: number }> {


### PR DESCRIPTION
The create-layer dialog gave no feedback while a .gpkg file uploaded, leaving the user staring at an unresponsive dialog. createLayer now reports HttpEvent progress, and the dialog shows a progress bar, disables Cancel/Create while uploading, and closes on the final response.