### PR TITLE
fix(service,web-app): make recent choices opt-in per field

### DIFF
--- a/service/src/adapters/preferences/adapters.preferences.db.mongoose.ts
+++ b/service/src/adapters/preferences/adapters.preferences.db.mongoose.ts
@@ -73,7 +73,7 @@ export class MongoosePreferenceRepository extends BaseMongooseRepository<UserPre
       const path = `events.${eventId}.forms.${formId}.fields.${fieldName}.recentChoices`
       const currentChoices = byPath[path] ?? preferences?.events?.[eventId]?.forms?.[formId]?.fields?.[fieldName]?.recentChoices ?? []
       const uniqueChoices = currentChoices.filter((currentChoice) => currentChoice !== choice)
-      byPath[path] = [choice, ...uniqueChoices].slice(0, entry.recentChoicesLimit || 5)
+      byPath[path] = [choice, ...uniqueChoices].slice(0, entry.recentChoicesLimit || 0)
       return byPath
     }, {} as Record<string, RecentChoice[]>)
 

--- a/service/src/app.impl/observations/app.impl.observations.ts
+++ b/service/src/app.impl/observations/app.impl.observations.ts
@@ -178,6 +178,7 @@ export function registerRecordRecentFormFieldChoicesHandler(domainEvents: EventE
         const formFields = observation.mageEvent.activeFieldsForForm(formEntry.formId) || []
         return formFields
           .filter((field) => field.type === FormFieldType.Dropdown || field.type === FormFieldType.MultiSelectDropdown)
+          .filter((field) => field.maxRecent && field.maxRecent > 0)
           .flatMap((field) => {
             const value = formEntry[field.name]
             const choices = Array.isArray(value) ? value : [value]

--- a/service/test/adapters/preferences/adapters.preferences.db.mongoose.test.ts
+++ b/service/test/adapters/preferences/adapters.preferences.db.mongoose.test.ts
@@ -54,7 +54,7 @@ describe('user preferences mongoose repository', function() {
     it('creates the preference document if none existed', async function() {
 
       const created = await repo.addRecentFormFieldChoices(userId, [
-        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 5 }
       ])
 
       expect(created.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['blue'])
@@ -62,31 +62,30 @@ describe('user preferences mongoose repository', function() {
 
     it('adds a new choice to the front of the list', async function() {
 
-      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
-      const updated = await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'green' }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 5 }])
+      const updated = await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'green', recentChoicesLimit: 5 }])
 
       expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['green', 'blue'])
     })
 
     it('moves a re-selected choice back to the front instead of duplicating it', async function() {
 
-      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
-      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'green' }])
-      const updated = await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 5 }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'green', recentChoicesLimit: 5 }])
+      const updated = await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 5 }])
 
       expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['blue', 'green'])
     })
 
-    it('truncates to the default limit of 5 when no limit is given', async function() {
+    it('records no recent choices when no limit is given', async function() {
 
-      for (const choice of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      for (const choice of ['a', 'b', 'c']) {
         await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice }])
       }
 
       const preferences = await repo.getPreferences(userId)
 
-      expect(preferences?.events[1].forms[1].fields['field1'].recentChoices)
-        .to.deep.equal(['f', 'e', 'd', 'c', 'b'])
+      expect(preferences?.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal([])
     })
 
     it('truncates to the given recentChoicesLimit', async function() {
@@ -101,12 +100,21 @@ describe('user preferences mongoose repository', function() {
         .to.deep.equal(['c', 'b'])
     })
 
+    it('records no recent choices when recentChoicesLimit is explicitly 0', async function() {
+
+      const updated = await repo.addRecentFormFieldChoices(userId, [
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 0 }
+      ])
+
+      expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal([])
+    })
+
     it('keeps preferences for different fields, forms, and events independent of each other', async function() {
 
-      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' }])
-      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field2', choice: 'big' }])
-      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 2, fieldName: 'field1', choice: 'square' }])
-      await repo.addRecentFormFieldChoices(userId, [{ eventId: 2, formId: 1, fieldName: 'field1', choice: 'north' }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 5 }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 1, fieldName: 'field2', choice: 'big', recentChoicesLimit: 5 }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 1, formId: 2, fieldName: 'field1', choice: 'square', recentChoicesLimit: 5 }])
+      await repo.addRecentFormFieldChoices(userId, [{ eventId: 2, formId: 1, fieldName: 'field1', choice: 'north', recentChoicesLimit: 5 }])
 
       const preferences = await repo.getPreferences(userId)
 
@@ -119,9 +127,9 @@ describe('user preferences mongoose repository', function() {
     it('applies multiple choices for one observation in a single write', async function() {
 
       const updated = await repo.addRecentFormFieldChoices(userId, [
-        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' },
-        { eventId: 1, formId: 1, fieldName: 'field2', choice: 'big' },
-        { eventId: 1, formId: 2, fieldName: 'field1', choice: 'square' }
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 5 },
+        { eventId: 1, formId: 1, fieldName: 'field2', choice: 'big', recentChoicesLimit: 5 },
+        { eventId: 1, formId: 2, fieldName: 'field1', choice: 'square', recentChoicesLimit: 5 }
       ])
 
       expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['blue'])
@@ -132,8 +140,8 @@ describe('user preferences mongoose repository', function() {
     it('applies repeated choices for the same field within one batch in order', async function() {
 
       const updated = await repo.addRecentFormFieldChoices(userId, [
-        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue' },
-        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'green' }
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'blue', recentChoicesLimit: 5 },
+        { eventId: 1, formId: 1, fieldName: 'field1', choice: 'green', recentChoicesLimit: 5 }
       ])
 
       expect(updated.events[1].forms[1].fields['field1'].recentChoices).to.deep.equal(['green', 'blue'])

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.html
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.html
@@ -127,9 +127,9 @@
     </div>
 
     <mat-form-field appearance="fill" *ngIf="field.type === 'dropdown' && !data.isMemberField">
-      <mat-label>Maximum Number of Recent Choices</mat-label>
+      <mat-label>Recent Choices Limit</mat-label>
       <input matInput type="number" [(ngModel)]="field.maxRecent" name="maxRecent" min="0">
-      <mat-hint>Maximum number of recent choices displayed first in the list.</mat-hint>
+      <mat-hint>Shown first in the list. Leave blank or 0 to disable.</mat-hint>
     </mat-form-field>
 
     <mat-form-field appearance="fill"

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.spec.ts
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.spec.ts
@@ -36,8 +36,8 @@ describe('FieldDialogComponent', () => {
       configureWith({ fieldTypes, attachmentAllowedTypes: [] });
     }));
 
-    it('defaults maxRecent to 5', () => {
-      expect(component.field.maxRecent).toEqual(5);
+    it('leaves maxRecent undefined so recent choices are off by default', () => {
+      expect(component.field.maxRecent).toBeUndefined();
     });
   });
 

--- a/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.ts
+++ b/web-app/src/app/admin/admin-event/admin-event-form/form-details/field-dialog/field-dialog.component.ts
@@ -62,8 +62,7 @@ export class FieldDialogComponent {
                 title: '',
                 required: false,
                 multiselect: false,
-                choices: [],
-                maxRecent: 5
+                choices: []
             };
         }
 

--- a/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.spec.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.spec.ts
@@ -26,6 +26,7 @@ class TestHostComponent {
     name: 'select',
     required: false,
     title: 'Colors',
+    maxRecent: 5,
     choices: [{
       title: 'red'
     }, {
@@ -137,6 +138,19 @@ describe('ObservationEditMultiselectComponent', () => {
 
       freshHost.component.recentChoices$.subscribe(recent => {
         expect(recent.map(c => c.title)).toEqual(['red'])
+        done()
+      })
+    })
+
+    it('ignores stale recent choices when the field no longer has recents enabled', (done) => {
+      const freshFixture = TestBed.createComponent(TestHostComponent)
+      const freshHost = freshFixture.componentInstance
+      freshHost.definition.maxRecent = undefined
+      freshHost.recentChoices = ['green', 'blue', 'red']
+      freshFixture.detectChanges()
+
+      freshHost.component.recentChoices$.subscribe(recent => {
+        expect(recent).toEqual([])
         done()
       })
     })

--- a/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-multiselect/observation-edit-multiselect.component.ts
@@ -15,7 +15,8 @@ interface MultiSelectField {
   title: string,
   name: string,
   required: boolean,
-  choices: Choice[]
+  choices: Choice[],
+  maxRecent?: number
 }
 
 @Component({
@@ -50,9 +51,11 @@ export class ObservationEditMultiselectComponent implements OnInit {
   ngOnInit(): void {
     this.control = this.formGroup.get(this.definition.name) as UntypedFormControl
 
-    this.recentChoicesFromDefinition = this.recentChoices
-      .map(recent => this.definition.choices.find(choice => choice.title === recent))
-      .filter(choice => !!choice)
+    this.recentChoicesFromDefinition = this.definition.maxRecent
+      ? this.recentChoices
+        .map(recent => this.definition.choices.find(choice => choice.title === recent))
+        .filter((choice): choice is Choice => choice !== undefined)
+      : []
 
     this.filteredChoices$ = this.choiceControl.valueChanges.pipe(
       startWith(''),

--- a/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.spec.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.spec.ts
@@ -33,6 +33,7 @@ class TestHostComponent {
   definition = {
     name: 'select',
     title: 'Colors',
+    maxRecent: 5,
     choices: [
       {
         title: 'red'
@@ -146,6 +147,22 @@ describe('ObservationEditSelectComponent', () => {
 
       freshHost.component.recentChoices$.subscribe(recent => {
         expect(recent.map(c => c.title)).toEqual(['red']);
+        done();
+      });
+    });
+
+    it('ignores stale recent choices when the field no longer has recents enabled', (done) => {
+      let freshFixture: ComponentFixture<TestHostComponent>;
+      let freshHost: TestHostComponent;
+
+      freshFixture = TestBed.createComponent(TestHostComponent);
+      freshHost = freshFixture.componentInstance;
+      freshHost.definition.maxRecent = undefined;
+      freshHost.recentChoices = ['green', 'blue', 'red'];
+      freshFixture.detectChanges();
+
+      freshHost.component.recentChoices$.subscribe(recent => {
+        expect(recent).toEqual([]);
         done();
       });
     });

--- a/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.ts
+++ b/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.ts
@@ -12,7 +12,8 @@ interface SelectField {
   title: string,
   name: string,
   required: boolean,
-  choices: Choice[]
+  choices: Choice[],
+  maxRecent?: number
 }
 
 @Component({
@@ -40,9 +41,11 @@ export class ObservationEditSelectComponent implements OnInit {
   recentChoices$: Observable<any[]>;
 
   ngOnInit(): void {
-    this.recentChoicesFromDefinition = this.recentChoices
-      .map(recent => this.definition.choices.find(choice => choice.title === recent))
-      .filter(choice => !!choice)
+    this.recentChoicesFromDefinition = this.definition.maxRecent
+      ? this.recentChoices
+        .map(recent => this.definition.choices.find(choice => choice.title === recent))
+        .filter((choice): choice is Choice => choice !== undefined)
+      : []
 
     this.filteredChoices$ = this.searchControl.valueChanges.pipe(
       startWith(''),


### PR DESCRIPTION
## Summary

A field's recent-choices limit (`maxRecent`) previously used `recentChoicesLimit || 5`
as its fallback, which treats an explicit `0` the same as "unset" and silently
defaults to 5. That also meant a field's recents kept showing in the observation
edit form even after an admin cleared the setting, since the read path and the
client both just displayed whatever was already stored, with no check against
the field's current configuration.

This makes recent choices strictly opt-in, per field, with no hidden default:

- Blank or `0` now both mean "no recents" server-side; the save handler skips
  fields with no configured limit entirely instead of recording choices and
  immediately truncating them to empty
- The admin field editor no longer pre-fills `maxRecent: 5` for new fields, so
  there's no asymmetry between new and existing fields — every field requires
  an explicit opt-in
- The observation edit form now checks the field definition's `maxRecent`
  before showing the "Recents" group, so stale choices recorded before a
  field's setting was cleared no longer appear
