### PR TITLE
fix(service): await attachment reads during CSV export

### DIFF
--- a/service/src/app.impl/exports/app.impl.exports.csv.ts
+++ b/service/src/app.impl/exports/app.impl.exports.csv.ts
@@ -219,8 +219,9 @@ export class CsvExportTransform implements ExportTransform {
     })
 
     if (observation.attachments) {
+      const evaluatedObservation = Observation.evaluate(observation, event)
       for (const attachment of observation.attachments) {
-        const content = await this.attachmentStore.readContent(attachment.id, Observation.evaluate(observation, event))
+        const content = await this.attachmentStore.readContent(attachment.id, evaluatedObservation)
 
         if (content instanceof Readable) {
           const name = attachment.name || `Attachment_${attachment.id}`

--- a/service/src/app.impl/exports/app.impl.exports.csv.ts
+++ b/service/src/app.impl/exports/app.impl.exports.csv.ts
@@ -219,16 +219,16 @@ export class CsvExportTransform implements ExportTransform {
     })
 
     if (observation.attachments) {
-      observation.attachments
-        .forEach(async attachment => {
-          const content = await this.attachmentStore.readContent(attachment.id, Observation.evaluate(observation, event))
-          if (content instanceof Readable) {
-            const name = attachment.name || `Attachment_${attachment.id}`
-            column.attachment = name
-            column.attachmentOriginalName = attachment.name
-            archive.append(content, { name })
-          }
-        })
+      for (const attachment of observation.attachments) {
+        const content = await this.attachmentStore.readContent(attachment.id, Observation.evaluate(observation, event))
+
+        if (content instanceof Readable) {
+          const name = attachment.name || `Attachment_${attachment.id}`
+          column.attachment = name
+          column.attachmentOriginalName = attachment.name
+          archive.append(content, { name })
+        }
+      }
     }
 
     return column


### PR DESCRIPTION
## Summary
- `observation.attachments.forEach(async attachment => {...})` doesn't await its async callback, so `exportColumn` could return before attachment content had actually been read and appended to the export archive — attachments could be missing or incomplete in CSV exports depending on timing.
- Replace the `forEach` with a `for...of` loop so each attachment's `readContent`/`archive.append` is properly awaited in order before the column is returned.

## Test plan
- [ ] Export an event with observations that have attachments to CSV and confirm all attachments are present in the resulting archive
