### PR TITLE
fix(service): attachment upload file name check

### DIFF
--- a/service/src/app.impl/observations/app.impl.observations.ts
+++ b/service/src/app.impl/observations/app.impl.observations.ts
@@ -151,8 +151,8 @@ export function StoreAttachmentContent(permissionService: api.ObservationPermiss
       return AppResponse.error(entityNotFound(req.attachmentId, 'Attachment'))
     }
     const content = req.content
-    if (content.mediaType !== attachmentBefore.contentType || content.name !== attachmentBefore.name) {
-      const errorMessage = `attachment upload error - uploaded content name and media type ${content.name}|${content.mediaType} must match attachment ${attachmentBefore.name}|${attachmentBefore.contentType}`
+    if (content.mediaType !== attachmentBefore.contentType) {
+      const errorMessage = `attachment upload error - uploaded media type ${content.mediaType} must match attachment ${attachmentBefore.contentType}`
       return AppResponse.error(invalidInput(errorMessage))
     }
     const denied = await permissionService.ensureStoreAttachmentContentPermission(req.context, obsBefore, attachmentBefore.id)

--- a/service/test/app/observations/app.observations.test.ts
+++ b/service/test/app/observations/app.observations.test.ts
@@ -2096,7 +2096,7 @@ describe('observations use case interactions', function() {
       obsRepo.didNotReceive().save(Arg.all())
     })
 
-    it('fails if the request content name does not match', async function() {
+    it('disregards non-matching request content name', async function() {
 
       const attachment = obs.attachments[0]
       const bytesBuffer = Buffer.from('photo of something')
@@ -2112,15 +2112,17 @@ describe('observations use case interactions', function() {
         attachmentId: attachment.id,
         content,
       }
+      const attachmentPatch: AttachmentContentPatchAttrs = Object.freeze({ contentLocator: uniqid(), size: 887766 })
+      const afterStore = patchAttachment(obs, attachment.id, attachmentPatch) as Observation
       obsRepo.findById(obs.id).resolves(obs)
+      store.saveContent(bytes, req.attachmentId, obs).resolves(attachmentPatch)
+      obsRepo.patchAttachment(Arg.all()).resolves(afterStore)
       const res = await storeAttachmentContent(req)
-      const err = res.error as EntityNotFoundError
 
-      expect(res.success).to.be.null
-      expect(err).to.be.instanceOf(MageError)
-      expect(err.code).to.equal(ErrInvalidInput)
-      store.didNotReceive().saveContent(Arg.all())
-      obsRepo.didNotReceive().save(Arg.all())
+      expect(res.error).to.be.null
+      expect(res.success).to.exist
+      store.received(1).saveContent(Arg.all())
+      obsRepo.received(1).patchAttachment(Arg.all())
     })
 
     it('fails if the request media type does not match', async function() {


### PR DESCRIPTION
## Description
This PR removes the check for a matching file name between attachment meta-data registration and attachment content upload.  The check is failing on some file names because the Busboy package's Express middleware removes special characters from the file names.  This is problematic for non-English users, as Busboy removes i18n characters from file names.  The check is not really constructive as any authenticated client can upload a file with whatever name they choose.

## Test Plan
1. Ensure attachment uploads work properly from web and mobile clients.
2. Ensure Mage accepts an attachment with international characters in the file name.