### PR TITLE
feat(web-app): add observation filter types and event-member-filter component

### DIFF
--- a/web-app/src/app/entities/observation/filter/entities.observation.filter.ts
+++ b/web-app/src/app/entities/observation/filter/entities.observation.filter.ts
@@ -1,0 +1,58 @@
+export type BinaryOperator =
+  | "="
+  | "!="
+  | ">"
+  | ">="
+  | "<"
+  | "<="
+  | "LIKE"
+
+export type ArrayOperator = "IN" | "NOT IN"
+
+export type RangeOperator = "BETWEEN"
+
+export type NullOperator = "IS NULL" | "IS NOT NULL"
+
+export type BinaryCondition = {
+  formId: number
+  field: string
+  operator: BinaryOperator
+  value: string | number | boolean
+}
+
+export type ArrayCondition = {
+  formId: number
+  field: string
+  operator: ArrayOperator
+  value: (string | number | boolean)[]
+}
+
+export type RangeCondition = {
+  formId: number
+  field: string
+  operator: RangeOperator
+  value: [string | number, string | number]
+}
+
+export type NullCondition = {
+  formId: number
+  field: string
+  operator: NullOperator
+}
+
+export type SimpleCondition =
+  | BinaryCondition
+  | ArrayCondition
+  | RangeCondition
+  | NullCondition
+
+export type CompoundCondition =
+  | { and: Condition[] }
+  | { or: Condition[] }
+
+export type Condition = SimpleCondition | CompoundCondition
+
+export type ObservationFieldFilter = {
+  condition?: Condition
+  keyword?: string
+}

--- a/web-app/src/app/event/event-member-filter.component.html
+++ b/web-app/src/app/event/event-member-filter.component.html
@@ -1,0 +1,39 @@
+<mat-form-field appearance="fill" class="member-filter-field">
+  <mat-label>Filter by Team or User</mat-label>
+
+  <mat-chip-grid #chipGridMember>
+    @for (item of selected(); track item.type + ':' + item.id) {
+      <mat-chip-row [removable]="true" (removed)="remove(item)">
+        <mat-icon matChipAvatar>{{ item.type === 'team' ? 'group' : 'person' }}</mat-icon>
+        {{ item.display }}
+        <mat-icon matChipRemove>cancel</mat-icon>
+      </mat-chip-row>
+    }
+
+    <input
+      #memberInput
+      matInput
+      [formControl]="inputControl"
+      [matAutocomplete]="auto"
+      [matChipInputFor]="chipGridMember"
+      [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+      placeholder="Search teams or members..."/>
+  </mat-chip-grid>
+
+  <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn" (optionSelected)="onOptionSelected($event)">
+    @for (group of filteredGroups(); track group.label) {
+      <mat-optgroup [label]="group.label">
+        @for (option of group.options; track option.type + ':' + option.id) {
+          <mat-option [value]="option">
+            <span class="member-option">
+              <mat-icon>{{ option.type === 'team' ? 'group' : 'person' }}</mat-icon>
+              {{ option.display }}
+            </span>
+          </mat-option>
+        }
+      </mat-optgroup>
+    }
+  </mat-autocomplete>
+
+  <mat-hint>Filter observations by team or user</mat-hint>
+</mat-form-field>

--- a/web-app/src/app/event/event-member-filter.component.scss
+++ b/web-app/src/app/event/event-member-filter.component.scss
@@ -1,0 +1,12 @@
+.member-filter-field {
+  width: 100%;
+
+  mat-icon {
+    margin-right: 4px;
+  }
+}
+
+.member-option {
+  display: flex;
+  align-items: center;
+}

--- a/web-app/src/app/event/event-member-filter.component.spec.ts
+++ b/web-app/src/app/event/event-member-filter.component.spec.ts
@@ -1,0 +1,228 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { of } from 'rxjs'
+import { EventService } from './event.service'
+import { EventMemberFilterComponent, MemberFilterSelection } from './event-member-filter.component'
+
+const SEARCH_DEBOUNCE_MS = 250
+
+const team1 = { id: 'team1', name: 'Alpha Team' }
+const team2 = { id: 'team2', name: 'Bravo Team' }
+
+const eventMembers = [
+  { id: 'u1', displayName: 'Alice Smith', username: 'asmith' },
+  { id: 'u2', displayName: 'Bob Jones', username: 'bjones' },
+  { id: 'u3', displayName: 'Carol White', username: 'cwhite' }
+]
+
+function createEventServiceSpy(): jasmine.SpyObj<EventService> {
+  const spy = jasmine.createSpyObj<EventService>('EventService', ['getMembers', 'searchMembers'])
+  spy.getMembers.and.returnValue(of(eventMembers as any))
+  spy.searchMembers.and.callFake((_event: any, term: string) => {
+    const q = (term || '').toLowerCase()
+    return of(eventMembers.filter(u => u.displayName.toLowerCase().includes(q)) as any)
+  })
+  return spy
+}
+
+describe('EventMemberFilterComponent', () => {
+  let component: EventMemberFilterComponent
+  let fixture: ComponentFixture<EventMemberFilterComponent>
+  let eventService: jasmine.SpyObj<EventService>
+
+  beforeEach(async () => {
+    eventService = createEventServiceSpy()
+
+    await TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        EventMemberFilterComponent
+      ],
+      providers: [
+        { provide: EventService, useValue: eventService }
+      ]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(EventMemberFilterComponent)
+    component = fixture.componentInstance
+  })
+
+  function setEventAndTeams(event: any, teams: any[]): void {
+    fixture.componentRef.setInput('event', event)
+    fixture.componentRef.setInput('teams', teams)
+    fixture.detectChanges()
+  }
+
+  function setEventTeamsAndFilter(event: any, teams: any[], filter: MemberFilterSelection): void {
+    fixture.componentRef.setInput('filter', filter)
+    fixture.componentRef.setInput('event', event)
+    fixture.componentRef.setInput('teams', teams)
+    fixture.detectChanges()
+  }
+
+  it('should create', () => {
+    fixture.detectChanges()
+    expect(component).toBeTruthy()
+  })
+
+  it('loads teams from input and searches members from the event service on input change', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1, team2])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    const groups = component.filteredGroups()
+    const teamGroup = groups.find(g => g.label === 'Teams')
+    const memberGroup = groups.find(g => g.label === 'Members')
+
+    expect(teamGroup?.options.length).toBe(2)
+    expect(teamGroup?.options.map(o => o.display)).toEqual(jasmine.arrayContaining(['Alpha Team', 'Bravo Team']))
+    expect(memberGroup?.options.length).toBe(3)
+    expect(eventService.searchMembers).toHaveBeenCalledWith({ id: 1 }, '')
+  }))
+
+  it('shows no groups when teams input is empty', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    expect(component.filteredGroups().length).toBe(0)
+    expect(eventService.searchMembers).not.toHaveBeenCalled()
+  }))
+
+  it('shows no groups when event input is not set', fakeAsync(() => {
+    setEventAndTeams(null, [team1])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    expect(component.filteredGroups().length).toBe(0)
+    expect(eventService.searchMembers).not.toHaveBeenCalled()
+  }))
+
+  it('searches the server for members as the query changes, debounced', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1, team2])
+    tick(SEARCH_DEBOUNCE_MS)
+    eventService.searchMembers.calls.reset()
+
+    component.inputControl.setValue('ali')
+    fixture.detectChanges()
+    tick(SEARCH_DEBOUNCE_MS)
+
+    expect(eventService.searchMembers).toHaveBeenCalledWith({ id: 1 }, 'ali')
+    const groups = component.filteredGroups()
+    const memberGroup = groups.find(g => g.label === 'Members')
+    expect(memberGroup?.options.length).toBe(1)
+    expect(memberGroup?.options[0].display).toBe('Alice Smith')
+  }))
+
+  it('filters team groups locally by the search query', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1, team2])
+    tick(SEARCH_DEBOUNCE_MS)
+    component.inputControl.setValue('alpha')
+    tick(SEARCH_DEBOUNCE_MS)
+
+    const groups = component.filteredGroups()
+    const teamGroup = groups.find(g => g.label === 'Teams')
+    expect(teamGroup?.options.length).toBe(1)
+    expect(teamGroup?.options[0].display).toBe('Alpha Team')
+  }))
+
+  it('emits teamIds and userIds when a team is selected', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1, team2])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    const emitted: MemberFilterSelection[] = []
+    component.memberFilterChanged.subscribe(s => emitted.push(s))
+
+    component.onOptionSelected({ option: { value: { type: 'team', id: 'team1', display: 'Alpha Team', raw: team1 } } } as any)
+
+    expect(emitted.length).toBe(1)
+    expect(emitted[0].teamIds).toEqual(['team1'])
+    expect(emitted[0].userIds).toEqual([])
+  }))
+
+  it('emits teamIds and userIds when a user is selected', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    const emitted: MemberFilterSelection[] = []
+    component.memberFilterChanged.subscribe(s => emitted.push(s))
+
+    const userOption = { type: 'user' as const, id: 'u1', display: 'Alice Smith', raw: eventMembers[0] }
+    component.onOptionSelected({ option: { value: userOption } } as any)
+
+    expect(emitted.length).toBe(1)
+    expect(emitted[0].teamIds).toEqual([])
+    expect(emitted[0].userIds).toEqual(['u1'])
+  }))
+
+  it('does not add duplicate selections', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    const teamOption = { type: 'team' as const, id: 'team1', display: 'Alpha Team', raw: team1 }
+    component.onOptionSelected({ option: { value: teamOption } } as any)
+    component.onOptionSelected({ option: { value: teamOption } } as any)
+
+    expect(component.selected().length).toBe(1)
+  }))
+
+  it('removes a selection and emits', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    const emitted: MemberFilterSelection[] = []
+    component.memberFilterChanged.subscribe(s => emitted.push(s))
+
+    const teamOption = { type: 'team' as const, id: 'team1', display: 'Alpha Team', raw: team1 }
+    component.onOptionSelected({ option: { value: teamOption } } as any)
+    component.remove(teamOption)
+
+    expect(component.selected().length).toBe(0)
+    expect(emitted[emitted.length - 1].teamIds).toEqual([])
+  }))
+
+  it('resets selection when inputs change', fakeAsync(() => {
+    setEventAndTeams({ id: 1 }, [team1])
+    tick(SEARCH_DEBOUNCE_MS)
+
+    const teamOption = { type: 'team' as const, id: 'team1', display: 'Alpha Team', raw: team1 }
+    component.onOptionSelected({ option: { value: teamOption } } as any)
+    expect(component.selected().length).toBe(1)
+
+    setEventAndTeams({ id: 1 }, [team2])
+    tick(SEARCH_DEBOUNCE_MS)
+    expect(component.selected().length).toBe(0)
+  }))
+
+  describe('pre-population from filter input', () => {
+
+    it('pre-selects teams from saved filter', fakeAsync(() => {
+      setEventTeamsAndFilter({ id: 1 }, [team1, team2], { teamIds: ['team1'], userIds: [] })
+      tick(SEARCH_DEBOUNCE_MS)
+      expect(component.selected().length).toBe(1)
+      expect(component.selected()[0].id).toBe('team1')
+      expect(component.selected()[0].type).toBe('team')
+      expect(eventService.getMembers).not.toHaveBeenCalled()
+    }))
+
+    it('pre-selects users from saved filter using a bulk lookup', fakeAsync(() => {
+      setEventTeamsAndFilter({ id: 1 }, [team1], { teamIds: [], userIds: ['u1'] })
+      tick(SEARCH_DEBOUNCE_MS)
+      expect(component.selected().length).toBe(1)
+      expect(component.selected()[0].id).toBe('u1')
+      expect(component.selected()[0].type).toBe('user')
+      expect(eventService.getMembers).toHaveBeenCalledWith({ id: 1 })
+    }))
+
+    it('pre-selects both teams and users from saved filter', fakeAsync(() => {
+      setEventTeamsAndFilter({ id: 1 }, [team1], { teamIds: ['team1'], userIds: ['u2'] })
+      tick(SEARCH_DEBOUNCE_MS)
+      expect(component.selected().length).toBe(2)
+      expect(component.selected().map(s => s.id)).toContain('team1')
+      expect(component.selected().map(s => s.id)).toContain('u2')
+    }))
+
+    it('makes no selection when filter has ids not present in the loaded options', fakeAsync(() => {
+      setEventTeamsAndFilter({ id: 1 }, [team1], { teamIds: ['unknown-team'], userIds: ['unknown-user'] })
+      tick(SEARCH_DEBOUNCE_MS)
+      expect(component.selected().length).toBe(0)
+    }))
+  })
+})

--- a/web-app/src/app/event/event-member-filter.component.ts
+++ b/web-app/src/app/event/event-member-filter.component.ts
@@ -1,0 +1,181 @@
+import { Component, ElementRef, ViewChild, computed, effect, input, output, signal } from '@angular/core'
+import { FormControl, ReactiveFormsModule } from '@angular/forms'
+import { COMMA, ENTER } from '@angular/cdk/keycodes'
+import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete'
+import { MatChipsModule } from '@angular/material/chips'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatIconModule } from '@angular/material/icon'
+import { MatInputModule } from '@angular/material/input'
+import { User } from '@ngageoint/mage.web-core-lib/user'
+import { toSignal } from '@angular/core/rxjs-interop'
+import { Subject, debounceTime, of, switchMap } from 'rxjs'
+import { EventService } from './event.service'
+import { Team } from '../filter/filter.types'
+
+const SEARCH_DEBOUNCE_MS = 250
+
+export interface MemberFilterSelection {
+  teamIds: string[]
+  userIds: string[]
+}
+
+type MemberOptionType = 'team' | 'user'
+
+interface MemberOption {
+  type: MemberOptionType
+  id: string
+  display: string
+  raw: any
+}
+
+interface MemberOptionGroup {
+  label: string
+  options: MemberOption[]
+}
+
+@Component({
+  selector: 'event-member-filter',
+  templateUrl: './event-member-filter.component.html',
+  styleUrls: ['./event-member-filter.component.scss'],
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatAutocompleteModule,
+    MatChipsModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule
+  ]
+})
+export class EventMemberFilterComponent {
+  event = input<any>()
+  teams = input<Team[]>([])
+  filter = input<MemberFilterSelection | null>(null)
+
+  memberFilterChanged = output<MemberFilterSelection>()
+
+  @ViewChild('memberInput') memberInput: ElementRef<HTMLInputElement>
+
+  readonly separatorKeysCodes: number[] = [ENTER, COMMA]
+
+  inputControl = new FormControl('')
+  private queryText = toSignal(this.inputControl.valueChanges, { initialValue: '' })
+
+  private search$ = new Subject<{ event: any; teams: Team[]; term: string }>()
+  private searchResults = toSignal(
+    this.search$.pipe(
+      debounceTime(SEARCH_DEBOUNCE_MS),
+      switchMap(({ event, teams, term }) => {
+        if (!event || !teams.length) {
+          return of([] as User[])
+        }
+        return this.eventService.searchMembers(event, term)
+      })
+    ),
+    { initialValue: [] as User[] }
+  )
+
+  selected = signal<MemberOption[]>([])
+
+  private teamOptions = computed<MemberOption[]>(() =>
+    this.event() ? this.teams().map(t => this.teamToOption(t)) : []
+  )
+
+  private userOptions = computed<MemberOption[]>(() =>
+    [...this.searchResults()]
+      .map(u => this.userToOption(u))
+      .sort((a, b) => a.display.localeCompare(b.display))
+  )
+
+  filteredGroups = computed<MemberOptionGroup[]>(() => this.buildGroups())
+
+  constructor(private eventService: EventService) {
+    effect(() => {
+      const event = this.event()
+      const teams = this.teams()
+      const term = this.queryText() ?? ''
+      this.search$.next({ event, teams, term: typeof term === 'string' ? term : '' })
+    })
+
+    effect(() => {
+      const event = this.event()
+      const teams = this.teams()
+      const filter = this.filter()
+      this.selected.set([])
+
+      if (!event || !teams.length || !filter) {
+        return
+      }
+
+      const teamSelections = this.teamOptions().filter(o => filter.teamIds.includes(o.id))
+
+      if (filter.userIds.length) {
+        this.eventService.getMembers(event).subscribe((users: User[]) => {
+          const userSelections = users
+            .filter(u => filter.userIds.includes(u.id))
+            .map(u => this.userToOption(u))
+          this.selected.set([...teamSelections, ...userSelections])
+        })
+      } else {
+        this.selected.set(teamSelections)
+      }
+    })
+  }
+
+  onOptionSelected(event: MatAutocompleteSelectedEvent): void {
+    const option: MemberOption = event.option.value
+    if (!this.selected().find(s => s.type === option.type && s.id === option.id)) {
+      this.selected.set([...this.selected(), option])
+      this.emit()
+    }
+    this.inputControl.setValue('')
+    this.memberInput.nativeElement.value = ''
+    this.memberInput.nativeElement.focus()
+  }
+
+  remove(option: MemberOption): void {
+    this.selected.set(this.selected().filter(s => !(s.type === option.type && s.id === option.id)))
+    this.emit()
+  }
+
+  displayFn(): string {
+    return ''
+  }
+
+  private buildGroups(): MemberOptionGroup[] {
+    const query = (this.queryText() || '').toLowerCase()
+    const selectedIds = new Set(this.selected().map(s => `${s.type}:${s.id}`))
+
+    const teams = this.teamOptions()
+      .filter(o => !selectedIds.has(`team:${o.id}`))
+      .filter(o => o.display.toLowerCase().includes(query))
+
+    const users = this.userOptions()
+      .filter(o => !selectedIds.has(`user:${o.id}`))
+
+    const groups: MemberOptionGroup[] = []
+    if (teams.length) groups.push({ label: 'Teams', options: teams })
+    if (users.length) groups.push({ label: 'Members', options: users })
+    return groups
+  }
+
+  private teamToOption(team: Team): MemberOption {
+    return { type: 'team', id: String(team.id), display: team.name || '', raw: team }
+  }
+
+  private userToOption(user: User): MemberOption {
+    return {
+      type: 'user',
+      id: user.id,
+      display: user.displayName || user.username,
+      raw: user
+    }
+  }
+
+  private emit(): void {
+    this.memberFilterChanged.emit({
+      teamIds: this.selected().filter(s => s.type === 'team').map(s => s.id),
+      userIds: this.selected().filter(s => s.type === 'user').map(s => s.id)
+    })
+  }
+}

--- a/web-app/src/app/event/event.service.ts
+++ b/web-app/src/app/event/event.service.ts
@@ -552,6 +552,18 @@ export class EventService {
       );
   }
 
+  searchMembers(event, term: string, pageSize = 20): Observable<User[]> {
+    const params = new HttpParams()
+      .set('term', term || '')
+      .set('page_size', String(pageSize));
+    return this.httpClient
+      .get<MemberPage>(`/api/events/${event.id}/members`, { params })
+      .pipe(
+        take(1),
+        map(res => res.items)
+      );
+  }
+
 
   isUserInEvent(user, event): boolean {
     if (!event) return false;

--- a/web-app/src/app/filter/entities.filter.ts
+++ b/web-app/src/app/filter/entities.filter.ts
@@ -1,0 +1,62 @@
+import { MemberFilterSelection } from '../event/event-member-filter.component'
+import { ObservationFieldFilter } from '../entities/observation/filter/entities.observation.filter'
+
+export interface IntervalChoice {
+  filter: string | number
+  label: string
+}
+
+export interface IntervalOptions {
+  startDate?: Date
+  endDate?: Date
+  localTime?: boolean
+}
+
+export interface TimeInterval {
+  choice: IntervalChoice
+  options?: IntervalOptions
+}
+
+export type EventObservationFilter = {
+  timeInterval?: TimeInterval
+  memberFilter?: MemberFilterSelection | null
+  hasAttachments?: boolean
+  isUserFavorite?: boolean
+  isFlaggedImportant?: boolean
+  fieldFilter?: ObservationFieldFilter | null
+}
+
+export type EventLocationFilter = {
+  timeInterval?: TimeInterval
+  memberFilter?: MemberFilterSelection | null
+}
+
+function localUtcOffset(): string {
+  const off = -new Date().getTimezoneOffset()
+  const sign = off >= 0 ? '+' : '-'
+  const hour = String(Math.floor(Math.abs(off) / 60)).padStart(2, '0')
+  const minute = String(Math.abs(off) % 60).padStart(2, '0')
+  return `${sign}${hour}:${minute}`
+}
+
+export const INTERVAL_CHOICES: IntervalChoice[] = [
+  { filter: 'all', label: 'All' },
+  { filter: 'today', label: `Today (Local GMT ${localUtcOffset()})` },
+  { filter: 86400, label: 'Last 24 Hours' },
+  { filter: 43200, label: 'Last 12 Hours' },
+  { filter: 21600, label: 'Last 6 Hours' },
+  { filter: 3600, label: 'Last Hour' },
+  { filter: 'custom', label: 'Custom' }
+]
+
+const DEFAULT_TIME_INTERVAL: TimeInterval = {
+  choice: INTERVAL_CHOICES[1]
+}
+
+export const DEFAULT_OBSERVATION_FILTER: EventObservationFilter = {
+  timeInterval: DEFAULT_TIME_INTERVAL
+}
+
+export const DEFAULT_LOCATION_FILTER: EventLocationFilter = {
+  timeInterval: DEFAULT_TIME_INTERVAL
+}


### PR DESCRIPTION
## Summary
Groundwork for the upcoming server-side observation/location search and filter feature. Nothing in the app consumes these yet, they're inert until the filter dialog and `FilterService`/`EventService` rewrite PRs wire them up.

- `entities.observation.filter.ts`: the structured field-condition types (`Condition`, `BinaryCondition`, `ArrayCondition`, `RangeCondition`, `NullCondition`) and `ObservationFieldFilter`, combining condition-based filtering with free-text keyword search.
- `filter/entities.filter.ts`: `TimeInterval`/`IntervalChoice` and `EventObservationFilter`/`EventLocationFilter`, the shapes the rewritten filter service will use to represent active observation/location filters. Lives alongside the existing `filter.types.ts` for now, not a replacement.
- `EventMemberFilterComponent`: a reusable team/user chip-input picker (grouped autocomplete, emits `{teamIds, userIds}`), adapted to use `EventService.getMembers()` since this repo has no `TeamService`, and built on the `mat-chip-grid` API already used elsewhere here.

Built modernized: standalone component with signal inputs/outputs, `computed()` in place of the RxJS-derived filter observable, an `effect()` in place of `ngOnChanges`, and `@if`/`@for` control flow in the template. No wrapper `NgModule` — standalone components don't need one.

## Test plan
- [x] `ng test` — event-member-filter.component.spec.ts (14/14 passing)
- [x] `tsc -p tsconfig.app.json --noEmit` — clean compile
