### PR TITLE
CI: always run tests on push

### DIFF
--- a/.github/workflows/build_test.service.yaml
+++ b/.github/workflows/build_test.service.yaml
@@ -1,6 +1,7 @@
 name: build and test service
 
 on:
+  push:
   workflow_dispatch:
   workflow_call:
   pull_request:

--- a/.github/workflows/build_test.web-app.yaml
+++ b/.github/workflows/build_test.web-app.yaml
@@ -1,6 +1,7 @@
 name: build and test web-app
 
 on:
+  push:
   workflow_dispatch:
   workflow_call:
   pull_request:

--- a/.github/workflows/container_image.dev.yaml
+++ b/.github/workflows/container_image.dev.yaml
@@ -1,9 +1,6 @@
 name: Dev Container Build
 
 on:
-  push:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       image-tag:


### PR DESCRIPTION
This PR configures the CI workflows to build and run tests for the service and web-app packages on every push so branches get immediate test feedback without the need to submit a PR.

Additionally, CI will no longer run the container build on every push, but only on a manual workflow dispatch.