### PR TITLE
fix(web-app): prevent fixed-width marker icon from stretching

### DIFF
--- a/web-app/src/app/map/marker/FixedWidthIcon.ts
+++ b/web-app/src/app/map/marker/FixedWidthIcon.ts
@@ -23,6 +23,7 @@ export class FixedWidthIcon extends DivIcon {
     const img = document.createElement('img')
     img.className = "mage-icon-image"
     img.style.width = this.options.iconWidth + 'px'
+    img.style.objectFit = 'contain'
     img.src = this.options.iconUrl;
 
     img.onload = (event: any) => {


### PR DESCRIPTION
## Summary
- Set `object-fit: contain` on the marker `<img>` in `FixedWidthIcon` so non-square icon images keep their aspect ratio instead of stretching to fill the fixed width/height.

## Test plan
- [ ] Verify map markers with non-square icons render without distortion