### PR TITLE
fix(service): let users get/download/delete their own exports

### DIFF
--- a/service/src/app.api/exports/app.api.exports.ts
+++ b/service/src/app.api/exports/app.api.exports.ts
@@ -47,8 +47,8 @@ export interface DeleteExport {
 
 export interface ExportAppLayerPermissionService {
   ensureCreateExportPermission(context: AppRequestContext): Promise<null | PermissionDeniedError>
-  ensureGetExportContentPermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError>
   ensureGetMyExportPermission(context: AppRequestContext): Promise<null | PermissionDeniedError>
+  ensureGetMyExportContentPermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError>
   ensureDeleteMyExportPermission(context: AppRequestContext): Promise<null | PermissionDeniedError>
 }
 

--- a/service/src/app.impl/exports/app.impl.exports.ts
+++ b/service/src/app.impl/exports/app.impl.exports.ts
@@ -26,7 +26,7 @@ export function GetExportContent(
   permissionService: api.ExportAppLayerPermissionService
 ): api.GetExportContent {
   return async function readExportContent(req: api.GetExportContentRequest): ReturnType<api.GetExportContent> {
-    const denied = await permissionService.ensureGetExportContentPermission(req.context)
+    const denied = await permissionService.ensureGetMyExportContentPermission(req.context)
     if (denied) {
       return AppResponse.error(denied)
     }

--- a/service/src/permissions/permissions.exports.ts
+++ b/service/src/permissions/permissions.exports.ts
@@ -1,10 +1,9 @@
 import { permissionDenied, PermissionDeniedError } from '../app.api/app.api.errors'
 import { AppRequestContext } from '../app.api/app.api.global'
 import { CreateExportRequestContext, ExportAppLayerPermissionService } from '../app.api/exports/app.api.exports'
-import { ExportPermission } from '../entities/authorization/entities.permissions'
 import { EventAccessType } from '../entities/events/entities.events'
 import { EventPermissionServiceImpl } from './permissions.events'
-import { UserWithRole, ensureContextUserHasPermission } from './permissions.role-based.base'
+import { UserWithRole } from './permissions.role-based.base'
 
 export class RoleBasedExportsPermissionService implements ExportAppLayerPermissionService {
 
@@ -17,20 +16,22 @@ export class RoleBasedExportsPermissionService implements ExportAppLayerPermissi
     if (await this.eventPermissions.userHasEventPermission(context.mageEvent, user.id, EventAccessType.Read)) {
       return null
     }
-    
-    return permissionDenied('CREATE_EXPORT', user.id)
+
+    return permissionDenied('CREATE EXPORT', user.id)
   }
 
   async ensureGetMyExportPermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError> {
-    return ensureContextUserHasPermission(context, ExportPermission.READ_EXPORT)
+    const user = context.requestingPrincipal()
+    return user ? null : permissionDenied('READ EXPORT', 'principal')
   }
 
-  async ensureGetExportContentPermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError> {
-    return ensureContextUserHasPermission(context, ExportPermission.READ_EXPORT)
+  async ensureGetMyExportContentPermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError> {
+    const user = context.requestingPrincipal()
+    return user ? null : permissionDenied('READ EXPORT CONTENT', 'principal')
   }
 
   async ensureDeleteMyExportPermission(context: AppRequestContext<UserWithRole>): Promise<null | PermissionDeniedError> {
-    // TODO, shouldn't need this permission to delete your own export
-    return ensureContextUserHasPermission(context, ExportPermission.DELETE_EXPORT)
+    const user = context.requestingPrincipal()
+    return user ? null : permissionDenied('DELETE EXPORT', 'principal')
   }
 }

--- a/service/test/app/exports/app.exports.test.ts
+++ b/service/test/app/exports/app.exports.test.ts
@@ -191,7 +191,7 @@ describe('export use case interactions', function() {
       const bytes: NodeJS.ReadableStream = Readable.from(bytesBuffer)
 
       const req: api.GetExportContentRequest = requestBy(mockUser, { exportId: exp.id })
-      permissions.ensureGetExportContentPermission(req.context).resolves(null)
+      permissions.ensureGetMyExportContentPermission(req.context).resolves(null)
       store.readContent(exp).resolves(bytes)
 
       repository.getExportForUser(exp.id, mockUser.id).resolves(exp)

--- a/service/test/permissions/permissions.exports.test.ts
+++ b/service/test/permissions/permissions.exports.test.ts
@@ -1,0 +1,65 @@
+import { RoleBasedExportsPermissionService } from '../../lib/permissions/permissions.exports'
+import { EventPermissionServiceImpl } from '../../lib/permissions/permissions.events'
+import { AppRequestContext } from '../../lib/app.api/app.api.global'
+import { UserWithRole } from '../../lib/permissions/permissions.role-based.base'
+import { expect } from 'chai'
+import { ErrPermissionDenied } from '../../lib/app.api/app.api.errors'
+import { Substitute as Sub, SubstituteOf } from '@fluffy-spoon/substitute'
+
+describe('export role-based permission service', function() {
+
+  let eventPermissions: SubstituteOf<EventPermissionServiceImpl>
+  let permissions: RoleBasedExportsPermissionService
+
+  beforeEach(function() {
+    eventPermissions = Sub.for<EventPermissionServiceImpl>()
+    permissions = new RoleBasedExportsPermissionService(eventPermissions)
+  })
+
+  function contextFor(principal: UserWithRole | null): AppRequestContext<UserWithRole> {
+    return {
+      requestToken: Symbol(),
+      requestingPrincipal: () => principal as UserWithRole,
+      locale() { return null }
+    }
+  }
+
+  it('denies get my exports permission for an anonymous principal', async function() {
+    const denied = await permissions.ensureGetMyExportPermission(contextFor(null))
+
+    expect(denied?.code).to.equal(ErrPermissionDenied)
+  })
+
+  it('allows get my exports permission for any authenticated user, regardless of role permissions', async function() {
+    const user = { username: 'noRolePermissions', roleId: { permissions: [] } } as unknown as UserWithRole
+    const denied = await permissions.ensureGetMyExportPermission(contextFor(user))
+
+    expect(denied).to.be.null
+  })
+
+  it('denies get my export content permission for an anonymous principal', async function() {
+    const denied = await permissions.ensureGetMyExportContentPermission(contextFor(null))
+
+    expect(denied?.code).to.equal(ErrPermissionDenied)
+  })
+
+  it('allows get my export content permission for any authenticated user, regardless of role permissions', async function() {
+    const user = { username: 'noRolePermissions', roleId: { permissions: [] } } as unknown as UserWithRole
+    const denied = await permissions.ensureGetMyExportContentPermission(contextFor(user))
+
+    expect(denied).to.be.null
+  })
+
+  it('denies delete my export permission for an anonymous principal', async function() {
+    const denied = await permissions.ensureDeleteMyExportPermission(contextFor(null))
+
+    expect(denied?.code).to.equal(ErrPermissionDenied)
+  })
+
+  it('allows delete my export permission for any authenticated user, regardless of role permissions', async function() {
+    const user = { username: 'noRolePermissions', roleId: { permissions: [] } } as unknown as UserWithRole
+    const denied = await permissions.ensureDeleteMyExportPermission(contextFor(user))
+
+    expect(denied).to.be.null
+  })
+})


### PR DESCRIPTION
## Summary
- `ensureGetMyExportPermission`, `ensureGetExportContentPermission`, and `ensureDeleteMyExportPermission` required the `READ_EXPORT`/`DELETE_EXPORT` role permissions, which the `add-export-permissions` migration only ever grants to `ADMIN_ROLE`.
- Export creation is gated on event access rather than a role permission, so non-admin users could create exports but then could never list, download, or delete their own — despite ownership already being enforced independently at the repository layer (`getExportForUser`/`deleteExportForUser`/`getExportsForUser` all scope by the requesting user's id).
- Simplify these three checks to just require an authenticated principal, and rename `ensureGetExportContentPermission` → `ensureGetMyExportContentPermission` for consistency with the other "my export" checks.
- Add test coverage for `RoleBasedExportsPermissionService`, which previously had none.

## Test plan
- [x] `npm run test:build && npx mocha --config .mocharc.js --grep "export"` — 31 passing, 1 pre-existing pending (unrelated)
- [ ] Manually verify a non-admin user can list, download, and delete their own exports
