### PR TITLE
feat(web-app): move event selection to the navbar

### DIFF
--- a/web-app/src/app/event/event.service.spec.ts
+++ b/web-app/src/app/event/event.service.spec.ts
@@ -1,22 +1,179 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { EventService } from './event.service';
+import { FilterService } from '../filter/filter.service';
+import { UserService } from '../user/user.service';
+import { LocalStorageService } from '../http/local-storage.service';
+import { SessionService } from 'mage-web-app/http/session.service';
+import { PollingService } from './polling.service';
+import { LocationService } from '../user/location/location.service';
+import { ObservationService } from '../observation/observation.service';
+import { LayerService } from '../layer/layer.service';
+import { FeedService } from '@ngageoint/mage.web-core-lib/feed';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
+const event: any = { id: 1, name: 'Event 1', teams: [], forms: [] };
+
 describe('Event Service Tests', () => {
 
+  let service: EventService;
+  let filterService: FilterService;
+  let pollingService: jasmine.SpyObj<PollingService>;
+  let locationService: jasmine.SpyObj<LocationService>;
+  let observationService: jasmine.SpyObj<ObservationService>;
+  let layerService: jasmine.SpyObj<LayerService>;
+  let feedService: jasmine.SpyObj<FeedService>;
+
   beforeEach(() => {
+    const userService = jasmine.createSpyObj('UserService', ['addRecentEvent']);
+    userService.addRecentEvent.and.returnValue(of({}));
+
+    const localStorageService = jasmine.createSpyObj('LocalStorageService', [
+      'getTimeInterval', 'setTimeInterval',
+      'getTeams', 'setTeams',
+      'setUsers', 'setForms'
+    ]);
+    localStorageService.getTimeInterval.and.returnValue(null);
+    localStorageService.getTeams.and.returnValue([]);
+
+    pollingService = jasmine.createSpyObj('PollingService', ['addListener', 'removeListener', 'getPollingInterval']);
+    locationService = jasmine.createSpyObj('LocationService', ['getUserLocationsForEvent']);
+    locationService.getUserLocationsForEvent.and.returnValue(of([]));
+    observationService = jasmine.createSpyObj('ObservationService', ['getObservationsForEvent']);
+    observationService.getObservationsForEvent.and.returnValue(of([]));
+    layerService = jasmine.createSpyObj('LayerService', ['getLayersForEvent']);
+    layerService.getLayersForEvent.and.returnValue(of([]));
+    feedService = jasmine.createSpyObj('FeedService', ['fetchFeeds']);
+    feedService.fetchFeeds.and.returnValue(of([]));
+
     TestBed.configureTestingModule({
-    imports: [],
-    providers: [EventService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      imports: [],
+      providers: [
+        EventService,
+        FilterService,
+        { provide: UserService, useValue: userService },
+        { provide: LocalStorageService, useValue: localStorageService },
+        { provide: SessionService, useValue: {} },
+        { provide: PollingService, useValue: pollingService },
+        { provide: LocationService, useValue: locationService },
+        { provide: ObservationService, useValue: observationService },
+        { provide: LayerService, useValue: layerService },
+        { provide: FeedService, useValue: feedService },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(EventService);
+    filterService = TestBed.inject(FilterService);
   });
 
   afterEach(() => {
+    service.destroy();
   });
 
-   it('should be created', () => {
-     const service: EventService = TestBed.inject(EventService);
-     expect(service).toBeTruthy();
-   });
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('event changes', () => {
+
+    it('creates an eventsById bucket and fetches layers/feeds/data when an event is selected', () => {
+      service.init();
+
+      filterService.setEvent(event);
+
+      expect(service.getEventById(event.id)).toBeTruthy();
+      expect(layerService.getLayersForEvent).toHaveBeenCalledWith(event);
+      expect(feedService.fetchFeeds).toHaveBeenCalledWith(event.id);
+      expect(locationService.getUserLocationsForEvent).toHaveBeenCalled();
+      expect(observationService.getObservationsForEvent).toHaveBeenCalled();
+    });
+
+    it('tears down the old eventsById bucket when the event changes', () => {
+      service.init();
+      filterService.setEvent(event);
+      expect(service.getEventById(event.id)).toBeTruthy();
+
+      const otherEvent: any = { id: 2, name: 'Event 2', teams: [], forms: [] };
+      filterService.setEvent(otherEvent);
+
+      expect(service.getEventById(event.id)).toBeUndefined();
+      expect(service.getEventById(otherEvent.id)).toBeTruthy();
+    });
+
+    it('does not react to a listener once destroy has been called', () => {
+      service.init();
+      service.destroy();
+
+      filterService.setEvent(event);
+
+      expect(service.getEventById(event.id)).toBeUndefined();
+    });
+  });
+
+  describe('interval changes', () => {
+
+    it('re-fetches when the time interval changes for an active event', () => {
+      service.init();
+      filterService.setEvent(event);
+
+      locationService.getUserLocationsForEvent.calls.reset();
+      observationService.getObservationsForEvent.calls.reset();
+
+      filterService.setTimeInterval({ choice: { filter: 86400, label: 'Last 24 Hours' } });
+
+      expect(locationService.getUserLocationsForEvent).toHaveBeenCalled();
+      expect(observationService.getObservationsForEvent).toHaveBeenCalled();
+    });
+  });
+
+  describe('team/user/form filter changes', () => {
+
+    it('re-evaluates the current event observations/users when teams change', () => {
+      service.init();
+      filterService.setEvent(event);
+
+      const listener = jasmine.createSpyObj('listener', ['onObservationsChanged']);
+      service.addObservationsChangedListener(listener);
+      listener.onObservationsChanged.calls.reset();
+
+      filterService.setTeams([{ id: 5, name: 'Team 5', userIds: [] }]);
+
+      expect(listener.onObservationsChanged).toHaveBeenCalled();
+    });
+
+    it('re-evaluates on users and forms changes too', () => {
+      service.init();
+      filterService.setEvent(event);
+
+      const listener = jasmine.createSpyObj('listener', ['onObservationsChanged']);
+      service.addObservationsChangedListener(listener);
+
+      listener.onObservationsChanged.calls.reset();
+      filterService.setUsers([{ id: 'u1' } as any]);
+      expect(listener.onObservationsChanged).toHaveBeenCalledTimes(1);
+
+      listener.onObservationsChanged.calls.reset();
+      filterService.setForms([{ id: 1 } as any]);
+      expect(listener.onObservationsChanged).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('action filter changes', () => {
+
+    it('re-evaluates observations against the action filter', () => {
+      service.init();
+      filterService.setEvent(event);
+
+      const listener = jasmine.createSpyObj('listener', ['onObservationsChanged']);
+      service.addObservationsChangedListener(listener);
+      listener.onObservationsChanged.calls.reset();
+
+      filterService.setFilter({ actionFilter: 'important' });
+
+      expect(listener.onObservationsChanged).toHaveBeenCalled();
+    });
+  });
 });

--- a/web-app/src/app/event/event.service.ts
+++ b/web-app/src/app/event/event.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from "@angular/core";
 import {
   Observable,
+  Subject,
   catchError,
   combineLatest,
   finalize,
   map,
+  merge,
   of,
+  pairwise,
+  skip,
+  startWith,
   take,
+  takeUntil,
   tap,
 } from "rxjs";
 import { FilterService } from "../filter/filter.service";
@@ -24,7 +30,6 @@ import { MemberPage, filterChanges } from "./event.types";
 import {
   Attachment,
   Event,
-  Filter,
   Form,
   FormField,
   Layer,
@@ -45,6 +50,7 @@ export class EventService {
   private pollingTimeout: any = null;
   private feedPollTimeout: any = null;
   private feedSyncStates: any = {};
+  private destroy$ = new Subject<void>();
 
   constructor(
     private pollingService: PollingService,
@@ -58,13 +64,50 @@ export class EventService {
   ) { }
 
   init() {
-    this.filterService.addListener(this);
+    this.destroy$ = new Subject<void>();
     this.pollingService.addListener(this);
+
+    this.filterService.event$
+      .pipe(startWith(null), pairwise(), takeUntil(this.destroy$))
+      .subscribe(([prev, curr]) => {
+        if (prev?.id !== curr?.id) {
+          this.onEventChanged({
+            added: curr ? [curr] : [],
+            removed: prev ? [prev] : [],
+          });
+          if (curr) {
+            this.fetch().subscribe();
+          }
+        }
+      });
+
+    this.filterService.interval$
+      .pipe(skip(1), takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.fetch().subscribe();
+      });
+
+    merge(
+      this.filterService.teams$.pipe(skip(1)),
+      this.filterService.users$.pipe(skip(1)),
+      this.filterService.forms$.pipe(skip(1))
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.onFiltersChanged();
+      });
+
+    this.filterService.actionFilter$
+      .pipe(skip(1), takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.onActionFilterChanged();
+      });
   }
 
   destroy() {
     this.eventsById = {};
-    this.filterService.removeListener(this);
+    this.destroy$.next();
+    this.destroy$.complete();
     this.pollingService.removeListener(this);
 
     if (this.pollingTimeout) {
@@ -103,22 +146,6 @@ export class EventService {
     return this.httpClient.delete<any>(
       `/api/events/${eventId}/feeds/${feedId}`
     );
-  }
-
-  async onFilterChanged(filter: any) {
-    if (filter.event) {
-      this.onEventChanged(filter.event);
-    }
-    if (filter.event?.added?.length || filter.timeInterval) {
-      // requery server
-      await this.fetch().subscribe();
-    }
-
-    this.onFiltersChanged(filter);
-
-    if (filter.actionFilter) {
-      this.onActionFilterChanged();
-    }
   }
 
   onEventChanged(event: filterChanges) {
@@ -167,12 +194,11 @@ export class EventService {
   }
 
   /**
-   * Updates List of Observations and Users when Filter Changes
-   * @param  {Filter} filter Filter Parametes
+   * Updates List of Observations and Users when the team/user/form filter changes
    * @return {void} No Return
    */
 
-  onFiltersChanged(filter: Filter): void {
+  onFiltersChanged(): void {
     const event = this.filterService.getEvent();
     if (!event) return;
 
@@ -184,12 +210,9 @@ export class EventService {
     Object.values(teamsEvent.filteredObservationsById).forEach(
       (observation: Observation) => {
         if (
-          (filter.users &&
-            !this.filterService.isUserInList(observation.userId)) ||
-          (filter.teams &&
-            !this.filterService.isUserInTeamFilter(observation.userId)) ||
-          (filter.forms &&
-            !this.filterService.hasFormInList(observation.properties.forms))
+          !this.filterService.isUserInList(observation.userId) ||
+          !this.filterService.isUserInTeamFilter(observation.userId) ||
+          !this.filterService.hasFormInList(observation.properties.forms)
         ) {
           delete teamsEvent.filteredObservationsById[observation.id];
           observationsRemoved.push(observation);
@@ -201,8 +224,8 @@ export class EventService {
     const usersRemoved = [];
     Object.values(teamsEvent.filteredUsersById).forEach((user: User) => {
       if (
-        (filter.users && !this.filterService.isUserInList(user.id)) ||
-        (filter.teams && !this.filterService.isUserInTeamFilter(user.id))
+        !this.filterService.isUserInList(user.id) ||
+        !this.filterService.isUserInTeamFilter(user.id)
       ) {
         delete teamsEvent.filteredUsersById[user.id];
         usersRemoved.push(user);
@@ -214,11 +237,8 @@ export class EventService {
     Object.values(teamsEvent.observationsById).forEach(
       (observation: Observation) => {
         if (
-          filter.users &&
           this.filterService.isUserInList(observation.userId) &&
-          filter.teams &&
           this.filterService.isUserInTeamFilter(observation.userId) &&
-          filter.forms &&
           this.filterService.hasFormInList(observation.properties.forms) &&
           !teamsEvent.filteredObservationsById[observation.id]
         ) {
@@ -232,10 +252,8 @@ export class EventService {
     const usersAdded = [];
     Object.values(teamsEvent.usersById).forEach((user: User) => {
       if (
-        filter.users &&
-        !this.filterService.isUserInList(user.id) &&
-        filter.teams &&
-        !this.filterService.isUserInTeamFilter(user.id) &&
+        this.filterService.isUserInList(user.id) &&
+        this.filterService.isUserInTeamFilter(user.id) &&
         !teamsEvent.filteredUsersById[user.id]
       ) {
         usersAdded.push(user);

--- a/web-app/src/app/filter/filter.component.html
+++ b/web-app/src/app/filter/filter.component.html
@@ -3,30 +3,6 @@
     <h2 mat-dialog-title>Filter</h2>
 
     <div mat-dialog-content *ngIf="!isLoading; else loadingTemplate">
-      <mat-form-field appearance="fill">
-        <mat-label>Events</mat-label>
-        <input
-          type="text"
-          matInput
-          [formControl]="eventControl"
-          [matAutocomplete]="autoEvent"
-        />
-
-        <mat-autocomplete
-          #autoEvent="matAutocomplete"
-          [displayWith]="onDisplayEvent"
-          (optionSelected)="onSelectEvent($event)"
-        >
-          <mat-option
-            *ngFor="let event of filteredEvents | async"
-            [value]="event"
-          >
-            <div class="option-text">{{ event.name }}</div>
-            <div class="option-description">{{ event.description }}</div>
-          </mat-option>
-        </mat-autocomplete>
-      </mat-form-field>
-
       <ng-container *ngIf="filteredTeams | async as teams">
         <div *ngIf="teams.length > 0 || selectedTeams.length > 0">
           <mat-form-field appearance="fill">

--- a/web-app/src/app/filter/filter.component.ts
+++ b/web-app/src/app/filter/filter.component.ts
@@ -8,8 +8,6 @@ import {
   firstValueFrom,
   map,
   startWith,
-  debounceTime,
-  switchMap,
   of
 } from 'rxjs';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
@@ -36,7 +34,7 @@ import {
 export class FilterComponent implements OnInit {
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
 
-  events: Event[];
+  event: Event;
   selectedTeams: Team[] = [];
 
   eventUsers: User[] = [];
@@ -45,12 +43,10 @@ export class FilterComponent implements OnInit {
   eventForms: Form[] = [];
   selectedForms: Form[] = [];
 
-  eventControl = new FormControl();
   teamControl = new FormControl();
   userControl = new FormControl();
   formControl = new FormControl();
 
-  filteredEvents: Observable<Event[]> = of([]);
   filteredTeams: Observable<Team[]> = of([]);
   filteredUsers: Observable<User[]> = of([]);
   filteredForms: Observable<Form[]> = of([]);
@@ -76,11 +72,11 @@ export class FilterComponent implements OnInit {
 
   async ngOnInit() {
     this.isLoading = true;
-  
+
     try {
       const event: Event = this.filterService.getEvent();
-      this.eventControl.setValue(event);
-  
+      this.event = event;
+
       const teamIds = this.localStorageService.getTeams() || [];
       this.selectedTeams = teamIds
         .map((teamId: number) =>
@@ -131,19 +127,13 @@ export class FilterComponent implements OnInit {
         : moment().endOf('day').toDate();
   
       this.localOffset = moment().format('Z');
-  
-      const events = await firstValueFrom(this.eventService.query());
-      this.setFilteredValues(events, this.eventUsers, this.eventForms);
+
+      this.setFilteredValues(this.eventUsers);
     } finally {
       this.isLoading = false;
     }
   }
 
-  /**
-   * Fetches Users for Given Event
-   * @param  {Event} event Event to Get Users From
-   * @return {Promise<User[]>} Returns List of Users as an Async Promise
-   */
   async getUsers(event: Event): Promise<User[]> {
     try {
       const users = await firstValueFrom(this.eventService.getMembers(event));
@@ -154,54 +144,14 @@ export class FilterComponent implements OnInit {
     }
   }
 
-  /**
-   * Resets Filter When Event is Selected
-   * @param  {Event[]} events List of Events
-   * @param  {User[]} eUsers Users in the Event
-   * @param  {Form[]} eForms Forms in the Event
-   * @return {void} No Return
-   */
-
-  setFilteredValues(events: Event[], eUsers: User[], eForms: Form[]): void {
-    this.events = events;
-
-    this.filteredEvents = this.eventControl.valueChanges.pipe(
-      startWith(''),
-      debounceTime(300),
-      switchMap((value) => {
-        const searchTerm =
-          typeof value === 'string' ? value : value?.name || '';
-        if (searchTerm && searchTerm.trim()) {
-          return this.eventService.query({
-            term: searchTerm.trim(),
-            limit: 100
-          });
-        } else {
-          return of(this.events);
-        }
-      })
-    );
-
+  setFilteredValues(users: User[]): void {
     this.filteredTeams = this.teamControl.valueChanges.pipe(
       startWith(''),
       map((value) => (typeof value === 'string' ? value : value.name)),
-      map((name) => {
-        if (this.eventControl.value) {
-          let teams = this.eventControl.value.teams.filter(
-            (team) => this.selectedTeams.indexOf(team) < 0
-          );
-          if (name) {
-            const filterValue = name.toLowerCase();
-            return teams.filter(
-              (team: Team) => team.name.toLowerCase().indexOf(filterValue) === 0
-            );
-          } else {
-            return teams.slice();
-          }
-        } else {
-          return [];
-        }
-      })
+      map((name) => this.event
+        ? this.filterAutocomplete(this.event.teams || [], this.selectedTeams, name, (team) => team.name || '')
+        : []
+      )
     );
 
     this.filteredUsers = this.userControl.valueChanges.pipe(
@@ -209,108 +159,37 @@ export class FilterComponent implements OnInit {
       map((value) =>
         typeof value === 'string' ? value : value.displayName || value.username
       ),
-      map((name) => {
-        if (eUsers.length) {
-          let usersList = eUsers.filter(
-            (user) => this.selectedUsers.map((x) => x.id).indexOf(user.id) < 0
-          );
-          if (name) {
-            const filterValue = name.toLowerCase();
-            return usersList.filter(
-              (user: User) =>
-                (user.displayName || user.username)
-                  .toLowerCase()
-                  .indexOf(filterValue) === 0
-            );
-          } else {
-            return usersList.slice();
-          }
-        } else {
-          return [];
-        }
-      })
+      map((name) => this.filterAutocomplete(
+        users, this.selectedUsers, name, (user) => user.displayName || user.username, (user) => user.id
+      ))
     );
 
     this.filteredForms = this.formControl.valueChanges.pipe(
       startWith(''),
       map((value) => (typeof value === 'string' ? value : value.name)),
-      map((name) => {
-        let formsList = this.eventForms.filter(
-          (form) => this.selectedForms.map((x) => x.id).indexOf(form.id) < 0
-        );
-        if (eForms.length) {
-          if (name) {
-            const filterValue = name.toLowerCase();
-            return formsList.filter(
-              (form: Form) => form.name.toLowerCase().indexOf(filterValue) === 0
-            );
-          } else {
-            return formsList.slice();
-          }
-        } else {
-          return [];
-        }
-      })
+      map((name) => this.filterAutocomplete(
+        this.eventForms, this.selectedForms, name, (form) => form.name, (form) => form.id
+      ))
     );
   }
 
   /**
-   * Resets Filter When Event is Selected
-   * @param  {MatAutocompleteSelectedEvent} event The Event from the Autocomplete SelectBox
-   * @return {Promise<void>} No Return
+   * Narrows a picker's remaining options to those not already selected, and
+   * to those matching the current search text by name prefix.
    */
-
-  async onSelectEvent(event: MatAutocompleteSelectedEvent): Promise<void> {
-    this.isLoading = true;
-  
-    try {
-      this.selectedTeams = [];
-      this.selectedUsers = [];
-      this.selectedForms = [];
-      this.teamControl.setValue('');
-      this.userControl.setValue('');
-      this.formControl.setValue('');
-  
-      const newEvent: Event = event.option.value;
-      const eUsers = await this.getUsers(newEvent);
-  
-      this.eventUsers = eUsers;
-      this.eventForms = newEvent.forms || [];
-  
-      if (this.eventUsers.length > 0) {
-        this.userControl.enable({ emitEvent: false });
-      } else {
-        this.userControl.disable({ emitEvent: false });
-      }
-  
-      if (this.eventForms.length > 0) {
-        this.formControl.enable({ emitEvent: false });
-      } else {
-        this.formControl.disable({ emitEvent: false });
-      }
-  
-      if (newEvent.teams?.length > 0) {
-        this.teamControl.enable({ emitEvent: false });
-      } else {
-        this.teamControl.disable({ emitEvent: false });
-      }
-  
-      const events = await firstValueFrom(this.eventService.query());
-      this.setFilteredValues(events, eUsers, this.eventForms);
-    } finally {
-      this.isLoading = false;
-    }
-  }
-
-  onDisplayEvent(event: Event): string {
-    return event && event.name ? event.name : '';
-  }
-
-  private filterEvent(name: string): Event[] {
-    const filterValue = name.toLowerCase();
-    return this.events.filter((option) =>
-      option.name.toLowerCase().includes(filterValue)
-    );
+  private filterAutocomplete<T>(
+    items: T[],
+    selected: T[],
+    name: string,
+    getName: (item: T) => string,
+    getId: (item: T) => unknown = (item) => item
+  ): T[] {
+    const selectedIds = selected.map(getId);
+    const available = items.filter((item) => !selectedIds.includes(getId(item)));
+    const query = (name || '').toLowerCase();
+    return query
+      ? available.filter((item) => getName(item).toLowerCase().startsWith(query))
+      : available;
   }
 
   onSelectTeam(event: MatAutocompleteSelectedEvent): void {
@@ -393,7 +272,6 @@ export class FilterComponent implements OnInit {
     }
 
     this.filterService.setFilter({
-      event: this.eventControl.value,
       teams: this.selectedTeams,
       timeInterval: {
         choice: this.intervalChoice,

--- a/web-app/src/app/filter/filter.service.spec.ts
+++ b/web-app/src/app/filter/filter.service.spec.ts
@@ -1,22 +1,188 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { FilterService } from './filter.service';
+import { UserService } from '../user/user.service';
+import { LocalStorageService } from '../http/local-storage.service';
+import { SessionService } from 'mage-web-app/http/session.service';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 describe('Filter Service Tests', () => {
 
+  let service: FilterService;
+  let userService: jasmine.SpyObj<UserService>;
+  let localStorageService: jasmine.SpyObj<LocalStorageService>;
+
   beforeEach(() => {
+    userService = jasmine.createSpyObj('UserService', ['addRecentEvent']);
+    userService.addRecentEvent.and.returnValue(of({}));
+
+    localStorageService = jasmine.createSpyObj('LocalStorageService', [
+      'getTimeInterval', 'setTimeInterval',
+      'getTeams', 'setTeams',
+      'getUsers', 'setUsers',
+      'getForms', 'setForms'
+    ]);
+    localStorageService.getTimeInterval.and.returnValue(null);
+    localStorageService.getTeams.and.returnValue([]);
+
     TestBed.configureTestingModule({
-    imports: [],
-    providers: [FilterService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      imports: [],
+      providers: [
+        FilterService,
+        { provide: UserService, useValue: userService },
+        { provide: LocalStorageService, useValue: localStorageService },
+        { provide: SessionService, useValue: {} },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(FilterService);
   });
 
-  afterEach(() => {
+  it('should be created', () => {
+    expect(service).toBeTruthy();
   });
 
-   it('should be created', () => {
-     const service: FilterService = TestBed.inject(FilterService);
-     expect(service).toBeTruthy();
-   });
+  describe('event$', () => {
+
+    it('emits the current value (null) to a new subscriber', (done) => {
+      service.event$.subscribe((event) => {
+        expect(event).toBeNull();
+        done();
+      });
+    });
+
+    it('emits when setEvent is called with a new event', () => {
+      const emitted: any[] = [];
+      service.event$.subscribe((event) => emitted.push(event));
+
+      const event: any = { id: 1, name: 'Event 1', teams: [] };
+      service.setEvent(event);
+
+      expect(emitted).toEqual([null, event]);
+    });
+
+    it('does not emit again for the same event id', () => {
+      const event: any = { id: 1, name: 'Event 1', teams: [] };
+      service.setEvent(event);
+
+      const emitted: any[] = [];
+      service.event$.subscribe((e) => emitted.push(e));
+
+      service.setEvent({ id: 1, name: 'Event 1 renamed', teams: [] } as any);
+
+      expect(emitted).toEqual([event]);
+    });
+
+    it('emits null when removeFilters is called', () => {
+      const event: any = { id: 1, name: 'Event 1', teams: [] };
+      service.setEvent(event);
+
+      const emitted: any[] = [];
+      service.event$.subscribe((e) => emitted.push(e));
+
+      service.removeFilters();
+
+      expect(emitted).toEqual([event, null]);
+    });
+  });
+
+  describe('teams$/users$/forms$', () => {
+
+    it('emits current teams when setTeams is called', () => {
+      const emitted: any[] = [];
+      service.teams$.subscribe((teams) => emitted.push(teams));
+
+      const team: any = { id: 1, name: 'Team 1' };
+      service.setTeams([team]);
+
+      expect(emitted).toEqual([[], [team]]);
+    });
+
+    it('emits current users when setUsers is called', () => {
+      const emitted: any[] = [];
+      service.users$.subscribe((users) => emitted.push(users));
+
+      const user: any = { id: 'u1', displayName: 'User 1' };
+      service.setUsers([user]);
+
+      expect(emitted).toEqual([[], [user]]);
+    });
+
+    it('emits current forms when setForms is called', () => {
+      const emitted: any[] = [];
+      service.forms$.subscribe((forms) => emitted.push(forms));
+
+      const form: any = { id: 1, name: 'Form 1' };
+      service.setForms([form]);
+
+      expect(emitted).toEqual([[], [form]]);
+    });
+  });
+
+  describe('interval$', () => {
+
+    it('emits when the interval actually changes', () => {
+      const emitted: any[] = [];
+      service.interval$.subscribe((interval) => emitted.push(interval));
+
+      const choice = { filter: 86400, label: 'Last 24 Hours' };
+      service.setTimeInterval({ choice });
+
+      expect(emitted.length).toBe(2);
+      expect(emitted[1].choice).toEqual(choice);
+    });
+
+    it('does not emit again for the same choice', () => {
+      const choice = service.getIntervalChoice();
+
+      const emitted: any[] = [];
+      service.interval$.subscribe((interval) => emitted.push(interval));
+
+      service.setTimeInterval({ choice });
+
+      expect(emitted.length).toBe(1);
+    });
+  });
+
+  describe('actionFilter$', () => {
+
+    it('emits when setFilter is called with an actionFilter', () => {
+      const emitted: string[] = [];
+      service.actionFilter$.subscribe((actionFilter) => emitted.push(actionFilter));
+
+      service.setFilter({ actionFilter: 'important' });
+
+      expect(emitted).toEqual(['', 'important']);
+    });
+  });
+
+  describe('setFilter', () => {
+
+    it('sets event, teams, users, and forms together', () => {
+      const event: any = { id: 1, name: 'Event 1', teams: [{ id: 5, name: 'Team 5' }] };
+      const team: any = { id: 5, name: 'Team 5' };
+      const user: any = { id: 'u1', displayName: 'User 1' };
+      const form: any = { id: 1, name: 'Form 1' };
+
+      service.setFilter({ event, teams: [team], users: [user], forms: [form] });
+
+      expect(service.getEvent()).toEqual(event);
+      expect(service.getTeams()).toEqual([team]);
+      expect(service.getUsers()).toEqual([user]);
+      expect(service.getForms()).toEqual([form]);
+    });
+
+    it('resets teams to the previously saved selection when event changes without an explicit teams filter', () => {
+      localStorageService.getTeams.and.returnValue([5]);
+      const team: any = { id: 5, name: 'Team 5' };
+      const event: any = { id: 1, name: 'Event 1', teams: [team] };
+
+      service.setFilter({ event });
+
+      expect(service.getTeams()).toEqual([team]);
+    });
+  });
 });

--- a/web-app/src/app/filter/filter.service.ts
+++ b/web-app/src/app/filter/filter.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
 import { UserService } from "../user/user.service";
 import { LocalStorageService } from "../http/local-storage.service";
 import moment from 'moment';
@@ -12,7 +13,6 @@ import {
   TeamById,
   Observation,
   Filter,
-  Changes,
   Form,
   FormProperties,
   SearchInterval,
@@ -27,13 +27,26 @@ import { SessionService } from "mage-web-app/http/session.service";
 export class FilterService {
   event: Event = null;
   teamsById: TeamById = {};
-  listeners: any = [];
   users: User[] = [];
   forms: Form[] = [];
 
   interval: Interval = {};
   filterLocalOffset = moment().format("Z");
   actionFilter: string = "";
+
+  private eventSubject = new BehaviorSubject<Event | null>(null);
+  private teamsSubject = new BehaviorSubject<Team[]>([]);
+  private usersSubject = new BehaviorSubject<User[]>([]);
+  private formsSubject = new BehaviorSubject<Form[]>([]);
+  private intervalSubject = new BehaviorSubject<Interval>(this.interval);
+  private actionFilterSubject = new BehaviorSubject<string>("");
+
+  readonly event$: Observable<Event | null> = this.eventSubject.asObservable();
+  readonly teams$: Observable<Team[]> = this.teamsSubject.asObservable();
+  readonly users$: Observable<User[]> = this.usersSubject.asObservable();
+  readonly forms$: Observable<Form[]> = this.formsSubject.asObservable();
+  readonly interval$: Observable<Interval> = this.intervalSubject.asObservable();
+  readonly actionFilter$: Observable<string> = this.actionFilterSubject.asObservable();
 
   intervalChoices: FilterChoice[] = [
     {
@@ -76,26 +89,6 @@ export class FilterService {
         choice: this.intervalChoices[1],
       }
     );
-    this.filterChanged({ intervalChoice: this.interval.choice });
-  }
-
-  addListener(listener: any) {
-    this.listeners.push(listener);
-
-    if (typeof listener.onFilterChanged === "function") {
-      listener.onFilterChanged({
-        event: this.event,
-        teams: Object.values(this.teamsById),
-        user: this.users,
-        timeInterval: {
-          choice: this.interval.choice,
-        },
-      });
-    }
-  }
-
-  removeListener(listener: any) {
-    this.listeners = this.listeners.filter((l: any) => l !== listener);
   }
 
   /**
@@ -105,23 +98,16 @@ export class FilterService {
    */
 
   setFilter(filter: Filter): void {
-    let eventChanged = null;
-    let teamsChanged = null;
-    let usersChanged = null;
-    let formsChanged = null;
-    let timeIntervalChanged = null;
-    let actionFilterChanged = null;
+    if (filter.users) this.setUsers(filter.users);
 
-    if (filter.users) usersChanged = this.setUsers(filter.users);
-
-    if (filter.forms) formsChanged = this.setForms(filter.forms);
+    if (filter.forms) this.setForms(filter.forms);
 
     if (filter.teams) {
-      teamsChanged = this.setTeams(filter.teams);
+      this.setTeams(filter.teams);
     }
 
     if (filter.event) {
-      eventChanged = this.setEvent(filter.event);
+      this.setEvent(filter.event);
 
       // if they changed the event, and didn't set teams filter
       // then reset teams filter to empty array
@@ -133,38 +119,25 @@ export class FilterService {
             teams.push(this.event.teams[i]);
           }
         }
-        teamsChanged = this.setTeams(teams);
+        this.setTeams(teams);
       }
     }
 
     if (filter.actionFilter) {
-      actionFilterChanged = filter.actionFilter;
       this.actionFilter = filter.actionFilter;
+      this.actionFilterSubject.next(this.actionFilter);
     }
 
-    if (filter.timeInterval && this.setTimeInterval(filter.timeInterval)) {
-      timeIntervalChanged = filter.timeInterval;
+    if (filter.timeInterval) {
+      this.setTimeInterval(filter.timeInterval);
     }
-
-    const changed: Changes = {};
-    if (eventChanged) changed.event = eventChanged;
-    if (teamsChanged) changed.teams = teamsChanged;
-    if (usersChanged) changed.users = usersChanged;
-    if (formsChanged) changed.forms = formsChanged;
-    if (actionFilterChanged) changed.actionFilter = actionFilterChanged;
-    if (timeIntervalChanged) changed.timeInterval = timeIntervalChanged;
-
-    this.filterChanged(changed);
   }
 
   removeFilters() {
-    const changed: Changes = {};
     if (this.event) {
-      changed.event = { removed: [this.event] };
       this.event = null;
+      this.eventSubject.next(this.event);
     }
-
-    this.filterChanged(changed);
   }
 
   /**
@@ -175,11 +148,13 @@ export class FilterService {
 
   setEvent(newEvent: Event): filterChanges {
     if (!newEvent && this.event) {
+      const removed = [this.event];
       this.event = null;
+      this.eventSubject.next(this.event);
 
       return {
         added: [],
-        removed: [this.event],
+        removed: removed,
       };
     } else if ((newEvent && !this.event) || this.event.id !== newEvent.id) {
       const added = [newEvent];
@@ -190,6 +165,7 @@ export class FilterService {
       });
 
       this.event = newEvent;
+      this.eventSubject.next(this.event);
 
       return {
         added: added,
@@ -224,6 +200,7 @@ export class FilterService {
 
     this.users = newUsers;
     this.localStorageService.setUsers(this.users);
+    this.usersSubject.next(this.users);
 
     return {
       added: added,
@@ -251,6 +228,7 @@ export class FilterService {
 
     this.forms = newForms;
     this.localStorageService.setForms(this.forms);
+    this.formsSubject.next(this.forms);
 
     return {
       added: added,
@@ -283,6 +261,7 @@ export class FilterService {
 
     this.teamsById = newTeamsById;
     this.localStorageService.setTeams(Object.keys(this.teamsById));
+    this.teamsSubject.next(this.getTeams());
 
     return {
       added: added,
@@ -335,6 +314,7 @@ export class FilterService {
     }
     this.localStorageService.setTimeInterval(newInterval);
     this.interval = newInterval;
+    this.intervalSubject.next(this.interval);
     return true;
   }
 
@@ -471,13 +451,5 @@ export class FilterService {
     }
 
     return { start: start, end: end };
-  }
-
-  filterChanged(filter: Changes) {
-    this.listeners.forEach((listener: any) => {
-      if (typeof listener.onFilterChanged === "function") {
-        listener.onFilterChanged(filter);
-      }
-    });
   }
 }

--- a/web-app/src/app/home/home.component.ts
+++ b/web-app/src/app/home/home.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MapService } from '../map/map.service';
 import { FilterService } from '../filter/filter.service';
 import { MatSidenav } from '@angular/material/sidenav';
@@ -31,7 +32,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     private sessionService: SessionService,
     private filterService: FilterService,
     private locationService: LocationService,
-    private activatedRoute: ActivatedRoute
+    private activatedRoute: ActivatedRoute,
+    private destroyRef: DestroyRef
   ) {
     this.sessionService.user$.subscribe((myself: User) => {
       this.myself = myself
@@ -39,7 +41,11 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.filterService.addListener(this)
+    this.filterService.event$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((event) => {
+        this.event = event
+      })
     this.mapService.addListener(this)
 
     this.activatedRoute.data.subscribe(({ user }) => {
@@ -49,20 +55,11 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.filterService.removeListener(this)
     this.mapService.removeListener(this)
   }
 
   onMap($event) {
     this.map = $event.map
-  }
-
-  onFilterChanged(filter: any) {
-    if (filter.event?.added?.length) {
-      this.event = filter.event.added[0]
-    } else if (filter.event?.removed?.length) {
-      this.event = null
-    }
   }
 
   onAddObservation($event) {

--- a/web-app/src/app/home/home.module.ts
+++ b/web-app/src/app/home/home.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { DragDropModule } from '@angular/cdk/drag-drop';
+import { CdkMenuModule } from '@angular/cdk/menu';
 
 import { SaturationModule, HueModule, CheckboardModule, AlphaModule } from 'ngx-color';
 
@@ -145,6 +146,7 @@ const routes: Routes = [{
   imports: [MatTimepickerModule],
   exports: [
     AlphaModule,
+    CdkMenuModule,
     CheckboardModule,
     CommonModule,
     FormsModule,

--- a/web-app/src/app/navigation/navigation.component.html
+++ b/web-app/src/app/navigation/navigation.component.html
@@ -6,12 +6,13 @@
       </button>
     </div>
 
-    <div class="event-title">
-      <span class="filter-event">{{ filteredEvent.name }}</span>
+    <button class="event-title" [cdkMenuTriggerFor]="eventPanel" [cdkMenuPosition]="eventMenuPosition" (cdkMenuOpened)="onEventMenuOpened()">
+      <span class="filter-event">{{ filteredEvent?.name || (eventsLoaded ? 'Select Event' : '') }}</span>
+      <mat-icon>arrow_drop_down</mat-icon>
       <span *ngIf="filteredTeams" class="filter-teams"><span>> {{ filteredTeams }}</span></span>
       <span *ngIf="filteredInterval" class="filter-interval">
         {{ filteredInterval }}</span>
-    </div>
+    </button>
 
     <div class="collapsed-menu">
       <button matIconButton class="navigation-options" [matMenuTriggerFor]="menu">
@@ -56,3 +57,26 @@
     </div>
   </div>
 </mat-toolbar>
+
+<ng-template #eventPanel>
+  <div cdkMenu class="event-panel">
+    <mat-form-field appearance="fill" class="event-panel__search">
+      <mat-icon matPrefix>search</mat-icon>
+      <input matInput
+        #eventSearchInput
+        placeholder="Search events..."
+        [formControl]="eventSearchControl"
+        (keydown)="$event.stopPropagation()">
+    </mat-form-field>
+    <div class="event-panel__list">
+      <button cdkMenuItem
+        *ngFor="let event of filteredEvents | async"
+        class="event-panel__item"
+        [class.event-panel__item--active]="event.id === filteredEvent?.id"
+        (click)="onSelectEvent(event)">
+        <div class="event-panel__item-name">{{ event.name }}</div>
+        <div class="event-panel__item-description" *ngIf="event.description">{{ event.description }}</div>
+      </button>
+    </div>
+  </div>
+</ng-template>

--- a/web-app/src/app/navigation/navigation.component.scss
+++ b/web-app/src/app/navigation/navigation.component.scss
@@ -36,12 +36,80 @@ mat-toolbar {
 }
 
 .event-title {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 300px;
   margin-top: 0.2rem;
   font-size: 0.75em;
-  text-align: center;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.event-panel {
+  width: 500px;
+  max-height: 400px;
+  display: flex;
+  flex-direction: column;
+  background: var(--mat-sys-surface, white);
+  color: var(--mat-sys-on-surface, inherit);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+
+  &__search {
+    width: 100%;
+  }
+
+  &__list {
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
+    min-height: 48px;
+    padding: 8px 16px;
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.04);
+    }
+
+    &--active {
+      color: var(--mat-sys-primary);
+    }
+  }
+
+  &__item-name {
+    font-size: 16px;
+  }
+
+  &__item-description {
+    font-size: 12px;
+    line-height: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 0.6;
+  }
 }
 
 .profile-avatar {

--- a/web-app/src/app/navigation/navigation.component.spec.ts
+++ b/web-app/src/app/navigation/navigation.component.spec.ts
@@ -1,23 +1,58 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Subject, of } from 'rxjs';
 import { NavigationComponent } from './navigation.component';
+import { FilterService } from '../filter/filter.service';
+import { MapService } from '../map/map.service';
+import { UserService } from '../user/user.service';
+import { EventService } from '../event/event.service';
+import { PollingService } from '../event/polling.service';
+import { SessionService } from 'mage-web-app/http/session.service';
+import { Router } from '@angular/router';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule as MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
+const eventA: any = { id: 1, name: 'Alpha Event' };
+const eventB: any = { id: 2, name: 'Bravo Event' };
+
 describe('Navigation Component', () => {
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
+  let filterService: jasmine.SpyObj<FilterService>;
+  let eventService: jasmine.SpyObj<EventService>;
+  let userService: jasmine.SpyObj<UserService>;
 
   beforeEach(waitForAsync(() => {
+    filterService = jasmine.createSpyObj('FilterService', ['setFilter', 'removeFilters', 'getIntervalChoice'], {
+      event$: of(null),
+      teams$: of([]),
+      interval$: of({})
+    });
+    filterService.getIntervalChoice.and.returnValue({ filter: 'all', label: 'All' });
+
+    eventService = jasmine.createSpyObj('EventService', ['query', 'init', 'destroy']);
+    eventService.query.and.returnValue(of([eventA, eventB]));
+
+    userService = jasmine.createSpyObj('UserService', ['getRecentEventId', 'logout']);
+    userService.getRecentEventId.and.returnValue(null);
+
     TestBed.configureTestingModule({
-    declarations: [NavigationComponent],
-    imports: [MatIconModule,
-        MatMenuModule,
-        MatToolbarModule],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+      declarations: [NavigationComponent],
+      imports: [MatIconModule, MatMenuModule, MatToolbarModule],
+      providers: [
+        { provide: FilterService, useValue: filterService },
+        { provide: MapService, useValue: jasmine.createSpyObj('MapService', ['init', 'destroy', 'onLocationStop']) },
+        { provide: UserService, useValue: userService },
+        { provide: EventService, useValue: eventService },
+        { provide: PollingService, useValue: jasmine.createSpyObj('PollingService', ['getPollingInterval', 'setPollingInterval']) },
+        { provide: SessionService, useValue: { amAdmin: false } },
+        { provide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
@@ -27,5 +62,78 @@ describe('Navigation Component', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('selects the first event when there is no recently used event', () => {
+    component.ngOnInit();
+
+    expect(filterService.setFilter).toHaveBeenCalledWith({ event: eventA });
+  });
+
+  it('selects the recently used event when one is saved', () => {
+    userService.getRecentEventId.and.returnValue(eventB.id);
+
+    component.ngOnInit();
+
+    expect(filterService.setFilter).toHaveBeenCalledWith({ event: eventB });
+  });
+
+  it('does not select an event when none are available', () => {
+    eventService.query.and.returnValue(of([]));
+
+    component.ngOnInit();
+
+    expect(filterService.setFilter).not.toHaveBeenCalled();
+  });
+
+  it('sorts the event list by name for the picker', () => {
+    eventService.query.and.returnValue(of([eventB, eventA]));
+
+    component.ngOnInit();
+
+    expect(component.events).toEqual([eventA, eventB]);
+  });
+
+  it('filters events in the picker by search text', (done) => {
+    component.ngOnInit();
+
+    component.filteredEvents.subscribe((events) => {
+      if (events.length === 1) {
+        expect(events).toEqual([eventB]);
+        done();
+      }
+    });
+
+    component.eventSearchControl.setValue('bravo');
+  });
+
+  it('calls setFilter when an event is selected from the picker', () => {
+    component.ngOnInit();
+
+    component.onSelectEvent(eventB);
+
+    expect(filterService.setFilter).toHaveBeenCalledWith({ event: eventB });
+  });
+
+  it('does not show the "no event" placeholder until the event query resolves', () => {
+    const events$ = new Subject<any[]>();
+    eventService.query.and.returnValue(events$);
+
+    component.ngOnInit();
+
+    expect(component.eventsLoaded).toBe(false);
+
+    events$.next([eventA, eventB]);
+
+    expect(component.eventsLoaded).toBe(true);
+  });
+
+  it('unsubscribes and cleans up on destroy', () => {
+    component.ngOnInit();
+
+    component.ngOnDestroy();
+
+    expect(filterService.removeFilters).toHaveBeenCalled();
+    expect(eventService.destroy).toHaveBeenCalled();
   });
 });

--- a/web-app/src/app/navigation/navigation.component.ts
+++ b/web-app/src/app/navigation/navigation.component.ts
@@ -1,10 +1,17 @@
 import {
   Component,
+  DestroyRef,
+  ElementRef,
   EventEmitter,
   OnDestroy,
   OnInit,
-  Output
+  Output,
+  ViewChild
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { FormControl } from '@angular/forms';
+import { Observable, map, startWith } from 'rxjs';
 import { FilterService } from '../filter/filter.service';
 import { MapService } from '../map/map.service';
 import { UserService } from '../user/user.service';
@@ -23,9 +30,19 @@ import { SessionService } from 'mage-web-app/http/session.service';
 export class NavigationComponent implements OnInit, OnDestroy {
   @Output() onFeedToggle = new EventEmitter<void>();
   @Output() onPreferencesToggle = new EventEmitter<void>();
+  @ViewChild('eventSearchInput') eventSearchInput: ElementRef<HTMLInputElement>;
+
+  events: any[] = [];
+  eventSearchControl = new FormControl('');
+  filteredEvents: Observable<any[]>;
+
+  eventMenuPosition: ConnectedPosition[] = [
+    { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top' }
+  ];
 
   state = 'map';
   filteredEvent: any = {};
+  eventsLoaded = false;
   filteredTeams: any;
   filteredInterval: any;
   feedChangedUsers = {};
@@ -38,31 +55,60 @@ export class NavigationComponent implements OnInit, OnDestroy {
     private userService: UserService,
     private eventService: EventService,
     private filterService: FilterService,
-    private pollingService: PollingService
+    private pollingService: PollingService,
+    private destroyRef: DestroyRef
   ) {}
 
   ngOnInit(): void {
-    this.filterService.addListener(this);
+    this.filterService.event$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((event) => this.onEventSelected(event));
+
+    this.filterService.teams$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((teams) => {
+        this.filteredTeams = _.map(teams, (t) => t.name).join(', ');
+      });
+
+    this.filterService.interval$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        const intervalChoice = this.filterService.getIntervalChoice();
+        if (intervalChoice.filter !== 'all') {
+          if (intervalChoice.filter === 'custom') {
+            // TODO format custom time interval
+            this.filteredInterval = 'Custom time interval';
+          } else {
+            this.filteredInterval = intervalChoice.label;
+          }
+        } else {
+          this.filteredInterval = null;
+        }
+      });
+
+    this.filteredEvents = this.eventSearchControl.valueChanges.pipe(
+      startWith(''),
+      map((value) => this.filterEvents(value ?? ''))
+    );
 
     this.eventService.query().subscribe((events) => {
+      this.events = [...events].sort((a, b) => a.name.localeCompare(b.name));
+      this.eventSearchControl.setValue('', { emitEvent: true });
+
       const recentEventId = this.userService.getRecentEventId();
       const recentEvent = _.find(events, (event) => {
         return event.id === recentEventId;
       });
-      if (recentEvent) {
-        this.filterService.setFilter({ event: recentEvent });
-        this.pollingService.setPollingInterval(
-          this.pollingService.getPollingInterval()
-        );
-      } else if (events.length > 0) {
-        // TODO 'welcome to Mage dialog'
-        this.filterService.setFilter({ event: events[0] });
+      const event = recentEvent || (events.length > 0 ? events[0] : null);
+      if (event) {
+        this.filterService.setFilter({ event });
         this.pollingService.setPollingInterval(
           this.pollingService.getPollingInterval()
         );
       } else {
         // TODO welcome to mage, sorry you have no events
       }
+      this.eventsLoaded = true;
     });
 
     this.mapService.init();
@@ -71,7 +117,6 @@ export class NavigationComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.filterService.removeListener(this);
     this.filterService.removeFilters();
 
     this.mapService.destroy();
@@ -93,32 +138,29 @@ export class NavigationComponent implements OnInit, OnDestroy {
     });
   }
 
-  onFilterChanged(filter) {
+  onEventMenuOpened(): void {
+    this.eventSearchControl.setValue('');
+    setTimeout(() => this.eventSearchInput?.nativeElement.focus(), 0);
+  }
+
+  onSelectEvent(event: any): void {
+    this.filterService.setFilter({ event });
+  }
+
+  private filterEvents(name: string): any[] {
+    if (!name) return this.events.slice();
+    const lower = name.toLowerCase();
+    return this.events.filter((e) => e.name.toLowerCase().includes(lower));
+  }
+
+  private onEventSelected(event: any) {
     this.feedChangedUsers = {};
 
-    if (filter.event) {
-      this.filteredEvent = this.filterService.getEvent();
+    if (event) {
+      this.filteredEvent = event;
 
       // Stop broadcasting location if the event switches
       this.mapService.onLocationStop();
-    }
-
-    if (filter.teams)
-      this.filteredTeams = _.map(this.filterService.getTeams(), (t) => {
-        return t.name;
-      }).join(', ');
-    if (filter.timeInterval) {
-      const intervalChoice = this.filterService.getIntervalChoice();
-      if (intervalChoice.filter !== 'all') {
-        if (intervalChoice.filter === 'custom') {
-          // TODO format custom time interval
-          this.filteredInterval = 'Custom time interval';
-        } else {
-          this.filteredInterval = intervalChoice.label;
-        }
-      } else {
-        this.filteredInterval = null;
-      }
     }
   }
 }

--- a/web-app/src/app/observation/observation-list/observation-list.component.ts
+++ b/web-app/src/app/observation/observation-list/observation-list.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { merge } from 'rxjs';
 import moment from 'moment';
 import { EventService } from '../../event/event.service';
 import { FilterService } from '../../filter/filter.service';
@@ -26,17 +28,26 @@ export class ObservationListComponent implements OnInit, OnDestroy {
 
   constructor(
     private eventService: EventService,
-    private filterService: FilterService) {
+    private filterService: FilterService,
+    private destroyRef: DestroyRef) {
   }
 
   ngOnInit(): void {
     this.event = this.filterService.getEvent()
     this.eventService.addObservationsChangedListener(this)
-    this.filterService.addListener(this)
+    merge(
+      this.filterService.event$,
+      this.filterService.teams$,
+      this.filterService.users$,
+      this.filterService.forms$,
+      this.filterService.interval$,
+      this.filterService.actionFilter$
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.onFilterChanged())
   }
 
   ngOnDestroy(): void {
-    this.filterService.removeListener(this)
     this.eventService.removeObservationsChangedListener(this)
   }
 

--- a/web-app/src/app/user/user-list/user-list.component.ts
+++ b/web-app/src/app/user/user-list/user-list.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { merge } from 'rxjs';
 import moment from 'moment';
 import { EventService } from '../../event/event.service';
 import { FilterService } from '../../filter/filter.service';
@@ -22,16 +24,25 @@ export class UserListComponent implements OnInit, OnDestroy {
 
   constructor(
     private eventService: EventService,
-    private filterService: FilterService) {
+    private filterService: FilterService,
+    private destroyRef: DestroyRef) {
   }
 
   ngOnInit(): void {
-    this.filterService.addListener(this)
+    merge(
+      this.filterService.event$,
+      this.filterService.teams$,
+      this.filterService.users$,
+      this.filterService.forms$,
+      this.filterService.interval$,
+      this.filterService.actionFilter$
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.onFilterChanged())
     this.eventService.addUsersChangedListener(this)
   }
 
   ngOnDestroy(): void {
-    this.filterService.removeListener(this)
     this.eventService.removeUsersChangedListener(this)
   }
 


### PR DESCRIPTION
## Summary

Adds a searchable event picker to the top navbar (CDK menu dropdown), replacing the old flow where the event was one of several fields in the "Filter" dialog. The dialog now only handles team/user/form/time filtering.

## Changes

- **Navbar event picker** — clicking the event title opens a searchable dropdown of all events, replacing the static event name text.
- **`FilterService`** moves from a listener/callback pattern (`addListener`/`onFilterChanged`) to RxJS `BehaviorSubject`s (`event$`, `teams$`, `users$`, `forms$`, `interval$`, `actionFilter$`). Same filtering logic and state — just a reactive notification mechanism instead of callbacks.
- **`EventService`**, `NavigationComponent`, `HomeComponent`, `UserListComponent`, and `ObservationListComponent` all subscribe to the new observables instead of registering as listeners. `EventService`'s event/interval/team/user/form reaction logic is otherwise unchanged — still client-side filtering, still the same incremental add/remove bookkeeping.
- Components with a real Angular lifecycle use `takeUntilDestroyed()` instead of a manual `destroy$` Subject. `EventService` keeps a manual `destroy$`, since it's a root-singleton service with its own `init()`/`destroy()` lifecycle that isn't tied to Angular's actual injector destruction.
- Fixed a loading flash: the navbar title no longer shows "Select Event" while the initial events query is still in flight — it stays blank until the query resolves and there's actually no event to show.
- Extracted a shared `filterAutocomplete()` helper in `FilterComponent` for the team/user/form autocomplete pickers, which had the same narrow-by-selection-and-search-text logic duplicated three times.

## Test plan

- `tsc --noEmit` clean
- Full suite: 1035/1035 passing
- New coverage: `filter.service.spec.ts`, `event.service.spec.ts`, `navigation.component.spec.ts` (reactive wiring, event picker search/select, loading-flash fix)



https://github.com/user-attachments/assets/4f44541a-def4-4bee-97c2-43c22fbeb422



