### PR TITLE
fix(web-app): truncate long plugin names in the admin sidebar nav

### DIFF
--- a/web-app/src/app/admin/admin-navigation/admin-navigation.component.html
+++ b/web-app/src/app/admin/admin-navigation/admin-navigation.component.html
@@ -114,7 +114,7 @@
           <img *ngIf="plugin.icon?.path" class="nav-plugin-icon" [src]="'/ui_plugins/' + plugin.id + '/' + plugin.icon.path" [alt]="plugin.title" />
           <mat-icon *ngIf="plugin.icon?.matIconName" fontSet="material-symbols-outlined">{{ plugin.icon.matIconName }}</mat-icon>
           <mat-icon *ngIf="!plugin.icon?.path && !plugin.icon?.matIconName" fontSet="material-symbols-outlined">extension</mat-icon>
-          <span class="nav-label">{{ plugin.title }}</span>
+          <span class="nav-label nav-label--truncate">{{ plugin.title }}</span>
         </a>
       </div>
     </div>

--- a/web-app/src/app/admin/admin-navigation/admin-navigation.component.scss
+++ b/web-app/src/app/admin/admin-navigation/admin-navigation.component.scss
@@ -72,6 +72,14 @@
   --mat-badge-text-color: var(--mat-sys-on-tertiary);
 }
 
+.nav-label--truncate {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .nav-plugin-icon {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary
- Long plugin titles in the admin sidebar nav wrapped onto a second line, but `.nav-item` has a fixed `36px` height and no overflow handling, so the wrapped line spilled out and visually overlapped the nav item below it.
- Truncate the plugin label with an ellipsis instead of wrapping, scoped to a new `.nav-label--truncate` modifier class rather than the shared `.nav-label` class — `.nav-label` is also used by the Users/Devices nav items which carry a `matBadge`, and `overflow: hidden` there would risk clipping the badge indicator.

## Test plan
- [ ] Edit a plugin nav label's text in devtools to something long and confirm it truncates cleanly with no overlap into the row below
- [ ] Confirm Users/Devices unread-count badges still render correctly
