### PR TITLE
feat: add per-field recent-choice preferences for dropdowns

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ngageoint/mage.service",
   "version": "6.7.0",
-  "apiVersion": "6.6.0",
+  "apiVersion": "6.7.0",
   "displayName": "Mage Service",
   "description": "Mage is a geospatial situational awareness and data collection platform.  The Mage Service is the ReST service API that the Mage client apps use to interact with Mage data.",
   "keywords": [

--- a/service/src/adapters/preferences/adapters.preferences.controllers.web.ts
+++ b/service/src/adapters/preferences/adapters.preferences.controllers.web.ts
@@ -1,0 +1,36 @@
+import express from 'express'
+import { compatibilityMageAppErrorHandler, WebAppRequestFactory } from '../adapters.controllers.web'
+import { GetEventPreferences, GetEventPreferencesRequest } from '../../app.api/preferences/app.api.preferences'
+import { invalidInput } from '../../app.api/app.api.errors'
+import { UserWithRole } from '../../permissions/permissions.role-based.base'
+import { AppRequest } from '../../app.api/app.api.global'
+
+export interface UserPreferencesAppLayer {
+  getEventPreferences: GetEventPreferences
+}
+
+export function UserPreferencesRoutes(
+  app: UserPreferencesAppLayer,
+  createAppRequest: WebAppRequestFactory<AppRequest<UserWithRole>>
+) {
+  const routes = express.Router()
+  routes.use(express.json())
+
+  routes.route('/events/:eventId')
+    .get(async (req, res, next) => {
+      const eventId = req.params.eventId
+
+      if (!eventId || isNaN(Number(eventId))) {
+        return next(invalidInput('Event id must be a number.', [ 'eventId' ]))
+      }
+
+      const appReq: GetEventPreferencesRequest = createAppRequest(req, { eventId: Number(eventId) })
+      const appRes = await app.getEventPreferences(appReq)
+      if (appRes.success) {
+        return res.json(appRes.success)
+      }
+      next(appRes.error)
+  })
+
+  return routes.use(compatibilityMageAppErrorHandler)
+}

--- a/service/src/adapters/preferences/adapters.preferences.db.mongoose.ts
+++ b/service/src/adapters/preferences/adapters.preferences.db.mongoose.ts
@@ -1,0 +1,89 @@
+import { BaseMongooseRepository } from '../base/adapters.base.db.mongoose'
+import { AddRecentFormFieldChoiceEntry, EventPreference, RecentChoice, UserId, UserPreference, UserPreferenceRepository } from '../../entities/users/entities.users'
+import mongoose from 'mongoose'
+import { MageEventId } from '../../entities/events/entities.events'
+
+export type UserPreferenceDocument = UserPreference & mongoose.Document
+export type UserPreferenceModel = mongoose.Model<UserPreferenceDocument>
+export const UserPreferencesModelName = 'UserPreference'
+
+export const UserPreferenceSchema = new mongoose.Schema<any>({
+  _id: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  events: {
+    type: Map,
+    of: {
+      forms: {
+        type: Map,
+        of: {
+          fields: {
+            type: Map,
+            of: {
+              recentChoices: [String]
+            }
+          }
+        }
+      }
+    },
+    default: {}
+  }
+},{
+  _id: false,
+  versionKey: false
+})
+
+export function UserPreferenceModel(conn: mongoose.Connection, collection?: string): UserPreferenceModel {
+  return conn.model(UserPreferencesModelName, UserPreferenceSchema, collection || 'user_preferences') as any
+}
+
+export class MongoosePreferenceRepository extends BaseMongooseRepository<UserPreferenceDocument, UserPreferenceModel, UserPreference> implements UserPreferenceRepository {
+  constructor(model: mongoose.Model<UserPreferenceDocument>) {
+    super(model, {
+      docToEntity: doc => {
+        const json = doc.toJSON<UserPreference>()
+        return {
+          ...json,
+          id: doc._id
+        }
+      }
+    })
+  }
+
+  async getPreferences(userId: UserId): Promise<UserPreference | null> {
+    const doc = await this.model.findById(userId)
+    if (!doc) {
+      return null
+    }
+
+    return this.entityForDocument(doc)
+  }
+
+  async getEventPreferences(userId: UserId, eventId: MageEventId): Promise<EventPreference | null> {
+    const preferences = await this.getPreferences(userId)
+    return preferences?.events[eventId] ?? null
+  }
+
+  async addRecentFormFieldChoices(userId: UserId, choices: AddRecentFormFieldChoiceEntry[]): Promise<UserPreference> {
+    const preferences = await this.getPreferences(userId)
+    const recentChoicesByPath = choices.reduce((byPath, entry) => {
+      const { eventId, formId, fieldName, choice } = entry
+      const path = `events.${eventId}.forms.${formId}.fields.${fieldName}.recentChoices`
+      const currentChoices = byPath[path] ?? preferences?.events?.[eventId]?.forms?.[formId]?.fields?.[fieldName]?.recentChoices ?? []
+      const uniqueChoices = currentChoices.filter((currentChoice) => currentChoice !== choice)
+      byPath[path] = [choice, ...uniqueChoices].slice(0, entry.recentChoicesLimit || 5)
+      return byPath
+    }, {} as Record<string, RecentChoice[]>)
+
+    const doc = await this.model.findByIdAndUpdate(userId, {
+      $set: recentChoicesByPath
+    },{
+      upsert: true,
+      new: true
+    })
+
+    return this.entityForDocument(doc)
+  }
+}

--- a/service/src/app.api/preferences/app.api.preferences.ts
+++ b/service/src/app.api/preferences/app.api.preferences.ts
@@ -1,0 +1,18 @@
+import { EventPreference } from '../../entities/users/entities.users'
+import { UserWithRole } from '../../permissions/permissions.role-based.base'
+import { EntityNotFoundError, InvalidInputError, PermissionDeniedError } from '../app.api.errors'
+import { AppRequest, AppRequestContext, AppResponse } from '../app.api.global'
+
+export interface UserPreferencesRequest<Principal = UserWithRole> extends AppRequest<Principal, AppRequestContext<Principal>> {}
+
+export type GetEventPreferencesRequest = UserPreferencesRequest & {
+  eventId: number
+}
+
+export interface GetEventPreferences {
+  (req: GetEventPreferencesRequest): Promise<AppResponse<EventPreference, PermissionDeniedError | InvalidInputError | EntityNotFoundError>>
+}
+
+export interface UserPreferencePermissionService {
+  ensureGetEventPreferencePermission(context: AppRequestContext): Promise<null | PermissionDeniedError>
+}

--- a/service/src/app.impl/observations/app.impl.observations.ts
+++ b/service/src/app.impl/observations/app.impl.observations.ts
@@ -4,8 +4,9 @@ import { AppResponse } from '../../app.api/app.api.global'
 import * as api from '../../app.api/observations/app.api.observations'
 import { MageEvent } from '../../entities/events/entities.events'
 import { FormFieldType } from '../../entities/events/entities.events.forms'
-import { addAttachment, AttachmentCreateAttrs, AttachmentNotFoundError, AttachmentsRemovedDomainEvent, AttachmentStore, AttachmentStoreError, AttachmentStoreErrorCode, FormEntry, FormEntryId, FormFieldEntry, Observation, ObservationAttrs, ObservationDomainEventType, ObservationEmitted, ObservationRepositoryErrorCode, removeAttachment, thumbnailIndexForTargetDimension, validationResultMessage } from '../../entities/observations/entities.observations'
-import { UserId, UserRepository } from '../../entities/users/entities.users'
+import { addAttachment, AttachmentCreateAttrs, AttachmentNotFoundError, AttachmentsRemovedDomainEvent, AttachmentStore, AttachmentStoreError, AttachmentStoreErrorCode, FormEntry, FormEntryId, FormFieldEntry, Observation, ObservationAttrs, ObservationDomainEventType, ObservationEmitted, ObservationRepositoryErrorCode, ObservationSavedDomainEvent, removeAttachment, thumbnailIndexForTargetDimension, validationResultMessage } from '../../entities/observations/entities.observations'
+import { AddRecentFormFieldChoiceEntry, UserId, UserPreferenceRepository, UserRepository } from '../../entities/users/entities.users'
+import { Logger, NoopLogger } from '../../entities/entities.logging'
 
 export function AllocateObservationId(permissionService: api.ObservationPermissionService): api.AllocateObservationId {
   return async function allocateObservationId(req: api.AllocateObservationIdRequest): ReturnType<api.AllocateObservationId> {
@@ -143,15 +144,61 @@ export function ReadAttachmentContent(permissionService: api.ObservationPermissi
   }
 }
 
-export function registerDeleteRemovedAttachmentsHandler(domainEvents: EventEmitter, attachmentStore: AttachmentStore): void {
+export function registerDeleteRemovedAttachmentsHandler(domainEvents: EventEmitter, attachmentStore: AttachmentStore, log: Logger = NoopLogger): void {
   domainEvents.on(ObservationDomainEventType.AttachmentsRemoved, (e: ObservationEmitted<AttachmentsRemovedDomainEvent>) => {
     setTimeout(async () => {
       const attachments = e.removedAttachments
       for (const att of attachments) {
-        console.info(`deleting removed attachment content ${att.id} from observation ${e.observation.id}`)
+        log.info(`deleting removed attachment content ${att.id} from observation ${e.observation.id}`)
         attachmentStore.deleteContent(att, e.observation).catch(err => {
-          console.error(`error deleting content of attachment ${att.id} on observation ${e.observation.id}:`, err)
+          log.error(`error deleting content of attachment ${att.id} on observation ${e.observation.id}:`, err)
         })
+      }
+    })
+  })
+}
+
+/**
+ * This re-scans and re-records every current dropdown/multiselect value on
+ * the observation each time `ObservationSaved` fires, rather than only
+ * fields that actually changed in this save.  Diffing would mean threading
+ * the prior field values through the event; recomputing from the saved
+ * observation is simpler and, since writes are idempotent, harmless -- just
+ * some wasted work on saves that didn't touch a dropdown.
+ */
+export function registerRecordRecentFormFieldChoicesHandler(domainEvents: EventEmitter, userPreferenceRepository: UserPreferenceRepository, log: Logger = NoopLogger): void {
+  domainEvents.on(ObservationDomainEventType.ObservationSaved, (e: ObservationEmitted<ObservationSavedDomainEvent>) => {
+    const userId = e.userId
+    if (!userId) {
+      return
+    }
+    setTimeout(async () => {
+      const observation = e.observation
+      const entries: AddRecentFormFieldChoiceEntry[] = observation.formEntries.flatMap((formEntry) => {
+        const formFields = observation.mageEvent.activeFieldsForForm(formEntry.formId) || []
+        return formFields
+          .filter((field) => field.type === FormFieldType.Dropdown || field.type === FormFieldType.MultiSelectDropdown)
+          .flatMap((field) => {
+            const value = formEntry[field.name]
+            const choices = Array.isArray(value) ? value : [value]
+            return choices
+              .filter((choice) => choice != null && choice !== '')
+              .map((choice) => ({
+                eventId: observation.eventId,
+                formId: formEntry.formId,
+                fieldName: field.name,
+                choice: String(choice),
+                recentChoicesLimit: field.maxRecent
+              }))
+          })
+      })
+
+      if (entries.length) {
+        try {
+          await userPreferenceRepository.addRecentFormFieldChoices(userId, entries)
+        } catch (err) {
+          log.error(`error recording recent form field choices on observation ${observation.id}:`, err)
+        }
       }
     })
   })
@@ -199,9 +246,8 @@ async function prepareObservationMod(mod: api.ExoObservationMod, observationToUp
   if (afterRemovedFormEntryAttachments) {
     modAttrs.attachments = afterRemovedFormEntryAttachments.attachments
   }
-  const afterFormEntriesRemoved = afterRemovedFormEntryAttachments ?
-    Observation.assignTo(afterRemovedFormEntryAttachments, modAttrs) as Observation :
-    Observation.evaluate(modAttrs, event)
+  const beforeFormEntriesRemoved = afterRemovedFormEntryAttachments || Observation.evaluate(modAttrs, event)
+  const afterFormEntriesRemoved = Observation.assignTo(beforeFormEntriesRemoved, modAttrs, context.userId) as Observation
   const afterAttachmentMods = attachmentMods.reduce<Observation | InvalidInputError>((obs, attachmentMod) => {
     if (obs instanceof MageError) {
       return obs

--- a/service/src/app.impl/preferences/app.impl.preferences.ts
+++ b/service/src/app.impl/preferences/app.impl.preferences.ts
@@ -1,0 +1,25 @@
+import * as api from '../../app.api/preferences/app.api.preferences'
+import { withPermission, KnownErrorsOf } from '../../app.api/app.api.global'
+import { EventPreference, UserPreferenceRepository } from '../../entities/users/entities.users'
+import { entityNotFound } from '../../app.api/app.api.errors'
+
+export function GetEventPreferences(
+  userPreferenceRepository: UserPreferenceRepository,
+  permissions: api.UserPreferencePermissionService
+): api.GetEventPreferences {
+  return async function getEventPreferences(req: api.GetEventPreferencesRequest): ReturnType<api.GetEventPreferences> {
+    return await withPermission<EventPreference, KnownErrorsOf<api.GetEventPreferences>>(
+      permissions.ensureGetEventPreferencePermission(req.context),
+      async () => {
+        const user = req.context.requestingPrincipal()
+        const eventPreference = await userPreferenceRepository.getEventPreferences(user.id, req.eventId)
+
+        if (!eventPreference) {
+          return entityNotFound(req.eventId, 'Event Preference')
+        }
+
+        return eventPreference
+      }
+    )
+  }
+}

--- a/service/src/app.ts
+++ b/service/src/app.ts
@@ -99,7 +99,11 @@ import {
   UsersRoutes
 } from './adapters/users/adapters.users.controllers.web';
 import { SearchUsers } from './app.impl/users/app.impl.users';
-import { RoleBasedUsersPermissionService } from './permissions/permissions.users';
+import { RoleBasedUsersPermissionService, RoleBasedUserPreferencesPermissionService } from './permissions/permissions.users';
+import { UserPreferencesAppLayer, UserPreferencesRoutes } from './adapters/preferences/adapters.preferences.controllers.web';
+import { GetEventPreferences } from './app.impl/preferences/app.impl.preferences';
+import { UserPreferenceRepository } from './entities/users/entities.users';
+import { MongoosePreferenceRepository, UserPreferenceModel } from './adapters/preferences/adapters.preferences.db.mongoose';
 import { MongoosePluginStateRepository } from './adapters/plugins/adapters.plugins.db.mongoose';
 import path from 'path';
 import { MageEventDocument } from './models/event';
@@ -375,6 +379,7 @@ type DatabaseLayer = {
   };
   users: {
     user: UserModel;
+    preference: UserPreferenceModel;
   };
   observations: {
     icons: ObservationIconModel;
@@ -421,6 +426,7 @@ type AppLayer = {
   exports: ExportAppLayer;
   icons: StaticIconsAppLayer;
   users: UsersAppLayer;
+  userPreferences: UserPreferencesAppLayer;
   systemInfo: SystemInfoAppLayer;
   settings: SettingsAppLayer;
 };
@@ -504,7 +510,8 @@ async function initDatabase(): Promise<DatabaseLayer> {
       staticIcon: StaticIconModel(conn)
     },
     users: {
-      user: userModel
+      user: userModel,
+      preference: UserPreferenceModel(conn)
     },
     observations: {
       icons: ObservationIconModel(conn)
@@ -545,6 +552,7 @@ type Repositories = {
   };
   users: {
     userRepo: UserRepository;
+    preferenceRepo: UserPreferenceRepository;
     iconStore: UserIconContentStore;
   };
   locations: {
@@ -615,6 +623,9 @@ async function initRepositories(
   const locationRepo = new MongooseUserLocationRepository(
     models.locations.location
   );
+  const userPreferenceRepo = new MongoosePreferenceRepository(
+    models.users.preference
+  );
   const settingRepo = new MongooseSettingsRepository(models.settings.setting);
   const attachmentStore = await intializeAttachmentStore(
     environment.attachmentBaseDirectory
@@ -655,6 +666,7 @@ async function initRepositories(
     },
     users: {
       userRepo,
+      preferenceRepo: userPreferenceRepo,
       iconStore: userIconStore
     },
     locations: {
@@ -674,6 +686,7 @@ async function initAppLayer(repos: Repositories): Promise<AppLayer> {
   const icons = await initIconsAppLayer(repos);
   const feeds = await initFeedsAppLayer(repos);
   const users = await initUsersAppLayer(repos);
+  const userPreferences = initUserPreferencesAppLayer(repos);
   const systemInfo = initSystemInfoAppLayer(repos);
   const settings = await initSettingsAppLayer(
     repos,
@@ -687,6 +700,7 @@ async function initAppLayer(repos: Repositories): Promise<AppLayer> {
     feeds,
     icons,
     users,
+    userPreferences,
     systemInfo,
     settings
   };
@@ -782,6 +796,16 @@ async function initUsersAppLayer(
   };
 }
 
+function initUserPreferencesAppLayer(repos: Repositories): UserPreferencesAppLayer {
+  const permissions = new RoleBasedUserPreferencesPermissionService();
+  return {
+    getEventPreferences: GetEventPreferences(
+      repos.users.preferenceRepo,
+      permissions
+    )
+  };
+}
+
 async function initEventsAppLayer(
   repos: Repositories
 ): Promise<AppLayer['events']> {
@@ -827,7 +851,14 @@ async function initObservationsAppLayer(
 
   observationsImpl.registerDeleteRemovedAttachmentsHandler(
     DomainEvents,
-    repos.observations.attachmentStore
+    repos.observations.attachmentStore,
+    log.child({ component: 'observations' })
+  );
+
+  observationsImpl.registerRecordRecentFormFieldChoicesHandler(
+    DomainEvents,
+    repos.users.preferenceRepo,
+    log.child({ component: 'observations' })
   );
 
   return {
@@ -1111,6 +1142,9 @@ async function initWebLayer(
 
   const myExportRoutes = MyExportRoutes(app.exports, appRequestFactory);
   webController.use(`/api/exports/mine`, [bearerAuthentication, myExportRoutes]);
+
+  const preferencesRoutes = UserPreferencesRoutes(app.userPreferences, appRequestFactory);
+  webController.use(`/api/my/preferences`, [bearerAuthentication, preferencesRoutes]);
 
   const uiPluginsAccessTokenToAuthHeader: express.RequestHandler = (
     req,

--- a/service/src/entities/events/entities.events.forms.ts
+++ b/service/src/entities/events/entities.events.forms.ts
@@ -101,6 +101,7 @@ export function copyFormFieldAttrs(x: FormField): FormField {
     max: x.max,
     value: x.value,
     choices: x.choices?.map(copyFormFieldChoiceAttrs),
+    maxRecent: x.maxRecent,
     allowedAttachmentTypes: x.allowedAttachmentTypes ? [...x.allowedAttachmentTypes] : undefined
   }
 }
@@ -146,6 +147,7 @@ export interface FormField {
   required: boolean,
   value?: any,
   choices?: FormFieldChoice[],
+  maxRecent?: number,
   /**
    * The absence of any media type constraints indicates the field allows any
    * file type as an attachment.

--- a/service/src/entities/observations/entities.observations.ts
+++ b/service/src/entities/observations/entities.observations.ts
@@ -275,7 +275,7 @@ export class Observation implements Readonly<ObservationAttrs> {
    * @param update
    * @returns
    */
-  static assignTo(target: Observation, update: ObservationAttrs): Observation | ObservationUpdateError {
+  static assignTo(target: Observation, update: ObservationAttrs, userId?: UserId): Observation | ObservationUpdateError {
     if (update.eventId !== target.eventId) {
       return ObservationUpdateError.eventIdMismatch(target.eventId, update.eventId)
     }
@@ -289,7 +289,10 @@ export class Observation implements Readonly<ObservationAttrs> {
     }, new Map<AttachmentId, Attachment>())
     const removedAttachments = target.attachments.filter(x => !updateAttachments.has(x.id))
     // TODO: whatever other mods generate events that matter
-    const updateEvents = removedAttachments.length ? [AttachmentsRemovedDomainEvent(target, removedAttachments)] : [] as PendingObservationDomainEvent[]
+    const updateEvents: PendingObservationDomainEvent[] = [ObservationSavedDomainEvent(target, userId)]
+    if (removedAttachments.length) {
+      updateEvents.push(AttachmentsRemovedDomainEvent(target, removedAttachments))
+    }
     const pendingEvents = mergePendingDomainEvents(target, updateEvents)
     return createObservation(update, target.mageEvent, pendingEvents)
   }
@@ -390,6 +393,7 @@ export class Observation implements Readonly<ObservationAttrs> {
 }
 
 export enum ObservationDomainEventType {
+  ObservationSaved = 'Observation.Saved',
   AttachmentsRemoved = 'Observation.AttachmentsRemoved',
 }
 
@@ -402,6 +406,10 @@ export enum ObservationDomainEventType {
 export type PendingObservationDomainEvent = {
   readonly type: ObservationDomainEventType
 } & (
+    | {
+      type: ObservationDomainEventType.ObservationSaved
+      readonly userId?: UserId
+    }
     | {
       type: ObservationDomainEventType.AttachmentsRemoved
       readonly removedAttachments: readonly Readonly<Attachment>[]
@@ -431,6 +439,7 @@ export type ObservationEmitted<Pending extends PendingObservationDomainEvent> = 
   readonly observation: Observation
 }
 
+export type ObservationSavedDomainEvent = Extract<PendingObservationDomainEvent, { type: ObservationDomainEventType.ObservationSaved }>
 export type AttachmentsRemovedDomainEvent = Extract<PendingObservationDomainEvent, { type: ObservationDomainEventType.AttachmentsRemoved }>
 
 export interface ObservationValidationResult {
@@ -1336,6 +1345,13 @@ class ObservationValidationContext {
   }
 }
 
+function ObservationSavedDomainEvent(observation: Observation, userId: UserId | undefined): ObservationSavedDomainEvent {
+  return Object.freeze<ObservationSavedDomainEvent>({
+    type: ObservationDomainEventType.ObservationSaved,
+    userId
+  })
+}
+
 function AttachmentsRemovedDomainEvent(observation: Observation, removedAttachments: Attachment[]): AttachmentsRemovedDomainEvent {
   return Object.freeze<AttachmentsRemovedDomainEvent>({
     type: ObservationDomainEventType.AttachmentsRemoved,
@@ -1350,9 +1366,10 @@ function mergePendingDomainEvents(from: Observation, nextEvents: PendingObservat
       removedAttachments.push(...e.removedAttachments)
       return merged
     }
-    else {
-      return [...merged, e]
+    if (merged.some(m => m.type === e.type)) {
+      return merged
     }
+    return [...merged, e]
   }, [] as PendingObservationDomainEvent[])
   if (removedAttachments.length) {
     merged.push(AttachmentsRemovedDomainEvent(from, removedAttachments))

--- a/service/src/entities/users/entities.users.ts
+++ b/service/src/entities/users/entities.users.ts
@@ -1,6 +1,8 @@
 import { PagingParameters, PageOf } from '../entities.global'
 import { Role } from '../authorization/entities.authorization'
 import { Authentication } from '../authentication/entities.authentication'
+import { MageEventId } from '../events/entities.events'
+import { FormId } from '../events/entities.events.forms'
 
 export type UserId = string
 
@@ -92,5 +94,44 @@ export enum UserIconStoreErrorCode {
    * some I/O operation.
    */
   StorageError = 'UserIconStoreError.StorageError'
+}
+
+export interface UserPreference {
+  events: { [key: number]: EventPreference }
+}
+
+export interface EventPreference {
+  forms: { [key: number]: FormPreference }
+}
+
+export interface FormPreference {
+  fields: { [key: string]: FieldPreference }
+}
+
+export interface FieldPreference {
+  recentChoices: RecentChoice[]
+}
+
+export type RecentChoice = string
+
+export type AddRecentFormFieldChoiceParams = {
+  eventId: MageEventId
+  formId: FormId
+  fieldName: string
+  choice: string
+}
+
+export type AddRecentFormFieldChoiceEntry = AddRecentFormFieldChoiceParams & {
+  recentChoicesLimit?: number
+}
+
+export interface UserPreferenceRepository {
+  getPreferences(userId: UserId): Promise<UserPreference | null>
+  getEventPreferences(userId: UserId, eventId: MageEventId): Promise<EventPreference | null>
+  /**
+   * Record the given recent form field choices for the user in a single
+   * write, rather than a separate read-modify-write round trip per choice.
+   */
+  addRecentFormFieldChoices(userId: UserId, choices: AddRecentFormFieldChoiceEntry[]): Promise<UserPreference>
 }
 

--- a/service/src/models/event.js
+++ b/service/src/models/event.js
@@ -31,6 +31,7 @@ const FieldSchema = new Schema({
   name: { type: String, required: true },
   required: { type: Boolean, required: true },
   choices: [OptionSchema],
+  maxRecent: { type: Number, required: false, default: 5 },
   allowedAttachmentTypes: [{ type: String, required: false, enum: ['image', 'video', 'audio'] }],
   min: { type: Number, required: false },
   max: { type: Number, required: false }

--- a/service/src/permissions/permissions.users.ts
+++ b/service/src/permissions/permissions.users.ts
@@ -2,11 +2,18 @@ import { UsersPermissionService } from '../app.api/users/app.api.users'
 import { AppRequestContext } from '../app.api/app.api.global'
 import { UsersPermission } from '../entities/authorization/entities.permissions'
 import { UserWithRole, ensureContextUserHasPermission } from './permissions.role-based.base'
-import { PermissionDeniedError } from '../app.api/app.api.errors'
-
+import { permissionDenied, PermissionDeniedError } from '../app.api/app.api.errors'
+import { UserPreferencePermissionService } from '../app.api/preferences/app.api.preferences'
 
 export class RoleBasedUsersPermissionService implements UsersPermissionService {
   async ensureReadUsersPermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError> {
     return ensureContextUserHasPermission(context, UsersPermission.READ_USER)
+  }
+}
+
+export class RoleBasedUserPreferencesPermissionService implements UserPreferencePermissionService {
+  async ensureGetEventPreferencePermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError> {
+    const user = context.requestingPrincipal()
+    return user ? null : permissionDenied('UPDATE', 'principal')
   }
 }

--- a/service/test/adapters/observations/adapters.observations.db.mongoose.test.ts
+++ b/service/test/adapters/observations/adapters.observations.db.mongoose.test.ts
@@ -730,13 +730,15 @@ describe('mongoose observation repository', function () {
       const mod = removeAttachment(obs, obs.attachments[1].id) as Observation
       const saved = await repo.save(mod) as Observation
 
-      expect(mod.pendingEvents).to.have.length(1)
+      expect(mod.pendingEvents).to.have.length(2)
       expect(saved.pendingEvents).to.deep.equal([])
-      domainEvents.received(1).emit(Arg.all())
-      domainEvents.received(1).emit(
-        mod.pendingEvents[0].type,
-        Arg.deepEquals({ ...mod.pendingEvents[0], observation: saved })
-      )
+      domainEvents.received(2).emit(Arg.all())
+      for (const pending of mod.pendingEvents) {
+        domainEvents.received(1).emit(
+          pending.type,
+          Arg.deepEquals({ ...pending, observation: saved })
+        )
+      }
     })
 
     it('emits readonly events', async function () {

--- a/service/test/adapters/preferences/adapters.preferences.db.mongoose.test.ts
+++ b/service/test/adapters/preferences/adapters.preferences.db.mongoose.test.ts
@@ -1,0 +1,170 @@
+import { expect } from 'chai'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import { MongoosePreferenceRepository, UserPreferenceDocument, UserPreferenceModel } from '../../../lib/adapters/preferences/adapters.preferences.db.mongoose'
+import { UserPreference } from '../../../lib/entities/users/entities.users'
+
+describe('user preferences mongoose repository', function() {
+
+  let mongo: MongoMemoryServer
+  let uri: string
+  let conn: mongoose.Connection
+  let model: mongoose.Model<UserPreferenceDocument>
+  let repo: MongoosePreferenceRepository
+  const userId = new mongoose.Types.ObjectId().toHexString()
+
+  before(async function() {
+    mongo = await MongoMemoryServer.create()
+    uri = mongo.getUri()
+  })
+
+  beforeEach(async function() {
+    conn = await mongoose.createConnection(uri).asPromise()
+    model = UserPreferenceModel(conn, 'test_user_preferences')
+    repo = new MongoosePreferenceRepository(model)
+  })
+
+  afterEach(async function() {
+    await model.deleteMany({})
+    await conn.close()
+  })
+
+  after(async function() {
+    await mongo.stop()
+  })
+
+  describe('getting preferences for a user with none saved', function() {
+
+    it('returns null', async function() {
+      const found = await repo.getPreferences(userId)
+      expect(found).to.be.null
+    })
+  })
+
+  describe('getting event preferences for a user with none saved', function() {
+
+    it('returns null', async function() {
+      const found = await repo.getEventPreferences(userId, 1)
+      expect(found).to.be.null
+    })
+  })
+
+  describe('adding recent form field choices', function() {
+
+    it('creates the preference document if none existed', async function() {
+
+      const created = await repo.addRecentFormFieldChoices(userId, [
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }
+      ])
+
+      expect(created.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['blue'])
+    })
+
+    it('adds a new choice to the front of the list', async function() {
+
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
+      const updated = await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'green' }])
+
+      expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['green', 'blue'])
+    })
+
+    it('moves a re-selected choice back to the front instead of duplicating it', async function() {
+
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'green' }])
+      const updated = await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
+
+      expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['blue', 'green'])
+    })
+
+    it('truncates to the default limit of 5 when no limit is given', async function() {
+
+      for (const choice of ['a', 'b', 'c', 'd', 'e', 'f']) {
+        await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice }])
+      }
+
+      const preferences = await repo.getPreferences(userId)
+
+      expect(preferences?.events[1].forms[1].fields['field1'].recentChoices)
+        .to.deep.equal(['f', 'e', 'd', 'c', 'b'])
+    })
+
+    it('truncates to the given recentChoicesLimit', async function() {
+
+      for (const choice of ['a', 'b', 'c']) {
+        await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice, recentChoicesLimit: 2 }])
+      }
+
+      const preferences = await repo.getPreferences(userId)
+
+      expect(preferences?.events[1].forms[1].fields['field1'].recentChoices)
+        .to.deep.equal(['c', 'b'])
+    })
+
+    it('keeps preferences for different fields, forms, and events independent of each other', async function() {
+
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field2', choice: 'big' }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 2, fieldName: 'field1', choice: 'square' }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 2, formId: 1, fieldName: 'field1', choice: 'north' }])
+
+      const preferences = await repo.getPreferences(userId)
+
+      expect(preferences?.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['blue'])
+      expect(preferences?.events[1].forms[1].fields['field2'].recentChoices).to.deep.equal(['big'])
+      expect(preferences?.events[1].forms[2].fields['field1'].recentChoices).to.deep.equal(['square'])
+      expect(preferences?.events[2].forms[1].fields['field1'].recentChoices).to.deep.equal(['north'])
+    })
+
+    it('applies multiple choices for one observation in a single write', async function() {
+
+      const updated = await repo.addRecentFormFieldChoices(userId, [
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' },
+        { eventId: 1, formId: 1, fieldName: 'field2', choice: 'big' },
+        { eventId: 1, formId: 2, fieldName: 'field1', choice: 'square' }
+      ])
+
+      expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['blue'])
+      expect(updated.events[1].forms[1].fields['field2'].recentChoices).to.deep.equal(['big'])
+      expect(updated.events[1].forms[2].fields['field1'].recentChoices).to.deep.equal(['square'])
+    })
+
+    it('applies repeated choices for the same field within one batch in order', async function() {
+
+      const updated = await repo.addRecentFormFieldChoices(userId, [
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' },
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'green' }
+      ])
+
+      expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['green', 'blue'])
+    })
+  })
+
+  describe('getting event preferences for a user with saved preferences', function() {
+
+    const preference: UserPreference = {
+      events: {
+        1: { forms: { 1: { fields: { field1: { recentChoices: ['blue'] } } } } },
+        2: { forms: { 2: { fields: { field1: { recentChoices: ['green'] } } } } }
+      }
+    }
+
+    beforeEach(async function() {
+      await model.findByIdAndUpdate(userId, preference, { upsert: true })
+    })
+
+    it('returns only the preferences for the requested event', async function() {
+
+      const found = await repo.getEventPreferences(userId, 1)
+
+      expect(found?.forms[1].fields['field1'].recentChoices).to.deep.equal(['blue'])
+    })
+
+    it('returns null for an event with no saved preferences', async function() {
+
+      const found = await repo.getEventPreferences(userId, 3)
+
+      expect(found).to.be.null
+    })
+  })
+})

--- a/service/test/app/observations/app.observations.test.ts
+++ b/service/test/app/observations/app.observations.test.ts
@@ -843,7 +843,7 @@ describe('observations use case interactions', function() {
             forms: [ { id: obsBefore.formEntries[0].id, formId: obsBefore.formEntries[0].formId, field1: 'updated field' } ]
           }
         }
-        const obsAfter = Observation.assignTo(obsBefore, obsAfterAttrs) as Observation
+        const obsAfter = Observation.assignTo(obsBefore, obsAfterAttrs, context.userId) as Observation
         const req: api.SaveObservationRequest = { context, observation: modExtra }
         obsRepo.save(Arg.all()).resolves(obsAfter)
         const res = await saveObservation(req)

--- a/service/test/app/preferences/app.preferences.test.ts
+++ b/service/test/app/preferences/app.preferences.test.ts
@@ -1,0 +1,69 @@
+import { Arg, Substitute as Sub, SubstituteOf } from '@fluffy-spoon/substitute'
+import { expect } from 'chai'
+import * as api from '../../../lib/app.api/preferences/app.api.preferences'
+import { GetEventPreferences } from '../../../lib/app.impl/preferences/app.impl.preferences'
+import { ErrEntityNotFound, ErrPermissionDenied, permissionDenied } from '../../../lib/app.api/app.api.errors'
+import { EventPreference, UserPreferenceRepository } from '../../../lib/entities/users/entities.users'
+import { UserWithRole } from '../../../lib/permissions/permissions.role-based.base'
+import { AppRequestContext } from '../../../lib/app.api/app.api.global'
+
+function contextFor(principal: string): AppRequestContext<UserWithRole> {
+  return {
+    requestToken: Symbol(),
+    requestingPrincipal: () => ({ id: principal } as unknown as UserWithRole),
+    locale() { return null }
+  }
+}
+
+describe('user preferences use case interactions', function() {
+
+  let userPreferenceRepo: SubstituteOf<UserPreferenceRepository>
+  let permissions: SubstituteOf<api.UserPreferencePermissionService>
+
+  beforeEach(function() {
+    userPreferenceRepo = Sub.for<UserPreferenceRepository>()
+    permissions = Sub.for<api.UserPreferencePermissionService>()
+  })
+
+  describe('getting event preferences', function() {
+
+    let getEventPreferences: api.GetEventPreferences
+
+    beforeEach(function() {
+      getEventPreferences = GetEventPreferences(userPreferenceRepo, permissions)
+    })
+
+    it('denies the request if permission is denied', async function() {
+
+      const context = contextFor('user1')
+      permissions.ensureGetEventPreferencePermission(Arg.any()).resolves(permissionDenied('READ', 'user1'))
+      const res = await getEventPreferences({ context, eventId: 1 })
+
+      expect(res.success).to.be.null
+      expect(res.error?.code).to.equal(ErrPermissionDenied)
+    })
+
+    it('returns entity not found if the user has no preferences saved for the event', async function() {
+
+      const context = contextFor('user1')
+      permissions.ensureGetEventPreferencePermission(Arg.any()).resolves(null)
+      userPreferenceRepo.getEventPreferences('user1', 1).resolves(null)
+      const res = await getEventPreferences({ context, eventId: 1 })
+
+      expect(res.success).to.be.null
+      expect(res.error?.code).to.equal(ErrEntityNotFound)
+    })
+
+    it('returns the event preferences for the requesting user', async function() {
+
+      const context = contextFor('user1')
+      const eventPreference: EventPreference = { forms: { 1: { fields: { field1: { recentChoices: ['blue'] } } } } }
+      permissions.ensureGetEventPreferencePermission(Arg.any()).resolves(null)
+      userPreferenceRepo.getEventPreferences('user1', 1).resolves(eventPreference)
+      const res = await getEventPreferences({ context, eventId: 1 })
+
+      expect(res.error).to.be.null
+      expect(res.success).to.deep.equal(eventPreference)
+    })
+  })
+})

--- a/service/test/entities/observations/entities.observations.test.ts
+++ b/service/test/entities/observations/entities.observations.test.ts
@@ -1152,10 +1152,10 @@ describe('observation entities', function () {
         const before: Observation = Observation.evaluate(beforeAttrs, mageEvent)
         const afterAttrs = copyObservationAttrs(beforeAttrs)
         afterAttrs.geometry = afterGeom
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as Observation
 
-        const beforeUnchanged = _.omit(before, 'geometry', 'lastModified')
-        const afterUnchanged = _.omit(after, 'geometry', 'lastModified')
+        const beforeUnchanged = _.omit(before, 'geometry', 'lastModified', 'pendingEvents')
+        const afterUnchanged = _.omit(after, 'geometry', 'lastModified', 'pendingEvents')
         expect(afterUnchanged).to.deep.equal(beforeUnchanged)
         expect(before.geometry).to.deep.equal(beforeGeom)
         expect(after.geometry).to.deep.equal(afterGeom)
@@ -1172,10 +1172,10 @@ describe('observation entities', function () {
         const before: Observation = Observation.evaluate(beforeAttrs, mageEvent)
         const afterAttrs = copyObservationAttrs(beforeAttrs)
         afterAttrs.properties.timestamp = new Date(now)
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as Observation
 
-        const beforeUnchanged = _.omit(before, 'properties.timestamp', 'lastModified')
-        const afterUnchanged = _.omit(after, 'properties.timestamp', 'lastModified')
+        const beforeUnchanged = _.omit(before, 'properties.timestamp', 'lastModified', 'pendingEvents')
+        const afterUnchanged = _.omit(after, 'properties.timestamp', 'lastModified', 'pendingEvents')
         expect(afterUnchanged).to.deep.equal(beforeUnchanged)
         expect(before.properties.timestamp.getTime()).to.equal(then)
         expect(after.properties.timestamp.getTime()).to.equal(now)
@@ -1192,7 +1192,7 @@ describe('observation entities', function () {
         const before = Observation.evaluate(beforeAttrs, mageEvent)
         const afterAttrs = copyObservationAttrs(beforeAttrs)
         afterAttrs.createdAt = new Date(now)
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as Observation
 
         const beforeUnchanged = _.omit(copyObservationAttrs(before), 'createdAt', 'lastModified')
         const afterUnchanged = _.omit(copyObservationAttrs(after), 'createdAt', 'lastModified')
@@ -1216,7 +1216,7 @@ describe('observation entities', function () {
             field1: 'a new form entry'
           }
         ]
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as Observation
 
         const beforeUnchanged = _.omit(before, 'properties.forms', 'lastModified')
         const afterUnchanged = _.omit(before, 'properties.forms', 'lastModified')
@@ -1248,7 +1248,7 @@ describe('observation entities', function () {
             field1: 'form entry after'
           }
         ]
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as Observation
 
         const beforeUnchanged = _.omit(before, 'properties.forms')
         const afterUnchanged = _.omit(before, 'properties.forms')
@@ -1298,7 +1298,8 @@ describe('observation entities', function () {
             field1: 'form entry 2 after'
           }
         ]
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const userId = uniqid()
+        const after = Observation.assignTo(before, afterAttrs, userId) as Observation
 
         const beforeUnchanged = _.omit(before, 'properties.forms')
         const afterUnchanged = _.omit(before, 'properties.forms')
@@ -1324,7 +1325,12 @@ describe('observation entities', function () {
             field1: 'form entry 2 after'
           }
         ])
-        expect(after.pendingEvents).to.deep.equal([])
+        expect(after.pendingEvents).to.deep.equal([
+          {
+            type: ObservationDomainEventType.ObservationSaved,
+            userId
+          }
+        ])
       })
 
       it.skip('removes child attachments of removed form entries', function () {
@@ -1380,7 +1386,7 @@ describe('observation entities', function () {
           }
         ]
         const before = Observation.evaluate(beforeAttrs, mageEvent)
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as Observation
 
         const beforeUnchanged = _.omit(before, 'attachments', 'lastModified')
         const afterUnchanged = _.omit(before, 'attachments', 'lastModified')
@@ -1464,8 +1470,10 @@ describe('observation entities', function () {
         const afterAttrs2 = copyObservationAttrs(beforeAttrs)
         afterAttrs2.attachments = []
         const before = Observation.evaluate(beforeAttrs, mageEvent)
-        const after1 = Observation.assignTo(before, afterAttrs1) as Observation
-        const after2 = Observation.assignTo(after1, afterAttrs2) as Observation
+        const userId1 = uniqid()
+        const userId2 = uniqid()
+        const after1 = Observation.assignTo(before, afterAttrs1, userId1) as Observation
+        const after2 = Observation.assignTo(after1, afterAttrs2, userId2) as Observation
 
         const beforeUnchanged = _.omit(before, 'lastModified', 'attachments', 'pendingEvents')
         const after1Unchanged = _.omit(after1, 'lastModified', 'attachments', 'pendingEvents')
@@ -1478,6 +1486,10 @@ describe('observation entities', function () {
         expect(after1.attachments).to.deep.equal([copyAttachmentAttrs(before.attachments[0])])
         expect(after1.pendingEvents).to.deep.equal([
           {
+            type: ObservationDomainEventType.ObservationSaved,
+            userId: userId1
+          },
+          {
             type: ObservationDomainEventType.AttachmentsRemoved,
             removedAttachments: [copyAttachmentAttrs(before.attachments[1])]
           }
@@ -1486,6 +1498,10 @@ describe('observation entities', function () {
         expect(after2.lastModified.getTime()).to.be.closeTo(Date.now(), 150)
         expect(after2.attachments).to.deep.equal([])
         expect(after2.pendingEvents).to.deep.equal([
+          {
+            type: ObservationDomainEventType.ObservationSaved,
+            userId: userId1
+          },
           {
             type: ObservationDomainEventType.AttachmentsRemoved,
             removedAttachments: [copyAttachmentAttrs(before.attachments[1]), copyAttachmentAttrs(before.attachments[0])]
@@ -1514,7 +1530,7 @@ describe('observation entities', function () {
             field1: validFieldEntry
           }
         ]
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as Observation
 
         const beforeUnchanged = _.omit(before, 'properties.forms')
         const afterUnchanged = _.omit(before, 'properties.forms')
@@ -1546,7 +1562,7 @@ describe('observation entities', function () {
         const before: Observation = Observation.evaluate(beforeAttrs, mageEvent)
         const afterAttrs = copyObservationAttrs(beforeAttrs)
         afterAttrs.eventId = beforeAttrs.eventId + 1
-        const after = Observation.assignTo(before, afterAttrs) as ObservationUpdateError
+        const after = Observation.assignTo(before, afterAttrs, uniqid()) as ObservationUpdateError
 
         expect(after).to.be.instanceOf(ObservationUpdateError)
         expect(after.reason).to.equal(ObservationUpdateErrorReason.EventId)
@@ -1574,11 +1590,16 @@ describe('observation entities', function () {
         const afterAttrs = copyObservationAttrs(beforeAttrs)
         afterAttrs.properties.forms = [beforeAttrs.properties.forms[1]]
         afterAttrs.attachments = [beforeAttrs.attachments[1]]
-        const after = Observation.assignTo(before, afterAttrs) as Observation
+        const userId = uniqid()
+        const after = Observation.assignTo(before, afterAttrs, userId) as Observation
 
         expect(before.validation.hasErrors).to.be.false
         expect(after.validation.hasErrors).to.be.false
         expect(after.pendingEvents).to.deep.equal([
+          {
+            type: ObservationDomainEventType.ObservationSaved,
+            userId
+          },
           {
             type: ObservationDomainEventType.AttachmentsRemoved,
             removedAttachments: [

--- a/service/test/permissions/permissions.users.test.ts
+++ b/service/test/permissions/permissions.users.test.ts
@@ -1,0 +1,41 @@
+import { RoleBasedUserPreferencesPermissionService } from '../../lib/permissions/permissions.users'
+import { AppRequestContext } from '../../lib/app.api/app.api.global'
+import { expect } from 'chai'
+import { ErrPermissionDenied } from '../../lib/app.api/app.api.errors'
+import { UserWithRole } from '../../lib/permissions/permissions.role-based.base'
+
+describe('user preferences role-based permission service', function() {
+
+  let permissions: RoleBasedUserPreferencesPermissionService
+
+  beforeEach(function() {
+    permissions = new RoleBasedUserPreferencesPermissionService()
+  })
+
+  function contextFor(principal: UserWithRole | null): AppRequestContext<UserWithRole> {
+    return {
+      requestToken: Symbol(),
+      requestingPrincipal: () => principal as UserWithRole,
+      locale() { return null }
+    }
+  }
+
+  describe('getting event preferences', function() {
+
+    it('denies the request if there is no requesting principal', async function() {
+
+      const denied = await permissions.ensureGetEventPreferencePermission(contextFor(null))
+
+      expect(denied?.code).to.equal(ErrPermissionDenied)
+      expect(denied?.data.subject).to.equal('principal')
+      expect(denied?.data.permission).to.equal('UPDATE')
+    })
+
+    it('allows the request for any authenticated principal', async function() {
+
+      const denied = await permissions.ensureGetEventPreferencePermission(contextFor({ username: 'user1' } as UserWithRole))
+
+      expect(denied).to.be.null
+    })
+  })
+})

--- a/web-app/projects/core-lib/user/user.model.ts
+++ b/web-app/projects/core-lib/user/user.model.ts
@@ -63,6 +63,24 @@ export interface User {
   recentEventIds: number[]
 }
 
+export interface UserPreference {
+  events?: { [key: number]: EventPreference }
+}
+
+export interface EventPreference {
+  forms?: { [key: number]: FormPreference }
+}
+
+export interface FormPreference {
+  fields?: { [key: string]: FieldPreference }
+}
+
+export interface FieldPreference {
+  recentChoices?: RecentChoice[]
+}
+
+export type RecentChoice = string
+
 export interface UserPhone {
   type: string
   number: string

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.html
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.html
@@ -126,6 +126,12 @@
       </div>
     </div>
 
+    <mat-form-field appearance="fill" *ngIf="field.type === 'dropdown' && !data.isMemberField">
+      <mat-label>Maximum Number of Recent Choices</mat-label>
+      <input matInput type="number" [(ngModel)]="field.maxRecent" name="maxRecent" min="0">
+      <mat-hint>Maximum number of recent choices displayed first in the list.</mat-hint>
+    </mat-form-field>
+
     <mat-form-field appearance="fill"
       *ngIf="field.type === 'dropdown' && !field.multiselect && !data.isMemberField">
       <mat-label>Default Value</mat-label>

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.spec.ts
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.spec.ts
@@ -1,0 +1,96 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FieldDialogComponent, FieldDialogData } from './field-dialog.component';
+
+describe('FieldDialogComponent', () => {
+  let component: FieldDialogComponent;
+  let fixture: ComponentFixture<FieldDialogComponent>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<FieldDialogComponent>>;
+
+  function configureWith(data: FieldDialogData) {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    TestBed.configureTestingModule({
+      declarations: [FieldDialogComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: data }
+      ]
+    });
+
+    fixture = TestBed.createComponent(FieldDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  const fieldTypes = [
+    { name: 'textfield', title: 'Text Field' },
+    { name: 'dropdown', title: 'Dropdown' }
+  ];
+
+  describe('creating a new field', () => {
+
+    beforeEach(waitForAsync(() => {
+      configureWith({ fieldTypes, attachmentAllowedTypes: [] });
+    }));
+
+    it('defaults maxRecent to 5', () => {
+      expect(component.field.maxRecent).toEqual(5);
+    });
+  });
+
+  describe('editing an existing dropdown field', () => {
+
+    beforeEach(waitForAsync(() => {
+      configureWith({
+        fieldTypes,
+        attachmentAllowedTypes: [],
+        editMode: true,
+        existingField: {
+          id: 1,
+          name: 'field1',
+          title: 'Field 1',
+          type: 'dropdown',
+          required: false,
+          maxRecent: 3,
+          choices: [{ id: 1, title: 'red', value: 0 }, { id: 2, title: 'blue', value: 1 }]
+        }
+      });
+    }));
+
+    it('preserves the existing maxRecent value', () => {
+      expect(component.field.maxRecent).toEqual(3);
+    });
+
+    it('does not mutate the original existingField data', () => {
+      component.field.maxRecent = 10;
+
+      expect(component.data.existingField.maxRecent).toEqual(3);
+    });
+  });
+
+  describe('editing an existing field with no maxRecent saved yet', () => {
+
+    beforeEach(waitForAsync(() => {
+      configureWith({
+        fieldTypes,
+        attachmentAllowedTypes: [],
+        editMode: true,
+        existingField: {
+          id: 1,
+          name: 'field1',
+          title: 'Field 1',
+          type: 'dropdown',
+          required: false,
+          choices: []
+        }
+      });
+    }));
+
+    it('leaves maxRecent undefined rather than inventing a default', () => {
+      expect(component.field.maxRecent).toBeUndefined();
+    });
+  });
+});

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.ts
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.ts
@@ -20,6 +20,7 @@ export interface FieldResult {
     value?: any;
     min?: number;
     max?: number;
+    maxRecent?: number;
     allowedAttachmentTypes?: string[];
 }
 
@@ -61,7 +62,8 @@ export class FieldDialogComponent {
                 title: '',
                 required: false,
                 multiselect: false,
-                choices: []
+                choices: [],
+                maxRecent: 5
             };
         }
 

--- a/web-app/src/app/admin/admin-event/helpers/observation-feed-helper.ts
+++ b/web-app/src/app/admin/admin-event/helpers/observation-feed-helper.ts
@@ -27,6 +27,7 @@ export interface Field {
     value?: any;
     min?: number;
     max?: number;
+    maxRecent?: number;
     allowedAttachmentTypes?: string[];
 }
 

--- a/web-app/src/app/observation/observation-edit/observation-edit-form.component.html
+++ b/web-app/src/app/observation/observation-edit/observation-edit-form.component.html
@@ -37,8 +37,16 @@
           <observation-edit-attachment *ngSwitchCase="'attachment'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]" [attachments]="observation?.attachments" [url]="attachmentUrl"></observation-edit-attachment>
           <observation-edit-checkbox *ngSwitchCase="'checkbox'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]"></observation-edit-checkbox>
           <observation-edit-date *ngSwitchCase="'date'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]"></observation-edit-date>
-          <observation-edit-dropdown *ngSwitchCase="'dropdown'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]"></observation-edit-dropdown>
-          <observation-edit-multiselect *ngSwitchCase="'multiselectdropdown'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]"></observation-edit-multiselect>
+          <observation-edit-dropdown *ngSwitchCase="'dropdown'"
+            [formGroup]="formGroup"
+            [definition]="fieldDefinitions[fieldName]"
+            [recentChoices]="formPreferences?.fields?.[fieldName]?.recentChoices">
+          </observation-edit-dropdown>
+          <observation-edit-multiselect *ngSwitchCase="'multiselectdropdown'"
+            [formGroup]="formGroup"
+            [definition]="fieldDefinitions[fieldName]"
+            [recentChoices]="formPreferences?.fields?.[fieldName]?.recentChoices">
+          </observation-edit-multiselect>
           <observation-edit-email *ngSwitchCase="'email'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]"></observation-edit-email>
           <observation-edit-number *ngSwitchCase="'numberfield'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]"></observation-edit-number>
           <observation-edit-radio *ngSwitchCase="'radio'" [formGroup]="formGroup" [definition]="fieldDefinitions[fieldName]"></observation-edit-radio>

--- a/web-app/src/app/observation/observation-edit/observation-edit-form.component.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-form.component.ts
@@ -1,6 +1,7 @@
 import { animate, state, style, transition, trigger } from '@angular/animations'
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { UntypedFormGroup } from '@angular/forms'
+import { FormPreference } from 'core-lib-src/user'
 
 @Component({
     selector: 'observation-edit-form',
@@ -26,6 +27,7 @@ import { UntypedFormGroup } from '@angular/forms'
 })
 export class ObservationEditFormComponent {
   @Input() formGroup: UntypedFormGroup
+  @Input() formPreferences: FormPreference
   @Input() definition: any
   @Input() geometryStyle: any
   @Input() attachmentUrl: string

--- a/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.html
+++ b/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.html
@@ -24,19 +24,46 @@
   </mat-chip-grid>
 
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">
-    <mat-option
-      *ngFor="let choice of filteredChoices | async"
-      [value]="choice.title"
-    >
-      <span
-        [ngClass]="{
-          'select__choice--disabled':
-            control.value && control.value.includes(choice.title)
-        }"
-      >
-        {{ choice.title }}
-      </span>
-    </mat-option>
+    <ng-container *ngIf="recentChoices$ | async as recentChoices">
+      <mat-optgroup [label]="'Recents'" *ngIf="recentChoices.length !== 0">
+        <mat-option *ngFor="let choice of recentChoices" [value]="choice.title">
+          <span
+            [ngClass]="{
+              'select__choice--disabled':
+                control.value && control.value.includes(choice.title)
+            }"
+          >
+            {{ choice.title }}
+          </span>
+        </mat-option>
+      </mat-optgroup>
+      <ng-container *ngIf="filteredChoices$ | async as filteredChoices">
+        <mat-optgroup [label]="'All'" *ngIf="recentChoices.length !== 0; else noRecents">
+          <mat-option *ngFor="let choice of filteredChoices" [value]="choice.title">
+            <span
+              [ngClass]="{
+                'select__choice--disabled':
+                  control.value && control.value.includes(choice.title)
+              }"
+            >
+              {{ choice.title }}
+            </span>
+          </mat-option>
+        </mat-optgroup>
+        <ng-template #noRecents>
+          <mat-option *ngFor="let choice of filteredChoices" [value]="choice.title">
+            <span
+              [ngClass]="{
+                'select__choice--disabled':
+                  control.value && control.value.includes(choice.title)
+              }"
+            >
+              {{ choice.title }}
+            </span>
+          </mat-option>
+        </ng-template>
+      </ng-container>
+    </ng-container>
   </mat-autocomplete>
 
   <mat-error *ngIf="formGroup.get(definition.name)?.invalid">

--- a/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.spec.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.spec.ts
@@ -13,7 +13,7 @@ import { By } from '@angular/platform-browser'
 
 @Component({
     selector: `host-component`,
-    template: `<observation-edit-multiselect [definition]="definition" [formGroup]="formGroup"></observation-edit-multiselect>`,
+    template: `<observation-edit-multiselect [definition]="definition" [formGroup]="formGroup" [recentChoices]="recentChoices"></observation-edit-multiselect>`,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })
@@ -34,6 +34,8 @@ class TestHostComponent {
       title: 'blue'
     }]
   }
+
+  recentChoices: string[] = []
 
   @ViewChild(ObservationEditMultiselectComponent) component: ObservationEditMultiselectComponent
 }
@@ -104,6 +106,40 @@ describe('ObservationEditMultiselectComponent', () => {
 
     const control = component.formGroup.get('select')
     expect(control.value).toEqual(['red'])
+  })
+
+  describe('recent choices', () => {
+
+    it('is empty when no recent choices are given', (done) => {
+      component.recentChoices$.subscribe(recent => {
+        expect(recent).toEqual([])
+        done()
+      })
+    })
+
+    it('preserves the given order, most recent first, as provided by the server', (done) => {
+      const freshFixture = TestBed.createComponent(TestHostComponent)
+      const freshHost = freshFixture.componentInstance
+      freshHost.recentChoices = ['green', 'blue', 'red']
+      freshFixture.detectChanges()
+
+      freshHost.component.recentChoices$.subscribe(recent => {
+        expect(recent.map(c => c.title)).toEqual(['green', 'blue', 'red'])
+        done()
+      })
+    })
+
+    it('excludes recent choices that are no longer valid choices for the field', (done) => {
+      const freshFixture = TestBed.createComponent(TestHostComponent)
+      const freshHost = freshFixture.componentInstance
+      freshHost.recentChoices = ['red', 'not-a-real-choice']
+      freshFixture.detectChanges()
+
+      freshHost.component.recentChoices$.subscribe(recent => {
+        expect(recent.map(c => c.title)).toEqual(['red'])
+        done()
+      })
+    })
   })
 
   it('should add choice', () => {

--- a/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.ts
@@ -5,6 +5,7 @@ import { MatAutocompleteSelectedEvent, MatAutocompleteTrigger } from '@angular/m
 import { MatChipInputEvent } from '@angular/material/chips';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
+import { RecentChoice } from 'core-lib-src/user';
 
 interface Choice {
   title: string;
@@ -27,24 +28,43 @@ export class ObservationEditMultiselectComponent implements OnInit {
   @Input() formGroup!: UntypedFormGroup
   @Input() definition!: MultiSelectField
 
+  private _recentChoices: RecentChoice[] = []
+  @Input()
+  set recentChoices(value: RecentChoice[]) {
+    this._recentChoices = value ?? []
+  }
+  get recentChoices(): RecentChoice[] {
+    return this._recentChoices
+  }
+
   @ViewChild('choiceInput', { static: false }) choiceInput!: ElementRef<HTMLInputElement>
   @ViewChild(MatAutocompleteTrigger, { static: false }) autocomplete!: MatAutocompleteTrigger
 
   separatorKeysCodes: number[] = [ENTER, COMMA]
   control!: UntypedFormControl
   choiceControl = new UntypedFormControl()
-  filteredChoices: Observable<Choice[]>
+  recentChoicesFromDefinition: Choice[] = []
+  filteredChoices$: Observable<Choice[]>
+  recentChoices$: Observable<Choice[]>
 
-  constructor() {
-    this.filteredChoices = this.choiceControl.valueChanges.pipe(
+  ngOnInit(): void {
+    this.control = this.formGroup.get(this.definition.name) as UntypedFormControl
+
+    this.recentChoicesFromDefinition = this.recentChoices
+      .map(recent => this.definition.choices.find(choice => choice.title === recent))
+      .filter(choice => !!choice)
+
+    this.filteredChoices$ = this.choiceControl.valueChanges.pipe(
       startWith(''),
       map(value => !value || typeof value === 'string' ? value : value.title),
       map(title => title ? this.filter(title) : this.definition.choices.slice())
     )
-  }
 
-  ngOnInit(): void {
-    this.control = this.formGroup.get(this.definition.name) as UntypedFormControl
+    this.recentChoices$ = this.choiceControl.valueChanges.pipe(
+      startWith(''),
+      map(value => !value || typeof value === 'string' ? value : value.title),
+      map(title => title ? this.recentFilter(title) : this.recentChoicesFromDefinition.slice())
+    )
   }
 
   add(event: MatChipInputEvent): void {
@@ -77,7 +97,13 @@ export class ObservationEditMultiselectComponent implements OnInit {
     const choices = new Set(this.control.value)
     choices.add(choice)
     this.control.setValue(Array.from(choices))
+    this.control.markAsDirty()
     this.choiceControl.setValue(null)
+  }
+
+  private recentFilter(title: string): Choice[] {
+    const filterValue = title.toLowerCase()
+    return this.recentChoicesFromDefinition.filter(option => option.title.toLowerCase().indexOf(filterValue) === 0)
   }
 
   private filter(value: string): Choice[] {

--- a/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.html
+++ b/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.html
@@ -1,14 +1,30 @@
 <mat-form-field appearance="fill" [formGroup]="formGroup">
   <mat-label>{{definition.title}}</mat-label>
-  <mat-select formControlName="{{definition.name}}" (selectionChange)="onSelectionChange($event)" [required]="definition.required">
+  <mat-select formControlName="{{definition.name}}" [required]="definition.required">
     <mat-option>
       <ngx-mat-select-search [formControl]="searchControl" placeholderLabel="{{definition.title}}" noEntriesFoundLabel=""></ngx-mat-select-search>
     </mat-option>
 
     <mat-option [value]="null"></mat-option>
-    <mat-option *ngFor="let choice of filteredChoices | async" [value]="choice.title">
-      {{choice.title}}
-    </mat-option>
+    <ng-container *ngIf="recentChoices$ | async as recentChoices">
+      <mat-optgroup [label]="'Recents'" *ngIf="recentChoices.length !== 0">
+        <mat-option *ngFor="let choice of recentChoices" [value]="choice.title">
+          {{choice.title}}
+        </mat-option>
+      </mat-optgroup>
+      <ng-container *ngIf="filteredChoices$ | async as filteredChoices">
+        <mat-optgroup [label]="'All'" *ngIf="recentChoices.length !== 0; else noRecents">
+          <mat-option *ngFor="let choice of filteredChoices" [value]="choice.title">
+            {{choice.title}}
+          </mat-option>
+        </mat-optgroup>
+        <ng-template #noRecents>
+          <mat-option *ngFor="let choice of filteredChoices" [value]="choice.title">
+            {{choice.title}}
+          </mat-option>
+        </ng-template>
+      </ng-container>
+    </ng-container>
   </mat-select>
   <mat-error *ngIf="formGroup.get(definition.name).hasError('required')">You must enter a value</mat-error>
 </mat-form-field>

--- a/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.spec.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.spec.ts
@@ -20,6 +20,7 @@ import { MatSelectModule } from '@angular/material/select';
     template: `<observation-edit-dropdown
     [definition]="definition"
     [formGroup]="formGroup"
+    [recentChoices]="recentChoices"
   ></observation-edit-dropdown>`,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
@@ -44,6 +45,8 @@ class TestHostComponent {
       }
     ]
   };
+
+  recentChoices: string[] = [];
 
   @ViewChild(ObservationEditSelectComponent)
   component: ObservationEditSelectComponent;
@@ -106,6 +109,46 @@ describe('ObservationEditSelectComponent', () => {
     await fixture.whenStable();
 
     expect(control.valid).toBe(false);
+  });
+
+  describe('recent choices', () => {
+
+    it('is empty when no recent choices are given', (done) => {
+      component.recentChoices$.subscribe(recent => {
+        expect(recent).toEqual([]);
+        done();
+      });
+    });
+
+    it('preserves the given order, most recent first, as provided by the server', (done) => {
+      let freshFixture: ComponentFixture<TestHostComponent>;
+      let freshHost: TestHostComponent;
+
+      freshFixture = TestBed.createComponent(TestHostComponent);
+      freshHost = freshFixture.componentInstance;
+      freshHost.recentChoices = ['green', 'blue', 'red'];
+      freshFixture.detectChanges();
+
+      freshHost.component.recentChoices$.subscribe(recent => {
+        expect(recent.map(c => c.title)).toEqual(['green', 'blue', 'red']);
+        done();
+      });
+    });
+
+    it('excludes recent choices that are no longer valid choices for the field', (done) => {
+      let freshFixture: ComponentFixture<TestHostComponent>;
+      let freshHost: TestHostComponent;
+
+      freshFixture = TestBed.createComponent(TestHostComponent);
+      freshHost = freshFixture.componentInstance;
+      freshHost.recentChoices = ['red', 'not-a-real-choice'];
+      freshFixture.detectChanges();
+
+      freshHost.component.recentChoices$.subscribe(recent => {
+        expect(recent.map(c => c.title)).toEqual(['red']);
+        done();
+      });
+    });
   });
 
   // it('should show error on invalid and touched', async () => {

--- a/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
-import { MatSelectChange as MatSelectChange } from '@angular/material/select';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
+import { RecentChoice } from 'core-lib-src/user';
 
 export interface Choice {
   title: string;
@@ -25,13 +25,26 @@ export class ObservationEditSelectComponent implements OnInit {
   @Input() formGroup: UntypedFormGroup
   @Input() definition: SelectField
 
-  @Output() selectionChange = new EventEmitter<{value: any}>();
+  private _recentChoices: RecentChoice[] = []
+  @Input()
+  set recentChoices(value: RecentChoice[]) {
+    this._recentChoices = value ?? []
+  }
+  get recentChoices(): RecentChoice[] {
+    return this._recentChoices
+  }
 
+  recentChoicesFromDefinition: Choice[] = []
   searchControl: UntypedFormControl = new UntypedFormControl();
-  filteredChoices: Observable<any[]>;
+  filteredChoices$: Observable<any[]>;
+  recentChoices$: Observable<any[]>;
 
   ngOnInit(): void {
-    this.filteredChoices = this.searchControl.valueChanges.pipe(
+    this.recentChoicesFromDefinition = this.recentChoices
+      .map(recent => this.definition.choices.find(choice => choice.title === recent))
+      .filter(choice => !!choice)
+
+    this.filteredChoices$ = this.searchControl.valueChanges.pipe(
       startWith(''),
       map(value => {
         return !value || typeof value === 'string' ? value : value.title
@@ -40,12 +53,17 @@ export class ObservationEditSelectComponent implements OnInit {
         return title ? this.filter(title) : this.definition.choices.slice()
       })
     );
+
+    this.recentChoices$ = this.searchControl.valueChanges.pipe(
+      startWith(''),
+      map(value => !value || typeof value === 'string' ? value : value.title),
+      map(title => title ? this.recentFilter(title) : this.recentChoicesFromDefinition.slice())
+    );
   }
 
-  onSelectionChange(event: MatSelectChange): void {
-    this.selectionChange.emit({
-      value: event.value
-    })
+  private recentFilter(title: string): Choice[] {
+    const filterValue = title.toLowerCase();
+    return this.recentChoicesFromDefinition.filter(option => option.title.toLowerCase().indexOf(filterValue) === 0);
   }
 
   private filter(title: string): Choice[] {

--- a/web-app/src/app/observation/observation-edit/observation-edit.component.html
+++ b/web-app/src/app/observation/observation-edit/observation-edit.component.html
@@ -46,6 +46,7 @@
         <ng-container *ngFor="let group of formGroup?.get('properties')?.get('forms')?.controls; let i = index">
           <div class="form" #form cdkDrag cdkDragBoundary=".edit-forms">
             <observation-edit-form [formGroup]="group" [definition]="formDefinitions[group.get('formId').value]"
+              [formPreferences]="eventPreferences?.forms?.[group.get('formId')?.value]"
               [geometryStyle]="geometryStyle" [attachmentUrl]="attachmentUrl" [observation]="observation"
               [options]="i === 0 ? {expand: true} : formOptions" (remove)="removeForm($event)"
               (featureEdit)="onGeometryEdit($event)">

--- a/web-app/src/app/observation/observation-edit/observation-edit.component.spec.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit.component.spec.ts
@@ -1,29 +1,150 @@
+import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { MatDialogModule as MatDialogModule } from '@angular/material/dialog';
+import { MatDialogModule } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Subject, of } from 'rxjs';
 
 import { ObservationEditComponent } from './observation-edit.component';
+import { AttachmentService } from '../attachment/attachment.service';
+import { MapService } from 'src/app/map/map.service';
+import { UserService } from 'src/app/user/user.service';
+import { EventService } from 'src/app/event/event.service';
+import { FilterService } from 'src/app/filter/filter.service';
+import { ObservationService } from '../observation.service';
+import { SessionService } from 'mage-web-app/http/session.service';
+import { EventPreference } from 'core-lib-src/user';
 
-/* TODO test MUST contain at least 1 test
+function newObservation(eventId: number) {
+  return {
+    id: 'new',
+    eventId,
+    properties: { forms: [], timestamp: new Date() },
+    geometry: null,
+    noGeometry: false
+  };
+}
+
+@Component({
+  selector: 'host-component',
+  template: `<observation-edit [observation]="observation"></observation-edit>`,
+  standalone: false
+})
+class TestHostComponent {
+  observation: any = newObservation(1);
+
+  @ViewChild(ObservationEditComponent)
+  component: ObservationEditComponent;
+}
+
 describe('ObservationEditComponent', () => {
-  let component: ObservationEditComponent;
-  let fixture: ComponentFixture<ObservationEditComponent>;
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let userService: jasmine.SpyObj<UserService>;
+  let eventService: jasmine.SpyObj<EventService>;
 
   beforeEach(waitForAsync(() => {
+    userService = jasmine.createSpyObj('UserService', ['getEventPreferences']);
+    eventService = jasmine.createSpyObj('EventService', ['getEventById', 'getFormsForEvent']);
+    eventService.getEventById.and.callFake((eventId: number) => ({ id: eventId }));
+    eventService.getFormsForEvent.and.returnValue([]);
+    userService.getEventPreferences.and.returnValue(of(null));
+
     TestBed.configureTestingModule({
-      imports: [MatDialogModule],
-      declarations: [ObservationEditComponent ]
+      imports: [NoopAnimationsModule, MatDialogModule],
+      declarations: [ObservationEditComponent, TestHostComponent],
+      providers: [
+        { provide: AttachmentService, useValue: { upload$: new Subject() } },
+        { provide: MapService, useValue: jasmine.createSpyObj('MapService', ['addFeaturesToLayer', 'updateFeatureForLayer', 'removeFeatureFromLayer']) },
+        { provide: SessionService, useValue: { user: { id: 'user1', role: { permissions: [] } }, getToken: () => 'token' } },
+        { provide: UserService, useValue: userService },
+        { provide: FilterService, useValue: jasmine.createSpyObj('FilterService', ['getEvent']) },
+        { provide: EventService, useValue: eventService },
+        { provide: ObservationService, useValue: jasmine.createSpyObj('ObservationService', ['getObservationStyleForForm']) }
+      ]
     })
-    .compileComponents();
+      // Override the real template, which pulls in the entire tree of form field
+      // components, so this suite can exercise the component class in isolation.
+      .overrideComponent(ObservationEditComponent, {
+        set: { template: '<div #editContent><div #form></div></div>' }
+      })
+      .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ObservationEditComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
   });
 
-  // it('should create', () => {
-  //   expect(component).toBeTruthy();
-  // });
+  it('should create', () => {
+    fixture.detectChanges();
+
+    expect(hostComponent.component).toBeTruthy();
+  });
+
+  describe('loading event preferences', () => {
+
+    it('loads preferences for the event on the very first change detection cycle', () => {
+      const eventPreference: EventPreference = { forms: { 1: { fields: { field1: { recentChoices: ['blue'] } } } } };
+      userService.getEventPreferences.and.returnValue(of(eventPreference));
+
+      // A single detectChanges() call drives ngOnChanges then ngOnInit, in that
+      // real Angular order, exactly like production. This is the regression test
+      // for the bug where the preferences subscription lived in ngOnInit while the
+      // trigger fired from ngOnChanges, silently dropping the very first load.
+      fixture.detectChanges();
+
+      expect(userService.getEventPreferences).toHaveBeenCalledOnceWith(1);
+      expect(hostComponent.component.eventPreferences).toEqual(eventPreference);
+    });
+
+    it('does not refetch preferences when the event has not changed', () => {
+      fixture.detectChanges();
+
+      hostComponent.observation = newObservation(1);
+      fixture.detectChanges();
+
+      expect(userService.getEventPreferences).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetches preferences when the event changes', () => {
+      fixture.detectChanges();
+
+      hostComponent.observation = newObservation(2);
+      fixture.detectChanges();
+
+      expect(userService.getEventPreferences).toHaveBeenCalledTimes(2);
+      expect(userService.getEventPreferences).toHaveBeenCalledWith(2);
+    });
+
+    it('ignores a stale, slower-resolving response from a previous event when the event changes again', () => {
+      const firstEventResponse = new Subject<EventPreference | null>();
+      const secondEventPreference: EventPreference = { forms: { 2: { fields: { field1: { recentChoices: ['green'] } } } } };
+
+      userService.getEventPreferences.and.callFake((eventId: number) => {
+        return eventId === 1 ? firstEventResponse.asObservable() : of(secondEventPreference);
+      });
+
+      fixture.detectChanges();
+      expect(userService.getEventPreferences).toHaveBeenCalledWith(1);
+
+      hostComponent.observation = newObservation(2);
+      fixture.detectChanges();
+      expect(userService.getEventPreferences).toHaveBeenCalledWith(2);
+
+      // The first event's request resolves after the second event's request already
+      // completed. switchMap should have unsubscribed from it, so it must not
+      // clobber the second event's preferences.
+      firstEventResponse.next({ forms: { 1: { fields: {} } } });
+
+      expect(hostComponent.component.eventPreferences).toEqual(secondEventPreference);
+    });
+
+    it('sets preferences to null if the request errors', () => {
+      userService.getEventPreferences.and.returnValue(of(null));
+
+      fixture.detectChanges();
+
+      expect(hostComponent.component.eventPreferences).toBeNull();
+    });
+  });
 });
-*/

--- a/web-app/src/app/observation/observation-edit/observation-edit.component.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit.component.ts
@@ -3,6 +3,7 @@ import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
 
 import {
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   Inject,
@@ -14,8 +15,10 @@ import {
   SimpleChanges,
   ViewChild,
   ViewChildren,
-  DOCUMENT
+  DOCUMENT,
+  inject
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   UntypedFormArray,
   UntypedFormBuilder,
@@ -24,7 +27,8 @@ import {
   Validators,
 } from "@angular/forms";
 import { DomSanitizer } from "@angular/platform-browser";
-import { first } from "rxjs/operators";
+import { catchError, distinctUntilChanged, first, switchMap } from "rxjs/operators";
+import { of, Subject } from "rxjs";
 import { ObservationEditFormPickerComponent } from "./observation-edit-form-picker.component";
 import moment from 'moment';
 import { ObservationEditDiscardComponent } from "./observation-edit-discard/observation-edit-discard.component";
@@ -49,6 +53,7 @@ import { EventService } from "src/app/event/event.service";
 import { FilterService } from "src/app/filter/filter.service";
 import { ObservationService } from "../observation.service";
 import { SessionService } from "mage-web-app/http/session.service";
+import { EventPreference } from "core-lib-src/user";
 
 export type ObservationFormControl = UntypedFormControl & { definition: any };
 
@@ -87,9 +92,13 @@ export class ObservationEditComponent implements OnInit, OnChanges {
   @ViewChild("dragHandle", { static: true }) dragHandle: ElementRef;
   @ViewChildren("form") formElements: QueryList<ElementRef>;
 
+  private destroyRef = inject(DestroyRef);
+  private loadEventPreferences$ = new Subject<number>();
+
   event: any;
   formGroup: UntypedFormGroup;
   formDefinitions: any;
+  eventPreferences: EventPreference | null;
   timestampDefinition = {
     title: "",
     type: "date",
@@ -147,6 +156,20 @@ export class ObservationEditComponent implements OnInit, OnChanges {
       "handle",
       sanitizer.bypassSecurityTrustResourceUrl("assets/images/handle-24px.svg")
     );
+
+    this.loadEventPreferences$
+      .pipe(
+        distinctUntilChanged(),
+        switchMap((eventId) =>
+          this.userService
+            .getEventPreferences(eventId)
+            .pipe(catchError(() => of(null)))
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((preferences) => {
+        this.eventPreferences = preferences;
+      });
   }
 
   ngOnInit(): void {
@@ -188,9 +211,9 @@ export class ObservationEditComponent implements OnInit, OnChanges {
 
       this.toFormGroup(this.observation);
       this.updatePrimarySecondary();
+      this.loadEventPreferences$.next(this.event.id);
     }
   }
-
 
   hasEventUpdatePermission(): boolean {
     return this.sessionService.user.role.permissions.includes('DELETE_OBSERVATION')

--- a/web-app/src/app/user/user.service.spec.ts
+++ b/web-app/src/app/user/user.service.spec.ts
@@ -1,21 +1,43 @@
 import { TestBed } from '@angular/core/testing';
 import { UserService } from './user.service';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { EventPreference } from 'core-lib-src/user';
 
 describe('User Service Tests', () => {
+  let httpTestingController: HttpTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
     imports: [],
     providers: [UserService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     const service: UserService = TestBed.inject(UserService);
     expect(service).toBeTruthy();
+  });
+
+  describe('getEventPreferences', () => {
+    it('gets preferences for the given event', () => {
+      const service: UserService = TestBed.inject(UserService);
+      const eventPreference: EventPreference = { forms: { 1: { fields: { field1: { recentChoices: ['blue'] } } } } };
+
+      let result: EventPreference;
+      service.getEventPreferences(1).subscribe(preferences => result = preferences);
+
+      const req = httpTestingController.expectOne('/api/my/preferences/events/1');
+      expect(req.request.method).toEqual('GET');
+      req.flush(eventPreference);
+
+      expect(result).toEqual(eventPreference);
+    });
   });
 });

--- a/web-app/src/app/user/user.service.ts
+++ b/web-app/src/app/user/user.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpContext, HttpEvent, HttpParams } from '@angular/common/
 import { Injectable } from '@angular/core';
 import { Observable, Subject, tap } from 'rxjs';
 import { BYPASS_TOKEN, SUPPRESS_AUTH_DIALOG } from '../http/token.interceptor';
-import { User } from 'core-lib-src/user';
+import { EventPreference, User } from 'core-lib-src/user';
 import { SessionService } from 'mage-web-app/http/session.service';
 
 @Injectable({
@@ -186,6 +186,10 @@ export class UserService {
   getRecentEventId() {
     const recentEventIds = this.sessionService.user?.recentEventIds
     return recentEventIds?.length > 0 ? recentEventIds[0] : null
+  }
+
+  getEventPreferences(eventId: number): Observable<EventPreference> {
+    return this.httpClient.get<EventPreference>(`/api/my/preferences/events/${eventId}`)
   }
 
   logout(): Observable<string> {


### PR DESCRIPTION
## Summary

Dropdown and multiselect observation fields show a "Recents" group sourced 
from the user's own history for that event/form/field, recorded automatically
whenever they save an observation. Admins can cap how many recent choices are
kept per field.

## What changed

**Backend**
- New `UserPreference`/`EventPreference`/`FormPreference`/`FieldPreference`
  entities and a `MongoosePreferenceRepository`
- `SaveObservation` fires an `ObservationSaved` domain event on every
  create/update; a handler batches every dropdown/multiselect value on the
  saved observation into a single `UserPreferenceRepository` write, so
  recording is a server-side side effect of saving rather than a
  client-driven call
- `GET /api/my/preferences/events/:eventId`, gated by a new
  `RoleBasedUserPreferencesPermissionService`
- Form fields gain an admin-configurable `maxRecent` limit (default 5)

**Frontend**
- `observation-edit-select`/`observation-edit-multiselect` show a "Recents"
  options group, in the order the server returns (most-recent-first)
- Admin field editor exposes "Maximum Number of Recent Choices" for dropdown
  fields

## Test plan

- [x] Backend: `MongoosePreferenceRepository` (batched writes, recency
      ordering, truncation, per-field/form/event independence),
      `ObservationSaved` domain event dispatch and handler, app-layer
      permission/not-found handling, `RoleBasedUserPreferencesPermissionService`
- [x] Frontend: recents ordering and invalid-choice filtering in
      select/multiselect, `user.service` HTTP wiring, admin `field-dialog`
      `maxRecent` defaulting
