### PR TITLE
fix(service,web-app): show user avatars in users feed

### DIFF
--- a/service/src/models/cappedLocation.js
+++ b/service/src/models/cappedLocation.js
@@ -76,7 +76,7 @@ exports.getLocations = function (options, callback) {
   if (options.populate) {
     query.populate({
       path: 'userId',
-      select: 'icon displayName email phones'
+      select: 'icon avatar displayName email phones'
     })
   }
 

--- a/web-app/src/app/user/user-list/user-list-item.component.html
+++ b/web-app/src/app/user/user-list/user-list-item.component.html
@@ -7,28 +7,28 @@
 
       <div class="item-header-content">
         <div class="item-title">
-          <span>{{ user?.user?.displayName }}</span>
+          <span>{{ user?.displayName }}</span>
         </div>
 
-        <div *ngIf="user?.location?.properties?.timestamp" class="item-subtitle">
-          {{ user?.location?.properties?.timestamp | moment }}
+        <div *ngIf="location?.properties?.timestamp" class="item-subtitle">
+          {{ location?.properties?.timestamp | moment }}
         </div>
 
-        <div *ngIf="user?.location?.geometry" class="item-subtitle">
-          {{ user?.location?.geometry | geometry : 5 }}
+        <div *ngIf="location?.geometry" class="item-subtitle">
+          {{ location?.geometry | geometry : 5 }}
         </div>
       </div>
 
-      <div *ngIf="user?.user?.iconUrl">
-        <img class="item-icon" [src]="user?.user?.iconUrl + '?access_token=' + token" alt="" />
+      <div *ngIf="user?.iconUrl">
+        <img class="item-icon" [src]="user?.iconUrl + '?access_token=' + token" alt="" />
       </div>
     </div>
   </mat-card-content>
 
   <mat-card-actions>
     <div class="actions-buttons">
-      <button *ngIf="followingUser.id !== user.id" matButton (click)="followUser($event)">Follow</button>
-      <button *ngIf="followingUser.id === user.id" matButton="filled" (click)="followUser($event)">Following</button>
+      <button *ngIf="followingUser.id !== user?.id" matButton (click)="followUser($event)">Follow</button>
+      <button *ngIf="followingUser.id === user?.id" matButton="filled" (click)="followUser($event)">Following</button>
     </div>
 
     <div class="actions-icons">

--- a/web-app/src/app/user/user-list/user-list-item.component.ts
+++ b/web-app/src/app/user/user-list/user-list-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
 import { MatRipple } from '@angular/material/core';
 import { MapService } from '../../map/map.service';
 import { SessionService } from '../../http/session.service';
@@ -10,8 +10,8 @@ import { FeedPanelService } from '../../feed-panel/feed-panel.service';
     styleUrls: ['./user-list-item.component.scss'],
     standalone: false
 })
-export class UserListItemComponent {
-  @Input() user: any
+export class UserListItemComponent implements OnChanges {
+  @Input() userWithLocation: any
   @Input() follow: any
   @Input() followable: boolean
 
@@ -22,6 +22,9 @@ export class UserListItemComponent {
   token: string | undefined
   followingUser: any
 
+  user: any
+  location: any
+
   constructor(
     private feedPanelService: FeedPanelService,
     private mapService: MapService,
@@ -30,18 +33,24 @@ export class UserListItemComponent {
     this.token = sessionService.getToken()
   }
 
+  ngOnChanges(): void {
+    if (!this.userWithLocation) return
+    this.user = this.userWithLocation.user
+    this.location = this.userWithLocation.location
+  }
+
   followUser(event): void {
     event.stopPropagation();
-    this.mapService.followFeatureInLayer(this.user, 'people')
+    this.mapService.followFeatureInLayer(this.userWithLocation, 'people')
   }
 
   onUserLocation(): void {
-    this.mapService.zoomToFeatureInLayer(this.user, 'people')
+    this.mapService.zoomToFeatureInLayer(this.userWithLocation, 'people')
   }
 
   viewUser(): void {
     this.onUserLocation()
-    this.feedPanelService.viewUser(this.user)
+    this.feedPanelService.viewUser(this.userWithLocation)
   }
 
   onRipple(): void {

--- a/web-app/src/app/user/user-list/user-list.component.html
+++ b/web-app/src/app/user/user-list/user-list.component.html
@@ -18,10 +18,10 @@
 
   <div class="page-container">
     <ng-container
-      *ngFor="let user of userPages[currentUserPage]; trackBy: trackByUserId">
+      *ngFor="let userWithLocation of userPages[currentUserPage]; trackBy: trackByUserId">
       <div class="feed-user">
         <user-list-item
-          [user]="user"
+          [userWithLocation]="userWithLocation"
           followable="true"
           [follow]="followUserId"></user-list-item>
       </div>

--- a/web-app/src/app/user/user-list/user-list.component.ts
+++ b/web-app/src/app/user/user-list/user-list.component.ts
@@ -39,8 +39,8 @@ export class UserListComponent implements OnInit, OnDestroy {
     return index
   }
 
-  trackByUserId(index: number, user: any): any {
-    return user.id
+  trackByUserId(index: number, userWithLocation: any): any {
+    return userWithLocation.id
   }
 
   onFilterChanged(): void {
@@ -50,19 +50,19 @@ export class UserListComponent implements OnInit, OnDestroy {
   onUsersChanged(changed): void {
     const { added = [], updated = [], removed = [] } = changed
 
-    added.forEach(user => {
-      this.usersById[user.id] = user;
+    added.forEach(userWithLocation => {
+      this.usersById[userWithLocation.id] = userWithLocation;
     })
 
-    updated.forEach(user => {
-      const updatedUser = this.usersById[user.id];
-      if (updatedUser) {
-        this.usersById[updatedUser.id] = user
+    updated.forEach(userWithLocation => {
+      const existing = this.usersById[userWithLocation.id];
+      if (existing) {
+        this.usersById[existing.id] = userWithLocation
       }
     })
 
-    removed.forEach(user => {
-      delete this.usersById[user.id];
+    removed.forEach(userWithLocation => {
+      delete this.usersById[userWithLocation.id];
     })
 
     // update the news feed observations


### PR DESCRIPTION
The feed's location query populated users with a field projection that excluded `avatar`, so `avatarUrl` was never computed for feed users even though it worked for the profile page's full user fetch.

The feed's list-item component also received the raw {id, location, user} location-feature wrapper and passed it directly to <user-avatar> instead of the nested actual user, so avatarUrl/id were looked up on the wrong object. Renamed the wrapper input to `userWithLocation` and unwrap it once into `user`/`location` fields, matching the pattern already used correctly in user-popup.component.