### PR TITLE
fix(web-app): cap observation edit error banner height and make it scrollable

### DIFF
--- a/web-app/src/app/observation/observation-edit/observation-edit.component.scss
+++ b/web-app/src/app/observation/observation-edit/observation-edit.component.scss
@@ -50,12 +50,13 @@ mat-toolbar {
   position: sticky;
   top: 0;
   z-index: 10;
+  max-height: 240px;
 }
 
 .edit-banner-container {
   margin: 16px;
-  display: flex;
-  flex-direction: row;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .edit-banner-content {


### PR DESCRIPTION
## Summary
- Caps the observation edit error banner at `max-height: 240px` and makes `.edit-banner-container` scroll internally (`flex: 1; overflow-y: auto`) instead of growing unbounded.
- Action buttons (`.edit-banner-actions`) stay pinned below the scrollable content, so they're never pushed out of view by a long error summary.

## Test plan
- [ ] Trigger an observation save validation error with a long/multi-line message and confirm the banner scrolls instead of expanding past 240px
- [ ] Confirm the action buttons remain visible and clickable while the error content scrolls
- [ ] Confirm short error messages still render normally with no visual regression
