### PR TITLE
fix(web-app): don't send literal "undefined"/"null" date query params

### DIFF
--- a/web-app/src/app/observation/observation.service.spec.ts
+++ b/web-app/src/app/observation/observation.service.spec.ts
@@ -1,21 +1,65 @@
 import { TestBed } from '@angular/core/testing';
 import { ObservationService } from './observation.service';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 describe('Observation Service', () => {
+  let service: ObservationService;
+  let httpMock: HttpTestingController;
+  const event: any = { id: 1, forms: [] };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
     imports: [],
     providers: [ObservationService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 });
+    service = TestBed.inject(ObservationService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
+    httpMock.verify();
   });
 
    it('should be created', () => {
-     const service: ObservationService = TestBed.inject(ObservationService);
      expect(service).toBeTruthy();
    });
+
+  it('should not include date params when no interval is provided', () => {
+    service.getObservationsForEvent(event, {}).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === '/api/events/1/observations');
+    expect(req.request.params.has('observationStartDate')).toBeFalse();
+    expect(req.request.params.has('observationEndDate')).toBeFalse();
+    req.flush([]);
+  });
+
+  it('should not send literal "undefined" or "null" date params when the interval has no start or end', () => {
+    service.getObservationsForEvent(event, { interval: { start: null, end: undefined } }).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === '/api/events/1/observations');
+    expect(req.request.params.has('observationStartDate')).toBeFalse();
+    expect(req.request.params.has('observationEndDate')).toBeFalse();
+    req.flush([]);
+  });
+
+  it('should include only the date params that are present on the interval', () => {
+    service.getObservationsForEvent(event, { interval: { start: '2026-01-01T00:00:00.000Z' } }).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === '/api/events/1/observations');
+    expect(req.request.params.get('observationStartDate')).toBe('2026-01-01T00:00:00.000Z');
+    expect(req.request.params.has('observationEndDate')).toBeFalse();
+    req.flush([]);
+  });
+
+  it('should include both date params when the interval has a start and end', () => {
+    service.getObservationsForEvent(event, {
+      interval: { start: '2026-01-01T00:00:00.000Z', end: '2026-01-02T00:00:00.000Z' }
+    }).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === '/api/events/1/observations');
+    expect(req.request.params.get('observationStartDate')).toBe('2026-01-01T00:00:00.000Z');
+    expect(req.request.params.get('observationEndDate')).toBe('2026-01-02T00:00:00.000Z');
+    req.flush([]);
+  });
 });

--- a/web-app/src/app/observation/observation.service.ts
+++ b/web-app/src/app/observation/observation.service.ts
@@ -28,18 +28,20 @@ export class ObservationService {
   }
 
   getObservationsForEvent(event: MageEvent, options: any): Observable<any> {
-    const parameters: any = {
-      eventId: event.id,
-      states: "active",
-      populate: "true",
-    };
-    if (options.interval) {
-      parameters.observationStartDate = options.interval.start;
-      parameters.observationEndDate = options.interval.end;
+    let params = new HttpParams()
+      .set("eventId", event.id.toString())
+      .set("states", "active")
+      .set("populate", "true");
+
+    if (options.interval?.start) {
+      params = params.set("observationStartDate", options.interval.start);
+    }
+    if (options.interval?.end) {
+      params = params.set("observationEndDate", options.interval.end);
     }
 
     return this.client
-      .get<any>(`/api/events/${event.id}/observations`, { params: parameters })
+      .get<any>(`/api/events/${event.id}/observations`, { params })
       .pipe(
         map((observations: any) => {
           return this.transformObservations(observations, event);


### PR DESCRIPTION
## Summary
- `getObservationsForEvent` unconditionally set `observationStartDate`/`observationEndDate` on a plain params object whenever `options.interval` was truthy. `HttpParams.fromObject` serializes every key it's given via `String(value)`, so a missing start/end (e.g. a 'custom' date filter with no dates chosen) sent the literal string `"undefined"` or `"null"` as the query value.
- Build the request params with `HttpParams.set` instead, only including `observationStartDate`/`observationEndDate` when they're actually present.

## Test plan
- [x] `ng test` — observation.service.spec.ts (5/5 passing), covering: no interval, interval with no start/end, start only, and both start and end
