### PR TITLE
feat(service): observation full-text and condition search engine

### DIFF
--- a/service/src/adapters/events/adapters.events.db.mongoose.ts
+++ b/service/src/adapters/events/adapters.events.db.mongoose.ts
@@ -1,5 +1,5 @@
 import { BaseMongooseRepository } from '../base/adapters.base.db.mongoose'
-import { MageEventRepository, MageEventAttrs, MageEventId, MageEvent } from '../../entities/events/entities.events'
+import { MageEventRepository, MageEventAttrs, MageEventId, MageEvent, ObservationSearchStatus } from '../../entities/events/entities.events'
 import mongoose from 'mongoose'
 import { FeedId } from '../../entities/feeds/entities.feeds'
 import * as legacy from '../../models/event'
@@ -21,7 +21,28 @@ export class MongooseMageEventRepository extends BaseMongooseRepository<MageEven
   }
 
   async update(attrs: Partial<MageEventAttrs> & { id: MageEventId }): Promise<MageEventAttrs | null> {
-    throw new Error('method not allowed')
+    const propertyWhitelist: (keyof MageEventAttrs)[] = [ 'name', 'description', 'minObservationForms', 'maxObservationForms', 'complete', 'forms', 'observationSearchStatus' ]
+    const update = Object.fromEntries(
+      propertyWhitelist.filter(key => key in attrs).map(key => [ key, attrs[key] ])
+    ) as Partial<MageEventAttrs>
+    if (update.forms) {
+      // preserve form ids
+      update.forms = update.forms.map(form => ({ ...form, _id: form.id } as any))
+    }
+    const updated = await this.model.findByIdAndUpdate(attrs.id, update, { new: true, runValidators: true })
+    return updated ? this.entityForDocument(updated) : null
+  }
+
+  async updateSearchStatusForEvents(status: ObservationSearchStatus): Promise<void> {
+    await this.model.updateMany({}, { $set: { observationSearchStatus: status } })
+  }
+
+  async claimIndexing(id: MageEventId): Promise<boolean> {
+    const result = await this.model.findOneAndUpdate(
+      { _id: id, observationSearchStatus: { $ne: 'running' } },
+      { $set: { observationSearchStatus: 'running' } }
+    )
+    return result !== null
   }
 
   async findById(id: MageEventId): Promise<MageEvent | null> {

--- a/service/src/adapters/observations/adapters.observations.search.controllers.web.ts
+++ b/service/src/adapters/observations/adapters.observations.search.controllers.web.ts
@@ -1,0 +1,45 @@
+import express from 'express'
+import { UserWithRole } from '../../permissions/permissions.role-based.base'
+import { compatibilityMageAppErrorHandler, WebAppRequestFactory } from '../adapters.controllers.web'
+import { AppRequest } from '../../app.api/app.api.global'
+import { invalidInput } from '../../app.api/app.api.errors'
+import { SearchIndexAllEvents, SearchIndexAllEventsRequest, SearchIndexEvent, SearchIndexEventRequest } from '../../app.api/observations/app.api.observations.search'
+
+export interface SearchIndexAppLayer {
+  searchIndexAll: SearchIndexAllEvents
+  searchIndexEvent: SearchIndexEvent
+}
+
+export function SearchIndexRoutes(appLayer: SearchIndexAppLayer, createAppRequest: WebAppRequestFactory<AppRequest<UserWithRole>>): express.Router {
+
+  const routes = express.Router()
+
+  routes.route('/events')
+    .post(async (req, res, next) => {
+      const appReq: SearchIndexAllEventsRequest = createAppRequest(req)
+
+      const appRes = await appLayer.searchIndexAll(appReq)
+      if (appRes.success) {
+        return res.sendStatus(202)
+      }
+      next(appRes.error)
+    })
+
+  routes.route('/events/:eventId')
+    .post(async (req, res, next) => {
+      const eventId = req.params.eventId
+      if (!eventId || isNaN(Number(eventId))) {
+        return next(invalidInput('Event id must be a number.', [ 'eventId' ]))
+      }
+      const appReq: SearchIndexEventRequest = createAppRequest(req, { eventId: Number(eventId) })
+      const appRes = await appLayer.searchIndexEvent(appReq)
+      if (appRes.success) {
+        return res.sendStatus(202)
+      }
+      next(appRes.error)
+    })
+
+  routes.use(compatibilityMageAppErrorHandler)
+
+  return routes
+}

--- a/service/src/adapters/observations/adapters.observations.search.db.mongoose.ts
+++ b/service/src/adapters/observations/adapters.observations.search.db.mongoose.ts
@@ -1,0 +1,298 @@
+import mongoose, { Connection, Document, FilterQuery, Model, Schema } from 'mongoose'
+import { MageEvent, MageEventId } from '../../entities/events/entities.events'
+import { Form, FormFieldType } from '../../entities/events/entities.events.forms'
+import { Condition, FormEntryId, ObservationAttrs, ObservationFieldFilter, ObservationId, ObservationSearchAttrs, ObservationSearchRepository, SimpleCondition } from '../../entities/observations/entities.observations'
+import { BaseMongooseRepository } from '../base/adapters.base.db.mongoose'
+import _ from 'lodash'
+import moment from 'moment'
+
+export const ObservationSearchModelVersion = 2
+
+export type ObservationSearchDocument = {
+  observationId: mongoose.Types.ObjectId
+  eventId: MageEventId
+  formId: number
+  formEntryId: FormEntryId
+  text: string
+  [key: string]: any
+} & Document
+
+export type ObservationSearchModel = Model<ObservationSearchDocument>
+
+export const ObservationSearchModelName = 'ObservationSearch'
+
+export const ObservationSearchSchema = new Schema({
+  observationId: { type: Schema.Types.ObjectId, required: true },
+  eventId: { type: Number, required: true },
+  formId: { type: Number, required: true },
+  formEntryId: { type: String, required: true },
+  text: { type: String, required: false, default: '' },
+}, {
+  strict: false,
+  versionKey: false
+})
+
+// unique per form entry — used by populate to skip already-indexed entries
+ObservationSearchSchema.index({ formEntryId: 1 }, { unique: true })
+// used by save to delete all entries for an observation before re-inserting
+ObservationSearchSchema.index({ observationId: 1 })
+// used by condition queries (with index intersection on wildcard for field values)
+ObservationSearchSchema.index({ eventId: 1, formId: 1 })
+// wildcard covers all dynamic form fields
+// MongoDB 6 — separate indexes; query optimizer uses index intersection for condition search.
+// When upgrading to MongoDB 7, replace the two above with a single compound wildcard:
+// { eventId: 1, formId: 1, '$**': 1 }
+ObservationSearchSchema.index({ '$**': 1 })
+ObservationSearchSchema.index({ eventId: 1, text: 'text' })
+
+export function ObservationSearchModel(conn: Connection, collection?: string): ObservationSearchModel {
+  return conn.model(ObservationSearchModelName, ObservationSearchSchema, collection || 'observationsearch') as any
+}
+
+export class MongooseObservationSearchRepository extends BaseMongooseRepository<ObservationSearchDocument, ObservationSearchModel, ObservationSearchAttrs> implements ObservationSearchRepository {
+
+  constructor(model: ObservationSearchModel) {
+    super(model)
+  }
+
+  async populate(eventId: MageEventId, observations: AsyncIterable<ObservationAttrs>, force: boolean = false): Promise<number> {
+    const insertIgnoreDuplicates = async (batch: ObservationSearchAttrs[]): Promise<number> => {
+      try {
+        const result = await this.model.insertMany(batch, { ordered: false })
+        return result.length
+      } catch (e: any) {
+        // Ignore 11000 duplicate key error — formEntryId already indexed
+        if (e.code !== 11000) throw e
+        return e.result?.insertedCount ?? 0
+      }
+    }
+
+    if (force) {
+      await this.model.deleteMany({ eventId })
+    }
+
+    let count = 0
+    const batchSize = 1000
+    let batch: ObservationSearchAttrs[] = []
+    for await (const observation of observations) {
+      batch.push(...searchDocsForObservation(observation))
+      if (batch.length >= batchSize) {
+        count += await insertIgnoreDuplicates(batch)
+        batch = []
+      }
+    }
+
+    if (batch.length) {
+      count += await insertIgnoreDuplicates(batch)
+    }
+
+    return count
+  }
+
+  async save(observation: ObservationAttrs): Promise<void> {
+    const docs = searchDocsForObservation(observation)
+    await this.model.deleteMany({ observationId: observation.id })
+    if (docs.length) {
+      await this.model.insertMany(docs)
+    }
+  }
+
+  async findIdsByFilter(filter: ObservationFieldFilter, event: MageEvent): Promise<ObservationId[]> {
+    if (filter.condition && filter.keyword) {
+      const keywordIds = await this.findObjectIdsByKeyword(filter.keyword, event.id)
+      if (keywordIds.length === 0) return []
+      return this.findIdsByCondition(filter.condition, event, keywordIds)
+    }
+    if (filter.keyword) {
+      return this.findIdsByKeyword(filter.keyword, event.id)
+    }
+    if (filter.condition) {
+      return this.findIdsByCondition(filter.condition, event)
+    }
+    return []
+  }
+
+  private async findIdsByKeyword(keyword: string, eventId: MageEventId): Promise<ObservationId[]> {
+    const ids = await this.findObjectIdsByKeyword(keyword, eventId)
+    return ids.map(id => id.toHexString())
+  }
+
+  private async findIdsByCondition(condition: Condition, event: MageEvent, withinIds?: mongoose.Types.ObjectId[]): Promise<ObservationId[]> {
+    const conditions = flattenCondition(condition).map(condition => {
+      const form = event.forms.find(f => f.id === condition.formId)
+      return { formId: condition.formId, ...asFilterQuery(condition, form) }
+    })
+    const baseMatch: Record<string, any> = withinIds
+      ? { eventId: event.id, observationId: { $in: withinIds }, $or: conditions }
+      : { eventId: event.id, $or: conditions }
+    const expression = asAggregateExpression(condition, event)
+    const results = await this.model.aggregate([
+      { $match: baseMatch },
+      { $group: { _id: '$observationId', observations: { $push: '$$ROOT' } } },
+      { $match: { $expr: expression } },
+      { $project: { _id: 1 } }
+    ]).exec()
+    return results.map((result: { _id: mongoose.Types.ObjectId }) => result._id.toHexString())
+  }
+
+  private async findObjectIdsByKeyword(keyword: string, eventId: MageEventId): Promise<mongoose.Types.ObjectId[]> {
+    const andSearch = toAndSearch(keyword)
+    const phrases = extractPhrases(keyword)
+    const match: Record<string, any> = { eventId, $text: { $search: andSearch } }
+    if (phrases.length) {
+      match.$and = phrases.map(phrase => ({ text: { $regex: `\\b${_.escapeRegExp(phrase)}\\b`, $options: 'i' } }))
+    }
+    return this.model.distinct('observationId', match)
+  }
+}
+
+/**
+ * Extracts quoted phrases from a keyword query, e.g. `hello "exact usecase"` → `["exact usecase"]`.
+ * Used to apply exact regex matching after the text index search to compensate for stemming.
+ */
+function extractPhrases(keyword: string): string[] {
+  const matches = keyword.match(/"([^"]+)"/g) ?? []
+  return matches.map(m => m.slice(1, -1))
+}
+
+/**
+ * Converts a keyword query to a MongoDB $text search string that requires ALL
+ * terms to match (AND semantics). Quoted phrases are passed through unchanged
+ * so users can search for exact phrases, e.g. `"exact usecase"`.
+ */
+function toAndSearch(keyword: string): string {
+  const tokens = keyword.trim().match(/("(?:[^"]+)"|\S+)/g)
+  if (!tokens) {
+    return keyword
+  }
+  return tokens.map(token => token.startsWith('"') ? token : `"${token}"`).join(' ')
+}
+
+function searchDocsForObservation(observation: ObservationAttrs): ObservationSearchAttrs[] {
+  return observation.properties.forms.map(form => {
+    const { id: formEntryId, formId, ...fields } = form
+    const text = Object.values(fields).flatMap(value => {
+      if (typeof value === 'string') return [value]
+      if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string')
+      return []
+    }).join(' ')
+    return {
+      observationId: observation.id,
+      eventId: observation.eventId,
+      formId,
+      formEntryId: String(formEntryId),
+      text,
+      ...fields,
+    }
+  })
+}
+
+function flattenCondition(condition: Condition): SimpleCondition[] {
+  if ('and' in condition) {
+    return condition.and.flatMap(flattenCondition)
+  }
+
+  if ('or' in condition) {
+    return condition.or.flatMap(flattenCondition)
+  }
+
+  return [condition]
+}
+
+function asAggregateExpression(condition: Condition, event: MageEvent): object {
+  if ('and' in condition) {
+    return { $and: condition.and.map(c => asAggregateExpression(c, event)) }
+  }
+
+  if ('or' in condition) {
+    return { $or: condition.or.map(c => asAggregateExpression(c, event)) }
+  }
+
+  const form = event.forms.find(f => f.id === condition.formId)
+  return {
+    $gt: [{
+      $size: {
+        $filter: {
+          input: '$observations',
+          cond: {
+            $and: [
+              { $eq: ['$$this.formId', condition.formId] },
+              asFieldAggregateExpression(condition, form),
+            ]
+          },
+        },
+      },
+    }, 0]
+  }
+}
+
+function toQueryValue(value: any, form: Form | undefined, fieldName: string): any {
+  const formField = form?.fields.find(f => f.name === fieldName)
+  if (formField?.type === FormFieldType.DateTime && typeof value === 'string') {
+    return parseISO8601(value) ?? value
+  }
+  return value
+}
+
+function asFilterQuery(condition: SimpleCondition, form: Form | undefined): FilterQuery<ObservationSearchDocument> {
+  const { field } = condition
+  const value = (v: any) => toQueryValue(v, form, field)
+
+  switch (condition.operator) {
+    case '=': return { [field]: { $eq: value(condition.value) } }
+    case '!=': return { [field]: { $ne: value(condition.value) } }
+    case '>': return { [field]: { $gt: value(condition.value) } }
+    case '>=': return { [field]: { $gte: value(condition.value) } }
+    case '<': return { [field]: { $lt: value(condition.value) } }
+    case '<=': return { [field]: { $lte: value(condition.value) } }
+    case 'LIKE': return { [field]: { $regex: _.escapeRegExp(String(condition.value)), $options: 'i' } }
+    case 'IN': return { [field]: { $in: condition.value } }
+    case 'NOT IN': return { [field]: { $nin: condition.value } }
+    case 'BETWEEN':
+      return { [field]: { $gte: value(condition.value[0]), $lte: value(condition.value[1]) } }
+    case 'IS NULL':
+      return { [field]: { $in: [null, undefined] } }
+    case 'IS NOT NULL':
+      return { [field]: { $nin: [null, undefined] } }
+  }
+}
+
+function asFieldAggregateExpression(
+  condition: SimpleCondition,
+  form: Form | undefined
+): object {
+  const formField = form?.fields.find(f => f.name === condition.field)
+  const fieldIsArray = formField?.type === FormFieldType.MultiSelectDropdown
+  const value = (v: any) => toQueryValue(v, form, condition.field)
+
+  const field = `$$this.${condition.field}`
+  switch (condition.operator) {
+    case '=':
+      if (fieldIsArray) {
+        return { $in: [value(condition.value), field] }
+      }
+      return { $eq: [field, value(condition.value)] }
+    case '!=':
+      if (fieldIsArray) {
+        return { $not: { $in: [value(condition.value), field] } }
+      }
+      return { $ne: [field, value(condition.value)] }
+    case '>': return { $gt: [field, value(condition.value)] }
+    case '>=': return { $gte: [field, value(condition.value)] }
+    case '<': return { $lt: [field, value(condition.value)] }
+    case '<=': return { $lte: [field, value(condition.value)] }
+    case 'LIKE': return { $regexMatch: { input: field, regex: _.escapeRegExp(String(condition.value)), options: 'i' } }
+    case 'IN': return { $in: [field, condition.value] }
+    case 'NOT IN': return { $not: { $in: [field, condition.value] } }
+    case 'BETWEEN': return { $and: [{ $gte: [field, value(condition.value[0])] }, { $lte: [field, value(condition.value[1])] }] }
+    case 'IS NULL': return { $eq: [{ $ifNull: [field, null] }, null] }
+    case 'IS NOT NULL': return { $ne: [{ $ifNull: [field, null] }, null] }
+  }
+}
+
+function parseISO8601(iso8601: string): Date | undefined {
+  const date = moment(iso8601, moment.ISO_8601, true)
+  if (typeof iso8601 === 'string' && date.isValid()) {
+    return date.toDate()
+  }
+}

--- a/service/src/app.api/observations/app.api.observations.search.ts
+++ b/service/src/app.api/observations/app.api.observations.search.ts
@@ -1,0 +1,27 @@
+import { MageEventAttrs, MageEventId } from '../../entities/events/entities.events'
+import { EntityNotFoundError, PermissionDeniedError } from '../app.api.errors'
+import { AppRequest, AppRequestContext, AppResponse } from '../app.api.global'
+
+export interface SearchIndexAllEventsRequest<Principal = unknown> extends AppRequest<Principal, AppRequestContext<Principal>> {}
+export interface SearchIndexEventRequest<Principal = unknown> extends AppRequest<Principal, AppRequestContext<Principal>> {
+  eventId: MageEventId
+}
+
+export interface SearchIndexResponse {}
+
+export interface SearchIndexAllEvents {
+  (req: SearchIndexAllEventsRequest): Promise<AppResponse<SearchIndexResponse, PermissionDeniedError>>
+}
+
+export interface SearchIndexEvent {
+  (req: SearchIndexEventRequest): Promise<AppResponse<SearchIndexResponse, PermissionDeniedError | EntityNotFoundError>>
+}
+
+export interface SearchIndexPermissionService {
+  ensureSearchIndexAllPermission(context: AppRequestContext): Promise<PermissionDeniedError | null>
+  ensureSearchIndexEventPermission(context: AppRequestContext): Promise<PermissionDeniedError | null>
+}
+
+export interface IndexEventObservations {
+  (event: MageEventAttrs, force?: boolean): Promise<void>
+}

--- a/service/src/app.impl/observations/app.impl.observations.search.ts
+++ b/service/src/app.impl/observations/app.impl.observations.search.ts
@@ -1,0 +1,104 @@
+import EventEmitter from 'events'
+import { AppResponse } from '../../app.api/app.api.global'
+import * as api from '../../app.api/observations/app.api.observations.search'
+import { entityNotFound } from '../../app.api/app.api.errors'
+import { Logger, NoopLogger } from '../../entities/entities.logging'
+import { MageEventAttrs, MageEventRepository } from '../../entities/events/entities.events'
+import { ObservationAttrs, ObservationDomainEventType, ObservationEmitted, ObservationRepositoryForEvent, ObservationSavedDomainEvent, ObservationSearchRepository } from '../../entities/observations/entities.observations'
+
+export function IndexEventObservations(
+  eventRepository: MageEventRepository,
+  observationRepoForEvent: ObservationRepositoryForEvent,
+  observationSearchRepo: ObservationSearchRepository,
+  log: Logger = NoopLogger
+): api.IndexEventObservations {
+  return async function indexEventObservations(event: MageEventAttrs, force: boolean = false): Promise<void> {
+    try {
+      const claimed = await eventRepository.claimIndexing(event.id)
+      if (!claimed) {
+        log.debug(`skipping index for event ${event.id}, already running`)
+        return
+      }
+
+      let observations: AsyncIterable<ObservationAttrs> & { close?: () => void } | null = null
+      try {
+        const observationRepo = await observationRepoForEvent(event.id)
+        observations = observationRepo.iterate({})
+        const count = await observationSearchRepo.populate(event.id, observations, force)
+        log.debug(`indexed ${count} new observations for search for event ${event.id}`)
+      } finally {
+        observations?.close?.()
+      }
+
+      await eventRepository.update({ id: event.id, observationSearchStatus: 'indexed' })
+    } catch (err) {
+      log.error(`failed to index observations for search for event ${event.id}`, err)
+      await eventRepository.update({ id: event.id, observationSearchStatus: 'pending' })
+    }
+  }
+}
+
+export async function indexAllEvents(
+  eventRepository: MageEventRepository,
+  indexEventObservations: api.IndexEventObservations,
+  force: boolean = false
+): Promise<void> {
+  const events = await eventRepository.findAll()
+  for (const event of events) {
+    // Reset any stale 'running' status left by a previous crash so claimIndexing can proceed
+    if (event.observationSearchStatus === 'running') {
+      await eventRepository.update({ id: event.id, observationSearchStatus: 'pending' })
+    }
+    await indexEventObservations(event, force)
+  }
+}
+
+export function SearchIndexAllEvents(
+  permissionService: api.SearchIndexPermissionService,
+  eventRepository: MageEventRepository,
+  indexEventObservations: api.IndexEventObservations
+): api.SearchIndexAllEvents {
+  return async function searchIndexAllEvents(req: api.SearchIndexAllEventsRequest): ReturnType<api.SearchIndexAllEvents> {
+    const denied = await permissionService.ensureSearchIndexAllPermission(req.context)
+    if (denied) {
+      return AppResponse.error(denied)
+    }
+
+    indexAllEvents(eventRepository, indexEventObservations, true)
+
+    return AppResponse.success({})
+  }
+}
+
+export function SearchIndexEvent(
+  permissionService: api.SearchIndexPermissionService,
+  eventRepository: MageEventRepository,
+  indexEventObservations: api.IndexEventObservations
+): api.SearchIndexEvent {
+  return async function searchIndexEvent(req: api.SearchIndexEventRequest): ReturnType<api.SearchIndexEvent> {
+    const denied = await permissionService.ensureSearchIndexEventPermission(req.context)
+    if (denied) {
+      return AppResponse.error(denied)
+    }
+
+    const event = await eventRepository.findById(req.eventId)
+    if (!event) {
+      return AppResponse.error(entityNotFound(req.eventId, 'Event'))
+    }
+
+    // Reset any stale 'running' status left by a previous crash so claimIndexing can proceed
+    if (event.observationSearchStatus === 'running') {
+      await eventRepository.update({ id: event.id, observationSearchStatus: 'pending' })
+    }
+
+    indexEventObservations(event, true)
+
+    return AppResponse.success({})
+  }
+}
+
+export function registerObservationSavedHandler(domainEvents: EventEmitter, repo: ObservationSearchRepository): void {
+  domainEvents.on(ObservationDomainEventType.ObservationSaved, async (e: ObservationEmitted<ObservationSavedDomainEvent>) => {
+    await repo.save(e.observation)
+  })
+}

--- a/service/src/app.ts
+++ b/service/src/app.ts
@@ -30,6 +30,10 @@ import * as eventsApi from './app.api/events/app.api.events';
 import * as eventsImpl from './app.impl/events/app.impl.events';
 import * as observationsApi from './app.api/observations/app.api.observations';
 import * as observationsImpl from './app.impl/observations/app.impl.observations';
+import * as observationsSearchImpl from './app.impl/observations/app.impl.observations.search';
+import { SearchIndexAppLayer, SearchIndexRoutes } from './adapters/observations/adapters.observations.search.controllers.web';
+import { SearchIndexPermissionsServiceImpl } from './permissions/permissions.observations.search';
+import { MongooseObservationSearchRepository, ObservationSearchModel } from './adapters/observations/adapters.observations.search.db.mongoose';
 import { PreFetchedUserRoleFeedsPermissionService } from './permissions/permissions.feeds';
 import { FeedsRoutes } from './adapters/feeds/adapters.feeds.controllers.web';
 import { WebAppRequestFactory } from './adapters/adapters.controllers.web';
@@ -198,6 +202,12 @@ export interface MageService {
 
 export interface Task {
   run(): Promise<void>;
+  /**
+   * If true, the task runs without the boot sequence waiting for it to
+   * complete.  Use this for tasks that could take a long time, such as a
+   * catch-up job over all existing data, so server startup is not blocked.
+   */
+  background?: boolean;
 }
 
 /**
@@ -372,7 +382,11 @@ export const boot = async function(config: BootConfig): Promise<MageService> {
   }
 
   for (const task of tasks) {
-    await task.run();
+    if (task.background) {
+      task.run();
+    } else {
+      await task.run();
+    }
   }
 
   const server = httpLib.createServer(webController);
@@ -422,6 +436,7 @@ type DatabaseLayer = {
   }
   observations: {
     icons: ObservationIconModel
+    search: ObservationSearchModel
   }
   locations: {
     location: UserLocationModel
@@ -476,6 +491,7 @@ type AppLayer = {
   userPreferences: UserPreferencesAppLayer
   systemInfo: SystemInfoAppLayer
   settings: SettingsAppLayer
+  searchIndex: SearchIndexAppLayer
 }
 
 async function initDatabase(): Promise<DatabaseLayer> {
@@ -560,7 +576,8 @@ async function initDatabase(): Promise<DatabaseLayer> {
       preference: UserPreferenceModel(conn)
     },
     observations: {
-      icons: ObservationIconModel(conn)
+      icons: ObservationIconModel(conn),
+      search: ObservationSearchModel(conn)
     },
     locations: {
       location: UserLocationModel(conn),
@@ -591,6 +608,7 @@ type Repositories = {
     attachmentStore: AttachmentStore
     iconRepo: ObservationIconRepository
     iconStore: ObservationIconContentStore
+    searchRepo: ObservationSearchRepository
   };
   feeds: {
     serviceTypeRepo: FeedServiceTypeRepository
@@ -718,7 +736,8 @@ async function initRepositories(
       ),
       iconRepo: observationIconRepo,
       iconStore: observationIconStore,
-      attachmentStore
+      attachmentStore,
+      searchRepo: new MongooseObservationSearchRepository(models.observations.search)
     },
     icons: {
       staticIconRepo
@@ -754,6 +773,7 @@ async function initAppLayer(repos: Repositories, attachmentHooks: AttachmentHook
   const teams = await initTeamsAppLayer(repos)
   const systemInfo = initSystemInfoAppLayer(repos)
   const settings = await initSettingsAppLayer(repos, log.child({ component: 'settings' }))
+  const searchIndex = await initSearchIndexAppLayer(repos)
 
   return {
     events,
@@ -767,6 +787,33 @@ async function initAppLayer(repos: Repositories, attachmentHooks: AttachmentHook
     systemInfo,
     settings,
     teams,
+    searchIndex,
+  }
+}
+
+async function initSearchIndexAppLayer(repos: Repositories): Promise<AppLayer['searchIndex']> {
+  const eventPermissions = await import('./permissions/permissions.events');
+  const permissionService = new SearchIndexPermissionsServiceImpl(
+    eventPermissions.defaultEventPermissionsService
+  );
+  const indexEvent = observationsSearchImpl.IndexEventObservations(
+    repos.events.eventRepo,
+    repos.observations.obsRepoFactory,
+    repos.observations.searchRepo,
+    log.child({ component: 'search-index' })
+  );
+
+  return {
+    searchIndexAll: observationsSearchImpl.SearchIndexAllEvents(
+      permissionService,
+      repos.events.eventRepo,
+      indexEvent
+    ),
+    searchIndexEvent: observationsSearchImpl.SearchIndexEvent(
+      permissionService,
+      repos.events.eventRepo,
+      indexEvent
+    )
   }
 }
 
@@ -937,24 +984,6 @@ async function initEventsAppLayer(
   };
 }
 
-/**
- * TODO: replace with a real implementation once the observation full-text/
- * condition search engine lands.  Until then, only requests that specify no
- * field filter reach {@link ReadObservations}, so this should never actually
- * be called.
- */
-const observationSearchRepoStub: ObservationSearchRepository = {
-  save(): Promise<void> {
-    throw new Error('ObservationSearchRepository is not yet implemented')
-  },
-  populate(): Promise<number> {
-    throw new Error('ObservationSearchRepository is not yet implemented')
-  },
-  findIdsByFilter(): Promise<string[]> {
-    throw new Error('ObservationSearchRepository is not yet implemented')
-  }
-}
-
 async function initObservationsAppLayer(
   repos: Repositories,
   attachmentHooks: AttachmentHook[]
@@ -978,11 +1007,16 @@ async function initObservationsAppLayer(
     log.child({ component: 'observations' })
   );
 
+  observationsSearchImpl.registerObservationSavedHandler(
+    DomainEvents,
+    repos.observations.searchRepo
+  );
+
   return {
     readObservations: observationsImpl.ReadObservations(
       obsPermissionsService,
       repos.teams.teamRepo,
-      observationSearchRepoStub
+      repos.observations.searchRepo
     ),
     allocateObservationId: observationsImpl.AllocateObservationId(
       obsPermissionsService
@@ -1226,6 +1260,9 @@ async function initWebLayer(
   const systemInfoRoutes = SystemInfoRoutes(app.systemInfo, appRequestFactory);
   webController.use('/api', [optionalBearerAuthentication, systemInfoRoutes]);
 
+  const searchIndexRoutes = SearchIndexRoutes(app.searchIndex, appRequestFactory);
+  webController.use('/api/search-index', [bearerAuthentication, searchIndexRoutes]);
+
   const observationRequestFactory: ObservationWebAppRequestFactory = <
     Params extends object | undefined
   >(
@@ -1372,7 +1409,20 @@ async function initTasks(repos: Repositories, logger: Logger): Promise<Task[]> {
     logger
   );
 
-  return [exportTask];
+  const indexEventObservations = observationsSearchImpl.IndexEventObservations(
+    repos.events.eventRepo,
+    repos.observations.obsRepoFactory,
+    repos.observations.searchRepo,
+    log.child({ component: 'search-index' })
+  );
+  const searchIndexTask: Task = {
+    background: true,
+    run(): Promise<void> {
+      return observationsSearchImpl.indexAllEvents(repos.events.eventRepo, indexEventObservations);
+    }
+  };
+
+  return [exportTask, searchIndexTask];
 }
 
 function baseAppRequestContext(

--- a/service/src/entities/events/entities.events.ts
+++ b/service/src/entities/events/entities.events.ts
@@ -5,6 +5,8 @@ import { copyLineStyleAttrs, LineStyle } from '../entities.global'
 
 export type MageEventId = number
 
+export type ObservationSearchStatus = 'pending' | 'running' | 'indexed'
+
 export interface MageEventAttrs {
   id: MageEventId
   name: string
@@ -19,6 +21,7 @@ export interface MageEventAttrs {
   maxObservationForms?: number
   style: LineStyle
   acl: Acl
+  observationSearchStatus?: ObservationSearchStatus
 }
 
 /**
@@ -48,6 +51,7 @@ export function copyMageEventAttrs(x: MageEventAttrs): MageEventAttrs {
     teams: x.teams, // TODO: this might go away
     acl: copyAclAttrs(x.acl),
     style: copyLineStyleAttrs(x.style),
+    observationSearchStatus: x.observationSearchStatus,
   }
 }
 
@@ -102,6 +106,7 @@ export class MageEvent implements Readonly<MageEventAttrs> {
   get maxObservationForms(): number | undefined { return this.#attrs.maxObservationForms }
   get style(): LineStyle { return this.#attrs.style }
   get acl(): Acl { return this.#attrs.acl }
+  get observationSearchStatus(): ObservationSearchStatus | undefined { return this.#attrs.observationSearchStatus }
 
   formFor(id: FormId): Form | null {
     return this.#formIndex.get(id) || null
@@ -196,4 +201,12 @@ export interface MageEventRepository {
    * @param feed the ID of the feed to remove from events
    */
   removeFeedsFromEvents(...feed: FeedId[]): Promise<number>
+  update(attrs: Partial<MageEventAttrs> & { id: MageEventId }): Promise<MageEventAttrs | null>
+  updateSearchStatusForEvents(status: ObservationSearchStatus): Promise<void>
+  /**
+   * Atomically set the search status to 'running' only if it is not already
+   * 'running'.  Returns true if the claim succeeded (this caller owns the
+   * indexing operation), false if another operation is already running.
+   */
+  claimIndexing(id: MageEventId): Promise<boolean>
 }

--- a/service/src/entities/observations/entities.observations.ts
+++ b/service/src/entities/observations/entities.observations.ts
@@ -962,6 +962,15 @@ export type FindObservationsResult<T> =
   | { type: 'all', observations: T[] }
   | { type: 'paged', page: PageOf<T> }
 
+export type ObservationSearchAttrs = {
+  observationId: ObservationId
+  eventId: MageEventId
+  formId: FormId
+  formEntryId: FormEntryId
+  text: string
+  [fieldName: string]: any
+}
+
 /**
  * Provides observation full-text/condition search results for a
  * {@link EventScopedObservationRepository.find | find} or

--- a/service/src/models/event.js
+++ b/service/src/models/event.js
@@ -86,6 +86,7 @@ const EventSchema = new Schema({
   forms: [FormSchema],
   minObservationForms: { type: Number },
   maxObservationForms: { type: Number },
+  observationSearchStatus: { type: String, enum: ['pending', 'running', 'indexed'] },
   style: {
     type: Schema.Types.Mixed,
     required: true,

--- a/service/src/permissions/permissions.observations.search.ts
+++ b/service/src/permissions/permissions.observations.search.ts
@@ -1,0 +1,19 @@
+import { PermissionDeniedError } from '../app.api/app.api.errors'
+import { AppRequestContext } from '../app.api/app.api.global'
+import { SearchIndexPermissionService } from '../app.api/observations/app.api.observations.search'
+import { MageEventPermission } from '../entities/authorization/entities.permissions'
+import { EventPermissionServiceImpl } from './permissions.events'
+import { ensureContextUserHasPermission, UserWithRole } from './permissions.role-based.base'
+
+export class SearchIndexPermissionsServiceImpl implements SearchIndexPermissionService {
+
+  constructor(private eventPermissions: EventPermissionServiceImpl) {}
+
+  async ensureSearchIndexAllPermission(context: AppRequestContext<UserWithRole>): Promise<PermissionDeniedError | null> {
+    return ensureContextUserHasPermission(context, MageEventPermission.UPDATE_EVENT)
+  }
+
+  async ensureSearchIndexEventPermission(context: AppRequestContext<UserWithRole>): Promise<PermissionDeniedError | null> {
+    return this.eventPermissions.ensureEventUpdatePermission(context)
+  }
+}

--- a/service/test/adapters/events/adapters.events.db.mongoose.test.ts
+++ b/service/test/adapters/events/adapters.events.db.mongoose.test.ts
@@ -461,8 +461,57 @@ describe('event mongoose repository', function () {
     await expect(repo.create()).to.eventually.rejectWith(Error)
   })
 
-  it('does not allow updating events', async function () {
-    await expect(repo.update({ id: eventDoc._id, feedIds: ['not_allowed'] })).to.eventually.rejectWith(Error)
+  describe('updating events', function () {
+
+    it('updates allowed attributes', async function () {
+      const updated = await repo.update({ id: eventDoc._id, name: 'Renamed Event', description: 'new description' })
+      expect(updated?.name).to.equal('Renamed Event')
+      expect(updated?.description).to.equal('new description')
+    })
+
+    it('ignores attributes that are not allowed to be updated', async function () {
+      const before = await model.findById(eventDoc._id)
+      const updated = await repo.update({ id: eventDoc._id, feedIds: [ 'not_allowed' ] } as any)
+      expect(updated?.feedIds).to.deep.equal(before?.feedIds ?? [])
+    })
+
+    it('returns null if the event does not exist', async function () {
+      const updated = await repo.update({ id: 999999999, name: 'does not exist' })
+      expect(updated).to.be.null
+    })
+
+    it('updates observationSearchStatus', async function () {
+      const updated = await repo.update({ id: eventDoc._id, observationSearchStatus: 'indexed' })
+      expect(updated?.observationSearchStatus).to.equal('indexed')
+    })
+  })
+
+  describe('search indexing status', function () {
+
+    it('updateSearchStatusForEvents sets the status on all events', async function () {
+      await repo.updateSearchStatusForEvents('pending')
+      const found = await model.findById(eventDoc._id)
+      expect(found?.observationSearchStatus).to.equal('pending')
+    })
+
+    it('claimIndexing succeeds and sets status to running when not already running', async function () {
+      const claimed = await repo.claimIndexing(eventDoc._id)
+      expect(claimed).to.be.true
+      const found = await model.findById(eventDoc._id)
+      expect(found?.observationSearchStatus).to.equal('running')
+    })
+
+    it('claimIndexing fails when already running', async function () {
+      const firstClaim = await repo.claimIndexing(eventDoc._id)
+      const secondClaim = await repo.claimIndexing(eventDoc._id)
+      expect(firstClaim).to.be.true
+      expect(secondClaim).to.be.false
+    })
+
+    it('claimIndexing returns false for an event that does not exist', async function () {
+      const claimed = await repo.claimIndexing(999999999)
+      expect(claimed).to.be.false
+    })
   })
 })
 

--- a/service/test/adapters/locations/adapters.locations.recents.db.mongoose.test.ts
+++ b/service/test/adapters/locations/adapters.locations.recents.db.mongoose.test.ts
@@ -184,6 +184,30 @@ describe('MongooseRecentUserLocationsRepository', function() {
         expect(r.user).to.be.undefined
       })
     })
+
+    it('filters by userIsAnyOf', async function() {
+      const results = await repo.findLocations({
+        where: { eventId, userIsAnyOf: [ user1Id.toHexString() ] }
+      })
+      expect(results).to.have.length(1)
+      expect(results[0].userId).to.equal(user1Id.toHexString())
+    })
+
+    it('returns all matching users when userIsAnyOf has multiple ids', async function() {
+      const results = await repo.findLocations({
+        where: { eventId, userIsAnyOf: [ user1Id.toHexString(), user2Id.toHexString() ] }
+      })
+      expect(results.map(r => r.userId).sort()).to.deep.equal(
+        [ user1Id.toHexString(), user2Id.toHexString() ].sort()
+      )
+    })
+
+    it('returns no results when userIsAnyOf does not match any user', async function() {
+      const results = await repo.findLocations({
+        where: { eventId, userIsAnyOf: [ new mongoose.Types.ObjectId().toHexString() ] }
+      })
+      expect(results).to.have.length(0)
+    })
   })
 
   describe('findLocations with populate', function() {

--- a/service/test/adapters/observations/adapters.observations.search.controllers.web.test.ts
+++ b/service/test/adapters/observations/adapters.observations.search.controllers.web.test.ts
@@ -1,0 +1,98 @@
+import express from 'express'
+import { expect } from 'chai'
+import supertest from 'supertest'
+import { Substitute as Sub, SubstituteOf, Arg } from '@fluffy-spoon/substitute'
+import { AppResponse } from '../../../lib/app.api/app.api.global'
+import { WebAppRequestFactory } from '../../../lib/adapters/adapters.controllers.web'
+import { permissionDenied, entityNotFound } from '../../../lib/app.api/app.api.errors'
+import { SearchIndexAppLayer, SearchIndexRoutes } from '../../../lib/adapters/observations/adapters.observations.search.controllers.web'
+import { AppRequest } from '../../../lib/app.api/app.api.global'
+import { UserWithRole } from '../../../lib/permissions/permissions.role-based.base'
+
+const basePath = '/search-index-test'
+const testUser = 'lummytin'
+
+describe('search index web controller', function () {
+
+  let createAppRequest: WebAppRequestFactory<AppRequest<UserWithRole>>
+  let app: SubstituteOf<SearchIndexAppLayer>
+  let webApp: express.Application
+  let client: supertest.SuperTest<supertest.Test>
+  let context: AppRequest<UserWithRole>['context']
+
+  beforeEach(function () {
+    context = {
+      requestToken: Symbol(),
+      requestingPrincipal(): typeof testUser { return testUser as any },
+      locale() { return null }
+    } as any
+    createAppRequest = <P extends object = {}>(webReq: express.Request, params?: P) => {
+      return { context, ...(params || {} as P) }
+    }
+    app = Sub.for<SearchIndexAppLayer>()
+    const routes = SearchIndexRoutes(app, createAppRequest)
+    webApp = express().use(basePath, routes)
+    client = supertest(webApp)
+  })
+
+  describe('POST /events', function () {
+
+    it('kicks off indexing for all events', async function () {
+
+      app.searchIndexAll(Arg.any()).resolves(AppResponse.success({}))
+
+      const res = await client.post(`${basePath}/events`)
+
+      expect(res.status).to.equal(202)
+      app.received(1).searchIndexAll(Arg.any())
+    })
+
+    it('returns 403 without permission', async function () {
+
+      app.searchIndexAll(Arg.any()).resolves(AppResponse.error(permissionDenied('search index all', testUser)))
+
+      const res = await client.post(`${basePath}/events`)
+
+      expect(res.status).to.equal(403)
+    })
+  })
+
+  describe('POST /events/:eventId', function () {
+
+    it('kicks off indexing for the given event', async function () {
+
+      app.searchIndexEvent(Arg.any()).resolves(AppResponse.success({}))
+
+      const res = await client.post(`${basePath}/events/42`)
+
+      expect(res.status).to.equal(202)
+      app.received(1).searchIndexEvent(Arg.is(req => req.eventId === 42))
+    })
+
+    it('returns 400 when the event id is not a number', async function () {
+
+      const res = await client.post(`${basePath}/events/not-a-number`)
+
+      expect(res.status).to.equal(400)
+      app.didNotReceive().searchIndexEvent(Arg.any())
+    })
+
+    it('returns 403 without permission', async function () {
+
+      app.searchIndexEvent(Arg.any()).resolves(AppResponse.error(permissionDenied('search index event', testUser)))
+
+      const res = await client.post(`${basePath}/events/42`)
+
+      expect(res.status).to.equal(403)
+    })
+
+    it('returns 404 when the event does not exist', async function () {
+
+      app.searchIndexEvent(Arg.any()).resolves(AppResponse.error(entityNotFound(42, 'Event')))
+
+      const res = await client.post(`${basePath}/events/42`)
+
+      expect(res.status).to.equal(404)
+    })
+  })
+})

--- a/service/test/adapters/observations/adapters.observations.search.db.mongoose.test.ts
+++ b/service/test/adapters/observations/adapters.observations.search.db.mongoose.test.ts
@@ -1,0 +1,618 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import mongoose from 'mongoose'
+import { MongooseMageEventRepository } from '../../../lib/adapters/events/adapters.events.db.mongoose'
+import { MongooseObservationSearchRepository, ObservationSearchModel, ObservationSearchModelName } from '../../../lib/adapters/observations/adapters.observations.search.db.mongoose'
+import * as legacyEvent from '../../../lib/models/event'
+import { MageEvent, MageEventAttrs, MageEventCreateAttrs, MageEventId } from '../../../lib/entities/events/entities.events'
+import { Condition, ObservationAttrs, ObservationId, SimpleCondition } from '../../../lib/entities/observations/entities.observations'
+import { FormFieldType, Form } from '../../../lib/entities/events/entities.events.forms'
+import { MageEventDocument, MageEventModelInstance } from '../../../src/models/event'
+import util from 'util'
+
+function observationStub(id: ObservationId, eventId: MageEventId): ObservationAttrs {
+  const now = Date.now()
+  return {
+    id,
+    eventId,
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [ 0, 0 ] },
+    createdAt: new Date(now),
+    lastModified: new Date(now),
+    properties: { timestamp: new Date(now), forms: [] },
+    states: [],
+    favoriteUserIds: [],
+    attachments: [],
+  }
+}
+
+async function* toAsyncIterable(observations: ObservationAttrs[]): AsyncIterable<ObservationAttrs> {
+  for (const obs of observations) {
+    yield obs
+  }
+}
+
+describe('mongoose observation search repository', function () {
+
+  let searchModel: ObservationSearchModel
+  let searchRepo: MongooseObservationSearchRepository
+  let event1: MageEvent
+  let event2: MageEvent
+  let formId1: number
+  let formId2: number
+  let createEvent: (attrs: MageEventCreateAttrs & Partial<MageEventAttrs>) => Promise<MageEventModelInstance>
+
+  beforeEach('initialize model', async function () {
+    const MageEventModel = legacyEvent.Model as any
+    const eventRepo = new MongooseMageEventRepository(MageEventModel)
+    createEvent = (attrs: Partial<MageEventAttrs>): Promise<MageEventModelInstance> => {
+      return new Promise<MageEventDocument>((resolve, reject) => {
+        legacyEvent.create(
+          attrs as MageEventCreateAttrs,
+          { _id: new mongoose.Types.ObjectId() },
+          (err: any | null, event?: MageEventDocument) => {
+            if (event) {
+              return resolve(event)
+            }
+            reject(err)
+          })
+      }).then(createdWithoutTeamId => {
+        return MageEventModel.findById(createdWithoutTeamId._id).then((withTeamId: any) => {
+          if (withTeamId) {
+            return withTeamId
+          }
+          throw new Error(`created event ${createdWithoutTeamId._id} now does not exist!`)
+        })
+      })
+    }
+
+    let eventDoc1 = await createEvent({ name: `Search Test Event 1 ${new mongoose.Types.ObjectId().toHexString()}`, maxObservationForms: 2 })
+    const addForm = util.promisify(legacyEvent.addForm) as (eventId: MageEventId, form: Form) => Promise<MageEventModelInstance>
+    eventDoc1 = await addForm(eventDoc1._id, {
+      id: 1,
+      archived: false,
+      name: 'Form 1',
+      color: '#aa0000',
+      fields: [
+        { type: FormFieldType.Text, id: 1, name: 'textField', title: 'Text Field', required: false },
+        { type: FormFieldType.Numeric, id: 2, name: 'numericField', title: 'Numeric Field', required: false },
+        { type: FormFieldType.DateTime, id: 3, name: 'dateField', title: 'Date Field', required: false },
+        {
+          type: FormFieldType.MultiSelectDropdown, id: 4, name: 'multiField', title: 'Multi Field', required: false,
+          choices: [ { id: 1, title: 'A', value: 1 }, { id: 2, title: 'B', value: 2 }, { id: 3, title: 'C', value: 3 } ]
+        },
+      ],
+      userFields: []
+    })
+    eventDoc1 = await addForm(eventDoc1._id, {
+      id: 2,
+      archived: false,
+      name: 'Form 2',
+      color: '#0000aa',
+      fields: [
+        { type: FormFieldType.Text, id: 1, name: 'textField', title: 'Text Field', required: false },
+      ],
+      userFields: []
+    })
+    event1 = new MageEvent(eventRepo.entityForDocument(eventDoc1))
+
+    let eventDoc2 = await createEvent({ name: `Search Test Event 2 ${new mongoose.Types.ObjectId().toHexString()}` })
+    eventDoc2 = await addForm(eventDoc2._id, {
+      id: 1,
+      archived: false,
+      name: 'Form 1',
+      color: '#00aa00',
+      fields: [
+        { type: FormFieldType.Text, id: 1, name: 'textField', title: 'Text Field', required: false },
+      ],
+      userFields: []
+    })
+    event2 = new MageEvent(eventRepo.entityForDocument(eventDoc2))
+    formId1 = event1.forms[0].id
+    formId2 = event1.forms[1].id
+
+    searchModel = (mongoose.connection.models[ObservationSearchModelName] as ObservationSearchModel) || ObservationSearchModel(mongoose.connection)
+    await searchModel.ensureIndexes()
+    searchRepo = new MongooseObservationSearchRepository(searchModel)
+  })
+
+  afterEach(async function () {
+    await legacyEvent.Model.deleteMany({})
+    if (searchModel) {
+      await searchModel.deleteMany({})
+    }
+  })
+
+  describe('save', function () {
+
+    it('indexes each form entry on the observation', async function () {
+      const obs: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: {
+          timestamp: new Date(),
+          forms: [
+            { id: '1', formId: formId1, textField: 'alpha' },
+            { id: '2', formId: formId2, textField: 'beta' }
+          ]
+        }
+      }
+      await searchRepo.save(obs)
+
+      const docs = await searchModel.find({ observationId: new mongoose.Types.ObjectId(obs.id) })
+      expect(docs).to.have.length(2)
+    })
+
+    it('replaces previously indexed entries for the observation on re-save', async function () {
+      const id = new mongoose.Types.ObjectId().toHexString()
+      const original: ObservationAttrs = {
+        ...observationStub(id, event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'original' } ] }
+      }
+      await searchRepo.save(original)
+
+      const updated: ObservationAttrs = {
+        ...observationStub(id, event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'updated' } ] }
+      }
+      await searchRepo.save(updated)
+
+      const docs = await searchModel.find({ observationId: new mongoose.Types.ObjectId(id) })
+      expect(docs).to.have.length(1)
+      expect(docs[0].textField).to.equal('updated')
+    })
+  })
+
+  describe('populate', function () {
+
+    it('indexes all observations and returns the count of form entries inserted', async function () {
+      const obs1: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'alpha' } ] }
+      }
+      const obs2: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'beta' } ] }
+      }
+
+      const count = await searchRepo.populate(event1.id, toAsyncIterable([ obs1, obs2 ]))
+
+      expect(count).to.equal(2)
+      const condition: SimpleCondition = { formId: formId1, field: 'textField', operator: 'IN', value: [ 'alpha', 'beta' ] }
+      const ids = await searchRepo.findIdsByFilter({ condition }, event1)
+      expect(ids).to.have.members([ obs1.id, obs2.id ])
+    })
+
+    it('skips already-indexed form entries on a subsequent populate without force', async function () {
+      const obs: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'alpha' } ] }
+      }
+      await searchRepo.populate(event1.id, toAsyncIterable([ obs ]))
+
+      const count = await searchRepo.populate(event1.id, toAsyncIterable([ obs ]))
+
+      expect(count).to.equal(0)
+    })
+
+    it('clears existing docs for the event and re-indexes when force is true', async function () {
+      const original: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'original' } ] }
+      }
+      await searchRepo.populate(event1.id, toAsyncIterable([ original ]))
+
+      const replacement: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'replacement' } ] }
+      }
+      const count = await searchRepo.populate(event1.id, toAsyncIterable([ replacement ]), true)
+
+      expect(count).to.equal(1)
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: '=', value: 'original' } }, event1)).to.be.empty
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: '=', value: 'replacement' } }, event1)).to.deep.equal([ replacement.id ])
+    })
+  })
+
+  describe('findIdsByFilter: keyword', function () {
+
+    it('finds an observation matching a word in a text field', async function () {
+      const matching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'hurricane damage reported' } ] }
+      }
+      const notMatching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'all clear' } ] }
+      }
+      await searchRepo.save(matching)
+      await searchRepo.save(notMatching)
+
+      const ids = await searchRepo.findIdsByFilter({ keyword: 'hurricane' }, event1)
+
+      expect(ids).to.deep.equal([ matching.id ])
+    })
+
+    it('requires all keyword terms to match (AND semantics)', async function () {
+      const matchesBoth: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'severe hurricane damage' } ] }
+      }
+      const matchesOne: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'hurricane approaching' } ] }
+      }
+      await searchRepo.save(matchesBoth)
+      await searchRepo.save(matchesOne)
+
+      const ids = await searchRepo.findIdsByFilter({ keyword: 'hurricane damage' }, event1)
+
+      expect(ids).to.deep.equal([ matchesBoth.id ])
+    })
+
+    it('matches an exact quoted phrase', async function () {
+      const matching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'this is an exact usecase for phrase search' } ] }
+      }
+      const notMatching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'usecase that is not exact' } ] }
+      }
+      await searchRepo.save(matching)
+      await searchRepo.save(notMatching)
+
+      const ids = await searchRepo.findIdsByFilter({ keyword: '"exact usecase"' }, event1)
+
+      expect(ids).to.deep.equal([ matching.id ])
+    })
+
+    it('does not find observations from a different event', async function () {
+      const obs: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'hurricane damage' } ] }
+      }
+      await searchRepo.save(obs)
+
+      const ids = await searchRepo.findIdsByFilter({ keyword: 'hurricane' }, event2)
+
+      expect(ids).to.be.empty
+    })
+
+    it('returns an empty array when the filter is empty', async function () {
+      const ids = await searchRepo.findIdsByFilter({}, event1)
+      expect(ids).to.be.empty
+    })
+  })
+
+  describe('findIdsByFilter: condition operators', function () {
+
+    it('= matches an exact text value', async function () {
+      const matching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'target' } ] }
+      }
+      const notMatching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'other' } ] }
+      }
+      await searchRepo.save(matching)
+      await searchRepo.save(notMatching)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: '=', value: 'target' } }, event1)
+
+      expect(ids).to.deep.equal([ matching.id ])
+    })
+
+    it('!= excludes an exact text value', async function () {
+      const matching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'other' } ] }
+      }
+      const notMatching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'target' } ] }
+      }
+      await searchRepo.save(matching)
+      await searchRepo.save(notMatching)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: '!=', value: 'target' } }, event1)
+
+      expect(ids).to.deep.equal([ matching.id ])
+    })
+
+    it('> >= < <= compare numeric values', async function () {
+      const low: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, numericField: 10 } ] }
+      }
+      const mid: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, numericField: 20 } ] }
+      }
+      const high: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '3', formId: formId1, numericField: 30 } ] }
+      }
+      await searchRepo.save(low)
+      await searchRepo.save(mid)
+      await searchRepo.save(high)
+
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'numericField', operator: '>', value: 20 } }, event1)).to.deep.equal([ high.id ])
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'numericField', operator: '>=', value: 20 } }, event1)).to.have.members([ mid.id, high.id ])
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'numericField', operator: '<', value: 20 } }, event1)).to.deep.equal([ low.id ])
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'numericField', operator: '<=', value: 20 } }, event1)).to.have.members([ low.id, mid.id ])
+    })
+
+    it('LIKE matches a case-insensitive substring', async function () {
+      const matching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'Bridge Collapsed' } ] }
+      }
+      const notMatching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'Road Blocked' } ] }
+      }
+      await searchRepo.save(matching)
+      await searchRepo.save(notMatching)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: 'LIKE', value: 'bridge' } }, event1)
+
+      expect(ids).to.deep.equal([ matching.id ])
+    })
+
+    it('IN and NOT IN match against a list of values', async function () {
+      const a: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'a' } ] }
+      }
+      const b: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'b' } ] }
+      }
+      const c: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '3', formId: formId1, textField: 'c' } ] }
+      }
+      await searchRepo.save(a)
+      await searchRepo.save(b)
+      await searchRepo.save(c)
+
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: 'IN', value: [ 'a', 'b' ] } }, event1)).to.have.members([ a.id, b.id ])
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: 'NOT IN', value: [ 'a', 'b' ] } }, event1)).to.deep.equal([ c.id ])
+    })
+
+    it('BETWEEN matches an inclusive numeric range', async function () {
+      const below: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, numericField: 5 } ] }
+      }
+      const within: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, numericField: 15 } ] }
+      }
+      const above: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '3', formId: formId1, numericField: 25 } ] }
+      }
+      await searchRepo.save(below)
+      await searchRepo.save(within)
+      await searchRepo.save(above)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'numericField', operator: 'BETWEEN', value: [ 10, 20 ] } }, event1)
+
+      expect(ids).to.deep.equal([ within.id ])
+    })
+
+    it('IS NULL and IS NOT NULL check for field presence', async function () {
+      const withField: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'present' } ] }
+      }
+      const withoutField: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, numericField: 1 } ] }
+      }
+      await searchRepo.save(withField)
+      await searchRepo.save(withoutField)
+
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: 'IS NULL' } }, event1)).to.deep.equal([ withoutField.id ])
+      expect(await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: 'IS NOT NULL' } }, event1)).to.deep.equal([ withField.id ])
+    })
+
+    it('compares a DateTime field using ISO8601 string values', async function () {
+      const earlier: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, dateField: new Date('2024-01-01T00:00:00Z') } ] }
+      }
+      const later: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, dateField: new Date('2024-06-01T00:00:00Z') } ] }
+      }
+      await searchRepo.save(earlier)
+      await searchRepo.save(later)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'dateField', operator: '>', value: '2024-03-01T00:00:00Z' } }, event1)
+
+      expect(ids).to.deep.equal([ later.id ])
+    })
+
+    it('= on a multi-select field matches when the value is one of the selections', async function () {
+      const matching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, multiField: [ 1, 2 ] } ] }
+      }
+      const notMatching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, multiField: [ 3 ] } ] }
+      }
+      await searchRepo.save(matching)
+      await searchRepo.save(notMatching)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'multiField', operator: '=', value: 2 } }, event1)
+
+      expect(ids).to.deep.equal([ matching.id ])
+    })
+
+    it('!= on a multi-select field excludes when the value is one of the selections', async function () {
+      const matching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, multiField: [ 3 ] } ] }
+      }
+      const notMatching: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, multiField: [ 1, 2 ] } ] }
+      }
+      await searchRepo.save(matching)
+      await searchRepo.save(notMatching)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'multiField', operator: '!=', value: 2 } }, event1)
+
+      expect(ids).to.deep.equal([ matching.id ])
+    })
+
+    it('scopes the condition to the given formId when the same field name exists on multiple forms', async function () {
+      const form1Match: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'target' } ] }
+      }
+      const form2Match: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId2, textField: 'target' } ] }
+      }
+      await searchRepo.save(form1Match)
+      await searchRepo.save(form2Match)
+
+      const ids = await searchRepo.findIdsByFilter({ condition: { formId: formId1, field: 'textField', operator: '=', value: 'target' } }, event1)
+
+      expect(ids).to.deep.equal([ form1Match.id ])
+    })
+  })
+
+  describe('findIdsByFilter: compound conditions', function () {
+
+    it('AND requires all conditions to match', async function () {
+      const matchesBoth: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'target', numericField: 42 } ] }
+      }
+      const matchesOnlyText: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'target', numericField: 99 } ] }
+      }
+      await searchRepo.save(matchesBoth)
+      await searchRepo.save(matchesOnlyText)
+
+      const condition: Condition = {
+        and: [
+          { formId: formId1, field: 'textField', operator: '=', value: 'target' },
+          { formId: formId1, field: 'numericField', operator: '=', value: 42 },
+        ]
+      }
+      const ids = await searchRepo.findIdsByFilter({ condition }, event1)
+
+      expect(ids).to.deep.equal([ matchesBoth.id ])
+    })
+
+    it('OR matches any condition', async function () {
+      const matchesText: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'target', numericField: 99 } ] }
+      }
+      const matchesNumber: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'other', numericField: 42 } ] }
+      }
+      const matchesNeither: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '3', formId: formId1, textField: 'other', numericField: 99 } ] }
+      }
+      await searchRepo.save(matchesText)
+      await searchRepo.save(matchesNumber)
+      await searchRepo.save(matchesNeither)
+
+      const condition: Condition = {
+        or: [
+          { formId: formId1, field: 'textField', operator: '=', value: 'target' },
+          { formId: formId1, field: 'numericField', operator: '=', value: 42 },
+        ]
+      }
+      const ids = await searchRepo.findIdsByFilter({ condition }, event1)
+
+      expect(ids).to.have.members([ matchesText.id, matchesNumber.id ])
+    })
+
+    it('supports a nested AND within an OR', async function () {
+      const matchesAndBranch: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'target', numericField: 42 } ] }
+      }
+      const matchesOrBranch: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'fallback', numericField: 99 } ] }
+      }
+      const matchesNeither: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '3', formId: formId1, textField: 'target', numericField: 99 } ] }
+      }
+      await searchRepo.save(matchesAndBranch)
+      await searchRepo.save(matchesOrBranch)
+      await searchRepo.save(matchesNeither)
+
+      const condition: Condition = {
+        or: [
+          { and: [
+            { formId: formId1, field: 'textField', operator: '=', value: 'target' },
+            { formId: formId1, field: 'numericField', operator: '=', value: 42 },
+          ] },
+          { formId: formId1, field: 'textField', operator: '=', value: 'fallback' },
+        ]
+      }
+      const ids = await searchRepo.findIdsByFilter({ condition }, event1)
+
+      expect(ids).to.have.members([ matchesAndBranch.id, matchesOrBranch.id ])
+    })
+  })
+
+  describe('findIdsByFilter: keyword and condition combined', function () {
+
+    it('intersects the keyword and condition matches', async function () {
+      const matchesBoth: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'hurricane', numericField: 42 } ] }
+      }
+      const matchesOnlyKeyword: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '2', formId: formId1, textField: 'hurricane', numericField: 99 } ] }
+      }
+      const matchesOnlyCondition: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '3', formId: formId1, textField: 'clear skies', numericField: 42 } ] }
+      }
+      await searchRepo.save(matchesBoth)
+      await searchRepo.save(matchesOnlyKeyword)
+      await searchRepo.save(matchesOnlyCondition)
+
+      const ids = await searchRepo.findIdsByFilter({
+        keyword: 'hurricane',
+        condition: { formId: formId1, field: 'numericField', operator: '=', value: 42 }
+      }, event1)
+
+      expect(ids).to.deep.equal([ matchesBoth.id ])
+    })
+
+    it('returns no results when the keyword matches nothing, without evaluating the condition', async function () {
+      const obs: ObservationAttrs = {
+        ...observationStub(new mongoose.Types.ObjectId().toHexString(), event1.id),
+        properties: { timestamp: new Date(), forms: [ { id: '1', formId: formId1, textField: 'clear skies', numericField: 42 } ] }
+      }
+      await searchRepo.save(obs)
+
+      const ids = await searchRepo.findIdsByFilter({
+        keyword: 'hurricane',
+        condition: { formId: formId1, field: 'numericField', operator: '=', value: 42 }
+      }, event1)
+
+      expect(ids).to.be.empty
+    })
+  })
+})

--- a/service/test/app/observations/app.observations.search.test.ts
+++ b/service/test/app/observations/app.observations.search.test.ts
@@ -1,0 +1,312 @@
+import { Substitute as Sub, Arg, SubstituteOf } from '@fluffy-spoon/substitute'
+import { expect } from 'chai'
+import uniqid from 'uniqid'
+import EventEmitter from 'events'
+import * as api from '../../../lib/app.api/observations/app.api.observations.search'
+import { IndexEventObservations, indexAllEvents, SearchIndexAllEvents, SearchIndexEvent, registerObservationSavedHandler } from '../../../lib/app.impl/observations/app.impl.observations.search'
+import { permissionDenied, MageError, ErrPermissionDenied, ErrEntityNotFound } from '../../../lib/app.api/app.api.errors'
+import { MageEvent, MageEventAttrs, MageEventRepository } from '../../../lib/entities/events/entities.events'
+import { EventScopedObservationRepository, ObservationAttrs, ObservationDomainEventType, ObservationRepositoryForEvent, ObservationSearchRepository } from '../../../lib/entities/observations/entities.observations'
+import { Logger } from '../../../lib/entities/entities.logging'
+import { AppRequestContext } from '../../../lib/app.api/app.api.global'
+
+function eventAttrsStub(overrides?: Partial<MageEventAttrs>): MageEventAttrs {
+  return {
+    id: Date.now(),
+    name: 'Search Test Event',
+    layerIds: [],
+    feedIds: [],
+    forms: [],
+    style: {},
+    acl: {},
+    ...overrides
+  }
+}
+
+function contextStub(): AppRequestContext {
+  return {
+    requestToken: uniqid(),
+    requestingPrincipal: () => 'test1',
+    locale: () => null
+  }
+}
+
+describe('observation search indexing', function() {
+
+  let eventRepo: SubstituteOf<MageEventRepository>
+  let obsRepo: SubstituteOf<EventScopedObservationRepository>
+  let searchRepo: SubstituteOf<ObservationSearchRepository>
+  let log: SubstituteOf<Logger>
+  let obsRepoFactory: ObservationRepositoryForEvent
+
+  beforeEach(function() {
+    eventRepo = Sub.for<MageEventRepository>()
+    obsRepo = Sub.for<EventScopedObservationRepository>()
+    searchRepo = Sub.for<ObservationSearchRepository>()
+    log = Sub.for<Logger>()
+    obsRepoFactory = async () => obsRepo
+  })
+
+  describe('IndexEventObservations', function() {
+
+    it('does nothing if it cannot claim the indexing operation', async function() {
+
+      const event = eventAttrsStub()
+      eventRepo.claimIndexing(event.id).resolves(false)
+      const indexEventObservations = IndexEventObservations(eventRepo, obsRepoFactory, searchRepo, log)
+
+      await indexEventObservations(event)
+
+      obsRepo.didNotReceive().iterate(Arg.any())
+      searchRepo.didNotReceive().populate(Arg.any(), Arg.any(), Arg.any())
+      eventRepo.didNotReceive().update(Arg.any())
+    })
+
+    it('populates the search index from the observation repository and marks the event indexed', async function() {
+
+      const event = eventAttrsStub()
+      const observations = { async *[Symbol.asyncIterator]() {} }
+      eventRepo.claimIndexing(event.id).resolves(true)
+      obsRepo.iterate(Arg.any()).returns(observations)
+      searchRepo.populate(event.id, observations, false).resolves(5)
+      const indexEventObservations = IndexEventObservations(eventRepo, obsRepoFactory, searchRepo, log)
+
+      await indexEventObservations(event)
+
+      searchRepo.received(1).populate(event.id, observations, false)
+      eventRepo.received(1).update({ id: event.id, observationSearchStatus: 'indexed' })
+    })
+
+    it('passes the force flag through to populate', async function() {
+
+      const event = eventAttrsStub()
+      const observations = { async *[Symbol.asyncIterator]() {} }
+      eventRepo.claimIndexing(event.id).resolves(true)
+      obsRepo.iterate(Arg.any()).returns(observations)
+      searchRepo.populate(event.id, observations, true).resolves(0)
+      const indexEventObservations = IndexEventObservations(eventRepo, obsRepoFactory, searchRepo, log)
+
+      await indexEventObservations(event, true)
+
+      searchRepo.received(1).populate(event.id, observations, true)
+    })
+
+    it('closes the observation iterable when populate finishes', async function() {
+
+      const event = eventAttrsStub()
+      let closed = false
+      const observations = { async *[Symbol.asyncIterator]() {}, close: () => { closed = true } }
+      eventRepo.claimIndexing(event.id).resolves(true)
+      obsRepo.iterate(Arg.any()).returns(observations)
+      searchRepo.populate(Arg.any(), Arg.any(), Arg.any()).resolves(0)
+      const indexEventObservations = IndexEventObservations(eventRepo, obsRepoFactory, searchRepo, log)
+
+      await indexEventObservations(event)
+
+      expect(closed).to.be.true
+    })
+
+    it('marks the event pending again if indexing throws', async function() {
+
+      const event = eventAttrsStub()
+      eventRepo.claimIndexing(event.id).resolves(true)
+      obsRepo.iterate(Arg.any()).mimicks(() => { throw new Error('boom') })
+      const indexEventObservations = IndexEventObservations(eventRepo, obsRepoFactory, searchRepo, log)
+
+      await indexEventObservations(event)
+
+      eventRepo.received(1).update({ id: event.id, observationSearchStatus: 'pending' })
+      eventRepo.didNotReceive().update({ id: event.id, observationSearchStatus: 'indexed' })
+    })
+  })
+
+  describe('indexAllEvents', function() {
+
+    it('indexes every event', async function() {
+
+      const event1 = eventAttrsStub({ id: 1 })
+      const event2 = eventAttrsStub({ id: 2 })
+      eventRepo.findAll().resolves([ event1, event2 ])
+      const indexed: MageEventAttrs[] = []
+      const indexEventObservations = async (event: MageEventAttrs) => { indexed.push(event) }
+
+      await indexAllEvents(eventRepo, indexEventObservations)
+
+      expect(indexed).to.deep.equal([ event1, event2 ])
+    })
+
+    it('resets a stale running status before indexing', async function() {
+
+      const event = eventAttrsStub({ observationSearchStatus: 'running' })
+      eventRepo.findAll().resolves([ event ])
+      const indexEventObservations = async () => {}
+
+      await indexAllEvents(eventRepo, indexEventObservations)
+
+      eventRepo.received(1).update({ id: event.id, observationSearchStatus: 'pending' })
+    })
+
+    it('does not reset status for events that are not running', async function() {
+
+      const event = eventAttrsStub({ observationSearchStatus: 'indexed' })
+      eventRepo.findAll().resolves([ event ])
+      const indexEventObservations = async () => {}
+
+      await indexAllEvents(eventRepo, indexEventObservations)
+
+      eventRepo.didNotReceive().update(Arg.any())
+    })
+
+    it('passes the force flag to each indexing call', async function() {
+
+      const event = eventAttrsStub()
+      eventRepo.findAll().resolves([ event ])
+      const forceFlags: (boolean | undefined)[] = []
+      const indexEventObservations = async (e: MageEventAttrs, force?: boolean) => { forceFlags.push(force) }
+
+      await indexAllEvents(eventRepo, indexEventObservations, true)
+
+      expect(forceFlags).to.deep.equal([ true ])
+    })
+  })
+
+  describe('SearchIndexAllEvents', function() {
+
+    let permissions: SubstituteOf<api.SearchIndexPermissionService>
+    let searchIndexAllEvents: api.SearchIndexAllEvents
+    let indexed: MageEventAttrs[]
+    let indexEventObservations: api.IndexEventObservations
+
+    beforeEach(function() {
+      permissions = Sub.for<api.SearchIndexPermissionService>()
+      indexed = []
+      indexEventObservations = async (event: MageEventAttrs) => { indexed.push(event) }
+      eventRepo.findAll().resolves([ eventAttrsStub() ])
+      searchIndexAllEvents = SearchIndexAllEvents(permissions, eventRepo, indexEventObservations)
+    })
+
+    it('fails without permission', async function() {
+
+      permissions.ensureSearchIndexAllPermission(Arg.any()).resolves(permissionDenied('search index all', 'test1'))
+      const res = await searchIndexAllEvents({ context: contextStub() })
+
+      expect(res.success).to.be.null
+      expect(res.error).to.be.instanceOf(MageError)
+      expect(res.error?.code).to.equal(ErrPermissionDenied)
+    })
+
+    it('kicks off indexing for all events and returns success', async function() {
+
+      permissions.ensureSearchIndexAllPermission(Arg.any()).resolves(null)
+
+      const res = await searchIndexAllEvents({ context: contextStub() })
+
+      expect(res.error).to.be.null
+      expect(res.success).to.deep.equal({})
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(indexed).to.have.length(1)
+    })
+  })
+
+  describe('SearchIndexEvent', function() {
+
+    let permissions: SubstituteOf<api.SearchIndexPermissionService>
+    let searchIndexEvent: api.SearchIndexEvent
+    let indexed: MageEventAttrs[]
+    let indexEventObservations: api.IndexEventObservations
+
+    beforeEach(function() {
+      permissions = Sub.for<api.SearchIndexPermissionService>()
+      indexed = []
+      indexEventObservations = async (event: MageEventAttrs) => { indexed.push(event) }
+      searchIndexEvent = SearchIndexEvent(permissions, eventRepo, indexEventObservations)
+    })
+
+    it('fails without permission', async function() {
+
+      permissions.ensureSearchIndexEventPermission(Arg.any()).resolves(permissionDenied('search index event', 'test1'))
+      const res = await searchIndexEvent({ context: contextStub(), eventId: 1 })
+
+      expect(res.success).to.be.null
+      expect(res.error?.code).to.equal(ErrPermissionDenied)
+    })
+
+    it('fails when the event does not exist', async function() {
+
+      permissions.ensureSearchIndexEventPermission(Arg.any()).resolves(null)
+      eventRepo.findById(1).resolves(null)
+      const res = await searchIndexEvent({ context: contextStub(), eventId: 1 })
+
+      expect(res.success).to.be.null
+      expect(res.error?.code).to.equal(ErrEntityNotFound)
+    })
+
+    it('kicks off indexing for the event', async function() {
+
+      const event = new MageEvent(eventAttrsStub({ id: 1 }))
+      permissions.ensureSearchIndexEventPermission(Arg.any()).resolves(null)
+      eventRepo.findById(1).resolves(event)
+
+      const res = await searchIndexEvent({ context: contextStub(), eventId: 1 })
+
+      expect(res.error).to.be.null
+      expect(res.success).to.deep.equal({})
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(indexed).to.deep.equal([ event ])
+    })
+
+    it('resets a stale running status before indexing so a crashed run does not get stuck forever', async function() {
+
+      const event = new MageEvent(eventAttrsStub({ id: 1, observationSearchStatus: 'running' }))
+      permissions.ensureSearchIndexEventPermission(Arg.any()).resolves(null)
+      eventRepo.findById(1).resolves(event)
+
+      const res = await searchIndexEvent({ context: contextStub(), eventId: 1 })
+
+      expect(res.error).to.be.null
+      eventRepo.received(1).update({ id: 1, observationSearchStatus: 'pending' })
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(indexed).to.deep.equal([ event ])
+    })
+
+    it('does not reset status when the event is not stuck running', async function() {
+
+      const event = new MageEvent(eventAttrsStub({ id: 1, observationSearchStatus: 'indexed' }))
+      permissions.ensureSearchIndexEventPermission(Arg.any()).resolves(null)
+      eventRepo.findById(1).resolves(event)
+
+      await searchIndexEvent({ context: contextStub(), eventId: 1 })
+
+      eventRepo.didNotReceive().update(Arg.any())
+    })
+  })
+
+  describe('registerObservationSavedHandler', function() {
+
+    it('saves the observation to the search repository when an ObservationSaved event fires', async function() {
+
+      const domainEvents = new EventEmitter()
+      registerObservationSavedHandler(domainEvents, searchRepo)
+
+      const observationAttrs: ObservationAttrs = {
+        id: uniqid(),
+        eventId: 1,
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [ 0, 0 ] },
+        createdAt: new Date(),
+        lastModified: new Date(),
+        properties: { timestamp: new Date(), forms: [] },
+        states: [],
+        favoriteUserIds: [],
+        attachments: [],
+      }
+      let saved: ObservationAttrs | null = null
+      searchRepo.save(Arg.any()).mimicks(async (obs: ObservationAttrs) => { saved = obs })
+
+      domainEvents.emit(ObservationDomainEventType.ObservationSaved, { type: ObservationDomainEventType.ObservationSaved, observation: observationAttrs })
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(saved).to.deep.equal(observationAttrs)
+    })
+  })
+})

--- a/service/test/permissions/permissions.observations.search.test.ts
+++ b/service/test/permissions/permissions.observations.search.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import uniqid from 'uniqid'
+import { Substitute as Sub, SubstituteOf } from '@fluffy-spoon/substitute'
+import { SearchIndexPermissionsServiceImpl } from '../../lib/permissions/permissions.observations.search'
+import { EventPermissionServiceImpl } from '../../lib/permissions/permissions.events'
+import { permissionDenied, MageError, ErrPermissionDenied } from '../../lib/app.api/app.api.errors'
+import { MageEventPermission } from '../../lib/entities/authorization/entities.permissions'
+import { AppRequestContext } from '../../lib/app.api/app.api.global'
+import { UserWithRole } from '../../lib/permissions/permissions.role-based.base'
+
+describe('search index permissions service', function() {
+
+  let eventPermissions: SubstituteOf<EventPermissionServiceImpl>
+  let permissions: SearchIndexPermissionsServiceImpl
+  let user: UserWithRole
+  let context: AppRequestContext<UserWithRole>
+
+  beforeEach(function() {
+    eventPermissions = Sub.for<EventPermissionServiceImpl>()
+    permissions = new SearchIndexPermissionsServiceImpl(eventPermissions)
+    user = {
+      id: uniqid(),
+      roleId: {
+        id: uniqid(),
+        name: 'Role 1',
+        permissions: []
+      } as any
+    } as any
+    context = {
+      requestToken: Symbol(),
+      requestingPrincipal() { return user },
+      locale() { return null }
+    }
+  })
+
+  describe('ensureSearchIndexAllPermission', function() {
+
+    it('grants access when the user role has UPDATE_EVENT permission', async function() {
+
+      user.roleId.permissions = [ MageEventPermission.UPDATE_EVENT ]
+
+      const denied = await permissions.ensureSearchIndexAllPermission(context)
+
+      expect(denied).to.be.null
+    })
+
+    it('denies access when the user role does not have UPDATE_EVENT permission', async function() {
+
+      user.roleId.permissions = []
+
+      const denied = await permissions.ensureSearchIndexAllPermission(context)
+
+      expect(denied).to.be.instanceOf(MageError)
+      expect(denied?.code).to.equal(ErrPermissionDenied)
+    })
+  })
+
+  describe('ensureSearchIndexEventPermission', function() {
+
+    it('delegates to the event permission service', async function() {
+
+      const expected = permissionDenied(MageEventPermission.UPDATE_EVENT, uniqid())
+      eventPermissions.ensureEventUpdatePermission(context).resolves(expected)
+
+      const denied = await permissions.ensureSearchIndexEventPermission(context)
+
+      expect(denied).to.equal(expected)
+    })
+
+    it('grants access when the event permission service grants access', async function() {
+
+      eventPermissions.ensureEventUpdatePermission(context).resolves(null)
+
+      const denied = await permissions.ensureSearchIndexEventPermission(context)
+
+      expect(denied).to.be.null
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add the backend search index that powers keyword and structured condition filtering on observations: a dedicated `ObservationSearch` collection (one document per form entry, with a text index for keyword search and a wildcard index for condition queries), and an aggregation-pipeline query builder that turns `Condition` AND/OR trees into Mongo `$match`/`$group`/`$expr` queries — supporting all operators (`=`, `!=`, `>`, `>=`, `<`, `<=`, `LIKE`, `IN`, `NOT IN`, `BETWEEN`, `IS NULL`, `IS NOT NULL`), DateTime field parsing, and multi-select-dropdown array semantics.
- Observations are indexed automatically on save via a domain event handler. A background boot-time task catches up any events left pending or stuck `running` from a prior crash, and admin endpoints (`POST /api/search-index/events`, `POST /api/search-index/events/:eventId`) let an admin manually trigger a full re-index of one or all events.
- This swaps in the real `ObservationSearchRepository` for the stub wired up in the read-modernization PR, turning on the keyword/condition search path in `ReadObservations`/`IterateObservations` for the first time.
- Adds `observationSearchStatus` tracking to events (`pending`/`running`/`indexed`) with an atomic `claimIndexing()` guard so two indexing runs never race on the same event, and a real `MageEventRepository.update()` that previously just threw `"method not allowed"`.

## Test plan
- [x] `tsc -b src` / `tsc -b test` compile clean
- [x] Full mocha suite passes (1211 passing, 0 failing)
- [x] New coverage: the full condition/keyword query engine (every operator, compound AND/OR, multi-select semantics, DateTime handling, cross-event/cross-form isolation), event search-status repo methods, indexing orchestration (claim/populate/mark-status, stale-lock reset, boot catch-up), permissions, and the admin web routes