### PR TITLE
fix(service): make bearer auth stateless and remove unneeded sessions

### DIFF
--- a/service/src/app.ts
+++ b/service/src/app.ts
@@ -840,7 +840,7 @@ async function initWebLayer(
     };
   };
 
-  const bearerAuthentication = webAuth.passport.authenticate('bearer');
+  const bearerAuthentication = webAuth.bearerAuthentication;
 
   // Attempts bearer authentication but never rejects the request - if a valid
   // token is present req.user is populated, otherwise req.user is set to an
@@ -906,36 +906,10 @@ async function initWebLayer(
   );
   webController.use('/api/events', [bearerAuthentication, eventFeedsRoutes]);
 
-  const uiPluginsAccessTokenToAuthHeader: express.RequestHandler = (
-    req,
-    _res,
-    next
-  ): void => {
-    const token =
-      typeof req.query.access_token === 'string'
-        ? req.query.access_token
-        : null;
-
-    if (token && !req.headers.authorization) {
-      req.headers.authorization = `Bearer ${token}`;
-    }
-
-    next();
-  };
-
   const webUiPluginRoutes = WebUIPluginRoutes(webUIPlugins);
 
-  const uiPluginsAuth: express.RequestHandler = (req, res, next): void => {
-    if (req.user) {
-      next();
-      return;
-    }
-    bearerAuthentication(req, res, next);
-  };
-
   webController.use('/ui_plugins', [
-    uiPluginsAccessTokenToAuthHeader,
-    uiPluginsAuth,
+    bearerAuthentication,
     webUiPluginRoutes
   ]);
 

--- a/service/src/authentication/index.d.ts
+++ b/service/src/authentication/index.d.ts
@@ -9,6 +9,7 @@ declare namespace AuthenticationInitializer {
 
   export interface AuthLayer {
     passport: passport.PassportStatic
+    bearerAuthentication: express.RequestHandler
   }
 }
 

--- a/service/src/authentication/index.js
+++ b/service/src/authentication/index.js
@@ -151,7 +151,8 @@ class AuthenticationInitializer {
     require('./anonymous').initialize();
 
     return {
-      passport: passport
+      passport: passport,
+      bearerAuthentication: passport.authenticate('bearer', { session: false })
     };
   }
 }

--- a/service/src/authentication/oauth.js
+++ b/service/src/authentication/oauth.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const OAuth2Strategy = require('passport-oauth2').Strategy
+const crypto = require('crypto')
+   , session = require('express-session')
+   , OAuth2Strategy = require('passport-oauth2').Strategy
    , TokenAssertion = require('./verification').TokenAssertion
    , base64 = require('base-64')
    , api = require('../api')
@@ -8,6 +10,13 @@ const OAuth2Strategy = require('passport-oauth2').Strategy
    , User = require('../models/user')
    , Role = require('../models/role')
    , { app, passport, tokenService } = require('./index');
+
+// OAuth2 is the only authentication strategy that needs a session: passport-oauth2's
+// CSRF `state` store (enabled via `store: true` below) and our own origin stash both
+// require req.session. Scope it to just these two routes so no other request in the
+// app (bearer-authenticated API calls, SAML, OIDC, static assets, etc.) carries or
+// depends on a session cookie.
+const oauthSession = session({ secret: crypto.randomBytes(64).toString('hex') });
 
 class OAuth2ProfileStrategy extends OAuth2Strategy {
    constructor(options, verify) {
@@ -187,6 +196,7 @@ function initialize(strategy) {
    }
 
    app.get(`/auth/${strategy.name}/signin`,
+      oauthSession,
       function (req, res, next) {
          passport.authenticate(strategy.name, {
             scope: strategy.settings.scope,
@@ -196,6 +206,7 @@ function initialize(strategy) {
    );
 
    app.get(`/auth/${strategy.name}/callback`,
+      oauthSession,
       authenticate,
       function (req, res) {
          if (req.query.state === 'mobile') {

--- a/service/src/authentication/oauth.js
+++ b/service/src/authentication/oauth.js
@@ -11,11 +11,6 @@ const crypto = require('crypto')
    , Role = require('../models/role')
    , { app, passport, tokenService } = require('./index');
 
-// OAuth2 is the only authentication strategy that needs a session: passport-oauth2's
-// CSRF `state` store (enabled via `store: true` below) and our own origin stash both
-// require req.session. Scope it to just these two routes so no other request in the
-// app (bearer-authenticated API calls, SAML, OIDC, static assets, etc.) carries or
-// depends on a session cookie.
 const oauthSession = session({ secret: crypto.randomBytes(64).toString('hex') });
 
 class OAuth2ProfileStrategy extends OAuth2Strategy {
@@ -157,10 +152,6 @@ function setDefaults(strategy) {
 function initialize(strategy) {
    setDefaults(strategy);
 
-   // TODO lets test with newer geoaxis server to see if this is still needed
-   // If it is, this should be a admin client side option, would also need to modify the
-   // renderer to provide a more generic message
-   strategy.redirect = false;
    configure(strategy);
 
    function authenticate(req, res, next) {
@@ -217,11 +208,7 @@ function initialize(strategy) {
                uri = `mage://app/authentication?token=${req.token}`
             }
 
-            if (strategy.redirect) {
-               res.redirect(uri);
-            } else {
-               res.render('oauth', { uri: uri });
-            }
+            res.render('oauth', { uri: uri });
          } else {
             res.render('authentication', { host: req.getRoot(), success: true, login: { token: req.token, user: req.user } });
          }

--- a/service/src/authentication/openidconnect.js
+++ b/service/src/authentication/openidconnect.js
@@ -1,10 +1,14 @@
-const OpenIdConnectStrategy = require('passport-openidconnect').Strategy
+const crypto = require('crypto')
+  , session = require('express-session')
+  , OpenIdConnectStrategy = require('passport-openidconnect').Strategy
   , log = require('winston')
   , User = require('../models/user')
   , Role = require('../models/role')
   , TokenAssertion = require('./verification').TokenAssertion
   , api = require('../api')
   , { app, passport, tokenService } = require('./index');
+
+const oidcSession = session({ secret: crypto.randomBytes(64).toString('hex') });
 
 function configure(strategy) {
   log.info(`Configuring ${strategy.title} authentication`);
@@ -106,6 +110,7 @@ function configure(strategy) {
   }
 
   app.get(`/auth/${strategy.name}/callback`,
+    oidcSession,
     authenticate,
     function (req, res) {
       if (req.query.state === 'mobile') {
@@ -153,6 +158,7 @@ function initialize(strategy) {
   setDefaults(strategy);
 
   app.get(`/auth/${strategy.name}/signin`,
+    oidcSession,
     function (req, res, next) {
       passport.authenticate(strategy.name, {
         scope: strategy.settings.scope,

--- a/service/src/authentication/saml.js
+++ b/service/src/authentication/saml.js
@@ -145,21 +145,15 @@ function configure(strategy) {
         return next();
       }
 
-      // DEPRECATED session authorization, remove req.login which creates session in next version
-      req.login(user, function (err) {
-        if (err) {
-          return next(err);
-        }
-        AuthenticationInitializer.tokenService.generateToken(user._id.toString(), TokenAssertion.Authorized, 60 * 5)
-          .then(token => {
-            req.token = token;
-            req.user = user;
-            req.info = info
-            next();
-          }).catch(err => {
-            next(err);
-          });
-      });
+      AuthenticationInitializer.tokenService.generateToken(user._id.toString(), TokenAssertion.Authorized, 60 * 5)
+        .then(token => {
+          req.token = token;
+          req.user = user;
+          req.info = info
+          next();
+        }).catch(err => {
+          next(err);
+        });
     })(req, res, next);
   }
 

--- a/service/src/express.ts
+++ b/service/src/express.ts
@@ -1,8 +1,6 @@
-import crypto from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import express from 'express'
-import session from 'express-session'
 import passport from 'passport'
 import yaml from 'yaml'
 import { httpRequestLogging } from './adapters/adapters.logging.http'
@@ -31,9 +29,6 @@ app.use(function(req, res, next) {
   return next();
 });
 
-const secret = crypto.randomBytes(64).toString('hex');
-app.use(session({ secret }));
-
 app.enable('trust proxy');
 
 app.set('views', path.join(__dirname, 'views'));
@@ -46,7 +41,6 @@ app.use(
 );
 
 app.use(passport.initialize());
-app.use(passport.session());
 
 app.use(httpRequestLogging(log.child({ component: 'http' }), env.httpRequestLogMethods));
 app.get('/api/docs/openapi.yaml', async function(req, res) {
@@ -58,17 +52,18 @@ app.get('/api/docs/openapi.yaml', async function(req, res) {
   });
 });
 app.use('/api/docs', express.static(path.join(__dirname, 'docs')));
-app.use(
-  '/private',
-  passport.authenticate('bearer'),
-  express.static(path.join(__dirname, 'private'))
-);
 
 // Configure authentication
 const auth = AuthenticationInitializer.initialize(
   app,
   passport,
   provision
+);
+
+app.use(
+  '/private',
+  auth.bearerAuthentication,
+  express.static(path.join(__dirname, 'private'))
 );
 
 // Configure routes

--- a/service/src/routes/authenticationconfigurations.js
+++ b/service/src/routes/authenticationconfigurations.js
@@ -11,7 +11,6 @@ const log = require('../logger')
 
 module.exports = function (app, security) {
 
-  const passport = security.authentication.passport;
   const blacklist = AuthenticationConfiguration.blacklist;
   const lock = new AsyncLock();
   const enabledKey = 'checkAuthEnabled';
@@ -34,7 +33,7 @@ module.exports = function (app, security) {
 
   app.get(
     '/api/authentication/configuration/',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_AUTH_CONFIG'),
     function (req, res, next) {
       const includeDisabled = req.query.includeDisabled === 'true' ? true :
@@ -69,7 +68,7 @@ module.exports = function (app, security) {
 
   app.get(
     '/api/authentication/configuration/count/:id',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_AUTH_CONFIG'),
     function (req, res, next) {
       Authentication.countAuthenticationsByAuthConfigId(req.params.id).then(cnt => {
@@ -84,7 +83,7 @@ module.exports = function (app, security) {
 
   app.put(
     '/api/authentication/configuration/:id',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('UPDATE_AUTH_CONFIG'),
     function (req, res, next) {
       const updatedConfig = {
@@ -168,7 +167,7 @@ module.exports = function (app, security) {
 
   app.post(
     '/api/authentication/configuration/',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('UPDATE_AUTH_CONFIG'),
     function (req, res, next) {
       const newConfig = {
@@ -247,7 +246,7 @@ module.exports = function (app, security) {
 
   app.delete(
     '/api/authentication/configuration/:id',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('UPDATE_AUTH_CONFIG'),
     function (req, res, next) {
 

--- a/service/src/routes/devices.js
+++ b/service/src/routes/devices.js
@@ -25,9 +25,8 @@ module.exports = function(app, security) {
         if (!user) {
           return next('route');
         }
-        req.login(user, function(err) {
-          next(err);
-        });
+        req.user = user;
+        next();
       })(req, res, next);
     },
     async function(req, res, next) {
@@ -64,7 +63,7 @@ module.exports = function(app, security) {
    */
   app.post(
     '/api/devices',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     resource.ensurePermission('CREATE_DEVICE'),
     resource.parseDeviceParams,
     resource.validateDeviceParams,
@@ -73,7 +72,7 @@ module.exports = function(app, security) {
 
   app.get(
     '/api/devices/count',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_DEVICE'),
     resource.count
   );
@@ -81,7 +80,7 @@ module.exports = function(app, security) {
   // get all devices
   app.get(
     '/api/devices',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_DEVICE'),
     resource.getDevices
   );
@@ -90,7 +89,7 @@ module.exports = function(app, security) {
   // TODO: check for READ_USER also
   app.get(
     '/api/devices/:id',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_DEVICE'),
     resource.getDevice
   );
@@ -98,7 +97,7 @@ module.exports = function(app, security) {
   // Update a device
   app.put(
     '/api/devices/:id',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('UPDATE_DEVICE'),
     resource.parseDeviceParams,
     resource.updateDevice
@@ -107,7 +106,7 @@ module.exports = function(app, security) {
   // Delete a device
   app.delete(
     '/api/devices/:id',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('DELETE_DEVICE'),
     resource.deleteDevice
   );

--- a/service/src/routes/events.ts
+++ b/service/src/routes/events.ts
@@ -176,7 +176,6 @@ function reduceStyle(style: any): LineStyle {
 
 function EventRoutes(app: express.Application, security: { authentication: authentication.AuthLayer }): void {
 
-  const passport = security.authentication.passport;
 
   /*
   TODO: this just sends whatever is in the body straight through the API level
@@ -186,7 +185,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
   */
   app.post(
     '/api/events',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize(MageEventPermission.CREATE_EVENT),
     function (req, res, next) {
       new api.Event().createEvent(req.body, req.user, function (err: any, event: MageEventDocument) {
@@ -200,7 +199,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     determineReadAccess,
     parseEventQueryParams,
     function (req, res, next) {
@@ -256,7 +255,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/count',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     determineReadAccess,
     function (req, res, next) {
       EventModel.count({ access: req.access }, function (err, count) {
@@ -269,7 +268,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:eventId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     determineReadAccess,
     parseEventQueryParams,
@@ -290,7 +289,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.put(
     '/api/events/:eventId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       new api.Event(req.event).updateEvent(req.body, {}, function (err: any, event: MageEventDocument) {
@@ -309,7 +308,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.delete(
     '/api/events/:eventId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.DELETE_EVENT, EventAccessType.Delete),
     function (req, res, next) {
       new api.Event(req.event).deleteEvent(function (err: any) {
@@ -321,7 +320,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.post(
     '/api/events/:eventId/forms',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     upload.single('form'),
     function (req, res, next) {
@@ -364,7 +363,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.post(
     '/api/events/:eventId/forms',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     parseForm,
     function (req, res, next) {
@@ -393,7 +392,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.put(
     '/api/events/:eventId/forms/:formId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     parseForm,
     function (req, res, next) {
@@ -417,7 +416,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
   // TODO: why not /api/events/:eventId/forms/:formId.zip?
   app.get(
     '/api/events/:eventId/:formId/form.zip',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     function (req, res, next) {
       new api.Form(req.event).export(parseInt(req.params.formId, 10), function (err: any, form: any) {
@@ -432,7 +431,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:eventId/form/icons.zip',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     function (req, res) {
       new api.Icon(req.event!._id).getZipPath(function (err: any, zipPath: string) {
@@ -450,7 +449,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
   // the eventId parameter is not even used.
   app.get(
     '/api/events/:eventId/form/icons*',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     function (req, res) {
       res.sendFile(api.Icon.defaultIconPath);
@@ -459,7 +458,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:eventId/icons/:formId.json',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     function (req, res, next) {
       new api.Icon(req.event!._id, req.params.formId).getIcons(function (err: any, icons: any) {
@@ -500,7 +499,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
   // TODO: should be PUT?
   app.post(
     '/api/events/:eventId/icons/:formId?/:primary?/:variant?',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     upload.single('icon'),
     function (req, res, next) {
@@ -516,7 +515,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
   // get icon
   app.get(
     '/api/events/:eventId/icons/:formId?/:primary?/:variant?',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     function (req, res, next) {
       new api.Icon(req.event!._id, req.params.formId, req.params.primary, req.params.variant).getIcon(function (err: any, icon: any) {
@@ -550,7 +549,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
   // Delete an icon
   app.delete(
     '/api/events/:eventId/icons/:formId?/:primary?/:variant?',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       new api.Icon(req.event!._id, req.params.formId, req.params.primary, req.params.variant).delete(function (err: any) {
@@ -563,7 +562,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.post(
     '/api/events/:eventId/layers',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       EventModel.addLayer(req.event!, req.body, function (err: any, event?: MageEventDocument) {
@@ -577,7 +576,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.delete(
     '/api/events/:eventId/layers/:id',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       EventModel.removeLayer(req.event!, { id: req.params.id }, function (err: any, event?: MageEventDocument) {
@@ -591,7 +590,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:eventId/users',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     determineReadAccess,
     function (req, res, next) {
@@ -607,7 +606,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.post(
     '/api/events/:eventId/teams',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       EventModel.addTeam(req.event!, req.body, function (err, event) {
@@ -628,7 +627,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.delete(
     '/api/events/:eventId/teams/:teamId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       EventModel.removeTeam(req.event!, req.team, function (err, event) {
@@ -649,7 +648,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.put(
     '/api/events/:eventId/acl/:targetUserId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       EventModel.updateUserInAcl(req.event!._id, req.params.targetUserId, req.body.role, function (err, event) {
@@ -663,7 +662,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.delete(
     '/api/events/:eventId/acl/:targetUserId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.UPDATE_EVENT, EventAccessType.Update),
     function (req, res, next) {
       EventModel.removeUserFromAcl(req.event!._id, req.params.targetUserId, function (err, event) {
@@ -677,7 +676,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:id/members',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     determineReadAccess,
     function (req, res, next) {
       const options = {
@@ -698,7 +697,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:id/nonMembers',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     determineReadAccess,
     function (req, res, next) {
       const options = {
@@ -731,7 +730,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:eventId/teams',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     function (req, res, next) {
       const options = teamQueryOptionsFromRequest(req)
@@ -751,7 +750,7 @@ function EventRoutes(app: express.Application, security: { authentication: authe
 
   app.get(
     '/api/events/:eventId/nonTeams',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     middlewareAuthorizeAccess(MageEventPermission.READ_EVENT_ALL, EventAccessType.Read),
     function (req, res, next) {
       const options = teamQueryOptionsFromRequest(req)

--- a/service/src/routes/exports.ts
+++ b/service/src/routes/exports.ts
@@ -25,7 +25,6 @@ type ExportRequest = express.Request & {
 
 const DefineExportsRoutes: MageRouteDefinitions = function (app, security) {
 
-  const passport = security.authentication.passport;
 
   async function authorizeEventAccess(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     if (access.userHasPermission(req.user, ObservationPermission.READ_OBSERVATION_ALL)) {
@@ -55,7 +54,7 @@ const DefineExportsRoutes: MageRouteDefinitions = function (app, security) {
   }
 
   app.post('/api/exports',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     parseQueryParams,
     getEvent,
     authorizeEventAccess,
@@ -82,7 +81,7 @@ const DefineExportsRoutes: MageRouteDefinitions = function (app, security) {
    * Get all exports
    */
   app.get('/api/exports',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize(ExportPermission.READ_EXPORT),
     function (req, res, next) {
       Export.getExports().then(results => {
@@ -96,7 +95,7 @@ const DefineExportsRoutes: MageRouteDefinitions = function (app, security) {
    * Get my exports
    */
   app.get('/api/exports/myself',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     function (req, res, next) {
       Export.getExportsByUserId(req.user._id, { populate: true }).then(exports => {
         const response = exportXform.transform(exports, { path: `${req.getRoot()}/api/exports` });
@@ -109,7 +108,7 @@ const DefineExportsRoutes: MageRouteDefinitions = function (app, security) {
   * Get a specific export
   */
   app.get('/api/exports/:exportId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     authorizeExportAccess(ExportPermission.READ_EXPORT),
     function (req, res) {
       const exportReq = req as ExportRequest
@@ -127,7 +126,7 @@ const DefineExportsRoutes: MageRouteDefinitions = function (app, security) {
    */
   // TODO should be able to delete your own export
   app.delete('/api/exports/:exportId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     authorizeExportAccess(ExportPermission.DELETE_EXPORT),
     function (req, res, next) {
       const exportId = req.params.exportId
@@ -150,7 +149,7 @@ const DefineExportsRoutes: MageRouteDefinitions = function (app, security) {
    * Retry a failed export
    */
   app.post('/api/exports/:exportId/retry',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     authorizeExportAccess(ExportPermission.READ_EXPORT),
     getExport,
     getEvent,

--- a/service/src/routes/imports.ts
+++ b/service/src/routes/imports.ts
@@ -10,6 +10,7 @@ import { KmlFeature, kml } from '../utilities/transformKML';
 interface SecurityConfig {
     authentication: {
         passport: any;
+        bearerAuthentication: any;
     };
 }
 interface LayerRequest extends Request {
@@ -101,11 +102,10 @@ const validate = async (req: Request, res: Response, next: NextFunction): Promis
 }
 
 function importRoutes(app: Express, security: SecurityConfig): void {
-    const passport = security.authentication.passport;
 
     app.post(
         '/api/layers/:layerId/kml',
-        passport.authenticate('bearer'),
+        security.authentication.bearerAuthentication,
         access.authorize('CREATE_LAYER' as AnyPermission),
         upload.single('file'),
         validate,

--- a/service/src/routes/layers.js
+++ b/service/src/routes/layers.js
@@ -12,8 +12,7 @@ module.exports = function (app, security) {
     { defaultHandler: upload } = require('../upload'),
     { defaultEventPermissionsService: eventPermissions } = require('../permissions/permissions.events');
 
-  const passport = security.authentication.passport;
-  app.all('/api/layers*', passport.authenticate('bearer'));
+  app.all('/api/layers*', security.authentication.bearerAuthentication);
 
   function validateLayerParams(req, res, next) {
     const layer = req.body;
@@ -210,7 +209,7 @@ module.exports = function (app, security) {
   });
 
   app.post('/api/events/:eventId/features',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     validateEventAccess,
     async function (req, res, next) {
       const clientLayers = req.body.layerIds;
@@ -301,7 +300,7 @@ module.exports = function (app, security) {
   );
 
   app.get('/api/events/:eventId/layers',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     validateEventAccess,
     parseQueryParams,
     function (req, res, next) {
@@ -365,7 +364,7 @@ module.exports = function (app, security) {
 
   // get layer
   app.get('/api/events/:eventId/layers/:layerId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     validateEventAccess,
     function (req, res) {
       if (req.accepts('application/json')) {
@@ -387,14 +386,14 @@ module.exports = function (app, security) {
   );
 
   app.get('/api/events/:eventId/layers/:layerId/:tableName/:z(\\d+)/:x(\\d+)/:y(\\d+).:format',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     validateEventAccess,
     handleGeoPackageXYZTileRequest
   );
 
   // get features for layer (must be a feature layer)
   app.get('/api/events/:eventId/layers/:layerId/features',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     validateEventAccess,
     function (req, res, next) {
       if (req.layer.type !== 'Feature') return res.status(400).send('cannot get features, layer type is not "Feature"');

--- a/service/src/routes/locations.js
+++ b/service/src/routes/locations.js
@@ -5,7 +5,6 @@ module.exports = function(app, security) {
   const access = require('../access');
   const { defaultEventPermissionsService: eventPermissions } = require('../permissions/permissions.events');
 
-  const passport = security.authentication.passport;
   const location = new Location();
 
   async function validateEventAccess(req, res, next) {
@@ -106,7 +105,7 @@ module.exports = function(app, security) {
   // max of 100 locations per user
   app.get(
     '/api/events/:eventId/locations/users',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     validateEventAccess,
     parseQueryParams,
     function(req, res) {
@@ -127,7 +126,7 @@ module.exports = function(app, security) {
   // Will only return locations for the teams that the user is a part of
   app.get(
     '/api/events/:eventId/locations',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     validateEventAccess,
     parseQueryParams,
     function(req, res) {
@@ -145,7 +144,7 @@ module.exports = function(app, security) {
   // create new location(s) for a specific user and event
   app.post(
     '/api/events/:eventId/locations',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('CREATE_LOCATION'),
     validateLocations,
     function(req, res, next) {

--- a/service/src/routes/logins.js
+++ b/service/src/routes/logins.js
@@ -1,10 +1,9 @@
 module.exports = function(app, security) {
   var access = require('../access')
     , moment = require('moment')
-    , Login = require('../models/login')
-    , passport = security.authentication.passport;
+    , Login = require('../models/login');
 
-  app.all('/api/logins*', passport.authenticate('bearer'));
+  app.all('/api/logins*', security.authentication.bearerAuthentication);
 
   function generateParameters(options) {
     var partial = "";

--- a/service/src/routes/observations.js
+++ b/service/src/routes/observations.js
@@ -16,7 +16,6 @@ module.exports = function (app, security) {
     geometryFormat = require("../format/geoJsonFormat"),
     observationXform = require("../transformers/observation"),
     FileType = require("file-type"),
-    passport = security.authentication.passport,
     {
       defaultEventPermissionsService: eventPermissions,
     } = require("../permissions/permissions.events");
@@ -305,7 +304,7 @@ module.exports = function (app, security) {
 
   app.get(
     "/api/events/:eventId/observations/(:observationId).zip",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     validateObservationReadAccess,
     getUserForObservation,
     getIconForObservation,
@@ -368,7 +367,7 @@ module.exports = function (app, security) {
 
   app.get(
     "/api/events/:eventId/observations/:observationIdInPath",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     validateObservationReadAccess,
     parseQueryParams,
     function (req, res, next) {
@@ -395,7 +394,7 @@ module.exports = function (app, security) {
 
   app.get(
     "/api/events/:eventId/observations",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     validateObservationReadAccess,
     parseQueryParams,
     function (req, res, next) {
@@ -420,7 +419,7 @@ module.exports = function (app, security) {
 
   app.put(
     "/api/events/:eventId/observations/:observationIdInPath/favorite",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     /*
     TODO: this is a strange permission check.  this is because the request
     modifies data, but there is a USER_NO_EDIT_ROLE role that has permission to
@@ -457,7 +456,7 @@ module.exports = function (app, security) {
 
   app.delete(
     "/api/events/:eventId/observations/:observationIdInPath/favorite",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     /* TODO: see above note on PUT favorite permission check */
     validateObservationCreateAccess(false),
     function (req, res, next) {
@@ -487,7 +486,7 @@ module.exports = function (app, security) {
 
   app.put(
     "/api/events/:eventId/observations/:observationId/important",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     authorizeEventAccess("UPDATE_EVENT", "update"),
     function (req, res, next) {
       const important = {
@@ -518,7 +517,7 @@ module.exports = function (app, security) {
 
   app.delete(
     "/api/events/:eventId/observations/:observationId/important",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     authorizeEventAccess("UPDATE_EVENT", "update"),
     function (req, res, next) {
       new api.Observation(req.event).removeImportant(
@@ -542,7 +541,7 @@ module.exports = function (app, security) {
 
   app.post(
     "/api/events/:eventId/observations/:observationId/states",
-    passport.authenticate("bearer"),
+    security.authentication.bearerAuthentication,
     authorizeDeleteAccess,
     function (req, res) {
       let state = req.body;

--- a/service/src/routes/plugins.js
+++ b/service/src/routes/plugins.js
@@ -1,12 +1,11 @@
 module.exports = function (app, security) {
   const fs = require('fs')
     , path = require('path')
-    , access = require('../access')
-    , passport = security.authentication.passport;
+    , access = require('../access');
 
   app.get(
     '/api/plugins',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_SETTINGS'), // TODO add new permission
     function (req, res, next) {
       console.log('get plugins');

--- a/service/src/routes/roles.js
+++ b/service/src/routes/roles.js
@@ -1,9 +1,8 @@
 module.exports = function(app, security) {
   var access = require('../access')
-    , Role = require('../models/role')
-    , passport = security.authentication.passport;
+    , Role = require('../models/role');
 
-  app.all('/api/roles*', passport.authenticate('bearer'));
+  app.all('/api/roles*', security.authentication.bearerAuthentication);
 
   function validateRoleParams(req, res, next) {
     var name = req.param('name');

--- a/service/src/routes/settings.js
+++ b/service/src/routes/settings.js
@@ -1,14 +1,13 @@
 module.exports = function(app, security) {
   const access = require('../access')
     , Setting = require('../models/setting')
-    , log = require('../logger').child({ component: 'settings' })
-    , passport = security.authentication.passport;
+    , log = require('../logger').child({ component: 'settings' });
 
-  app.all('/api/settings*', passport.authenticate('bearer'));
+  app.all('/api/settings*', security.authentication.bearerAuthentication);
 
   app.get(
     '/api/settings',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_SETTINGS'),
     function (req, res, next) {
       Setting.getSettings()
@@ -28,7 +27,7 @@ module.exports = function(app, security) {
 
   app.put(
     '/api/settings/:type(banner|disclaimer|contactinfo)',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('UPDATE_SETTINGS'),
     function(req, res, next) {
       Setting.getSetting(req.params.type)

--- a/service/src/routes/teams.js
+++ b/service/src/routes/teams.js
@@ -3,10 +3,9 @@ module.exports = function(app, security) {
     , UserModel = require('../models/user')
     , access = require('../access')
     , log = require('../logger').child({ component: 'teams' })
-    , pageinfoTransformer = require('../transformers/pageinfo')
-    , passport = security.authentication.passport;
+    , pageinfoTransformer = require('../transformers/pageinfo');
 
-  app.all('/api/teams*', passport.authenticate('bearer'));
+  app.all('/api/teams*', security.authentication.bearerAuthentication);
 
   function determineReadAccess(req, res, next) {
     if (!access.userHasPermission(req.user, 'READ_TEAM')) {

--- a/service/src/routes/users.js
+++ b/service/src/routes/users.js
@@ -332,7 +332,7 @@ module.exports = function(app, security) {
    */
   app.get(
     '/api/users',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_USER'),
     async function(req, res) {
       const limit = req.query.limit || null;
@@ -352,7 +352,7 @@ module.exports = function(app, security) {
 
   app.get(
     '/api/users/count',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_USER'),
     function(req, res, next) {
       var filter = {};
@@ -381,7 +381,7 @@ module.exports = function(app, security) {
   );
 
   // get info for the user bearing a token, i.e get info for myself
-  app.get('/api/users/myself', passport.authenticate('bearer'), function(
+  app.get('/api/users/myself', security.authentication.bearerAuthentication, function(
     req,
     res
   ) {
@@ -393,7 +393,7 @@ module.exports = function(app, security) {
   // update myself
   app.put(
     '/api/users/myself',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     upload.single('avatar'),
     function(req, res, next) {
       if (req.param('username')) req.user.username = req.param('username');
@@ -458,7 +458,7 @@ module.exports = function(app, security) {
   );
 
   // update status for myself
-  app.put('/api/users/myself/status', passport.authenticate('bearer'), function(
+  app.put('/api/users/myself/status', security.authentication.bearerAuthentication, function(
     req,
     res
   ) {
@@ -478,7 +478,7 @@ module.exports = function(app, security) {
   // remove status for myself
   app.delete(
     '/api/users/myself/status',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     function(req, res) {
       req.user.status = undefined;
       new api.User().update(req.user, function(err, updatedUser) {
@@ -493,7 +493,7 @@ module.exports = function(app, security) {
   // get user by id
   app.get(
     '/api/users/:userId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_USER'),
     function(req, res) {
       var user = userTransformer.transform(req.userParam, {
@@ -506,7 +506,7 @@ module.exports = function(app, security) {
   // Update a specific user
   app.put(
     '/api/users/:userId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('UPDATE_USER'),
     upload.fields([{ name: 'avatar' }, { name: 'icon' }]),
     parseIconUpload,
@@ -603,7 +603,7 @@ module.exports = function(app, security) {
   // TODO this needs to be update to use the UPDATE_USER_PASSWORD permission when Android is updated to handle that permission
   app.put(
     '/api/users/:userId/password',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('UPDATE_USER_ROLE'),
     function(req, res, next) {
       const user = req.userParam;
@@ -639,7 +639,7 @@ module.exports = function(app, security) {
   // Delete a specific user
   app.delete(
     '/api/users/:userId',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('DELETE_USER'),
     function(req, res, next) {
       const user = req.userParam;
@@ -661,7 +661,7 @@ module.exports = function(app, security) {
   // get user avatar/icon by id
   app.get(
     '/api/users/:userId/:content(avatar|icon)',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     access.authorize('READ_USER'),
     function(req, res, next) {
       new api.User()[req.params.content](req.userParam, function(err, content) {
@@ -684,7 +684,7 @@ module.exports = function(app, security) {
 
   app.post(
     '/api/users/:userId/events/:eventId/recent',
-    passport.authenticate('bearer'),
+    security.authentication.bearerAuthentication,
     async function(req, res, next) {
       if (access.userHasPermission(req.user, 'UPDATE_EVENT')) {
         return next();

--- a/service/src/routes/users.js
+++ b/service/src/routes/users.js
@@ -427,7 +427,7 @@ module.exports = function(app, security) {
 
   app.put(
     '/api/users/myself/password',
-    passport.authenticate('local'),
+    passport.authenticate('local', { session: false }),
     function(req, res, next) {
       if (req.user.authentication.type !== 'local') {
         return res.sendStatus(404);


### PR DESCRIPTION
MAGE's authenticated API/token traffic was accidentally relying on express-session everywhere: passport.authenticate('bearer') defaults to session:true unless told otherwise, so every bearer-authenticated request across ~80 call sites was silently establishing/regenerating a session cookie. Combined with global session middleware and in-memory MemoryStore, concurrent requests could race each other's session state, intermittently leaving req.user unpopulated on requests that otherwise carried a valid token (observed as intermittent 400s loading /ui_plugins/* assets).

- Scope express-session to only the OAuth2 SSO signin/callback routes (oauth.js), the one flow that legitimately needs it (passport-oauth2's CSRF state store and our origin stash both require req.session). Remove the global session()/passport.session() middleware.
- Remove SAML's and the deprecated /api/devices local-auth route's req.login() calls, which established sessions no code depended on.
- Add { session: false } to every passport.authenticate('bearer') call, and centralize it as a single security.authentication.bearerAuthentication middleware (added to AuthenticationInitializer's returned auth layer) instead of each route file constructing its own.
- Simplify /ui_plugins auth: drop the custom access-token-to-header copy and req.user pre-check, since passport-http-bearer already reads access_token from the query string natively; the old code was manufacturing a token-in-two-places state that passport-http-bearer's own CSRF guard then rejected with 400.