### PR TITLE
fix(web-app): save vertical space in select/optgroup UI

### DIFF
--- a/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.html
+++ b/web-app/src/app/observation/observation-edit/observation-edit-select/observation-edit-select.component.html
@@ -5,7 +5,7 @@
       <ngx-mat-select-search [formControl]="searchControl" placeholderLabel="{{definition.title}}" noEntriesFoundLabel=""></ngx-mat-select-search>
     </mat-option>
 
-    <mat-option [value]="null"></mat-option>
+    <mat-option *ngIf="!definition.required" [value]="null"></mat-option>
     <ng-container *ngIf="recentChoices$ | async as recentChoices">
       <mat-optgroup [label]="'Recents'" *ngIf="recentChoices.length !== 0">
         <mat-option *ngFor="let choice of recentChoices" [value]="choice.title">

--- a/web-app/src/theme.scss
+++ b/web-app/src/theme.scss
@@ -30,3 +30,10 @@ html {
 @include mat.list-overrides((
   active-indicator-shape: var(--mat-sys-corner-extra-small),
 ));
+
+// Angular Material's MDC-based mat-optgroup has no density token for its
+// label row (min-height/padding are hardcoded at 48px), so shrink it here.
+.mat-mdc-optgroup .mat-mdc-optgroup-label {
+  min-height: 32px;
+  padding: 0 16px;
+}


### PR DESCRIPTION
## Summary
- Hide the blank clear-option in `mat-select` fields when the field is required, so a required dropdown can't be left in an invalid empty state via that option
- Shrink the `mat-optgroup` label row (MDC hardcodes it at 48px with no density token) to free up vertical space so more choices are visible in long dropdowns without scrolling
