### PR TITLE
fix(web-app): Modernizing admin delete settings to support angular 21+

### DIFF
--- a/web-app/src/app/admin/admin-devices/admin-devices.module.ts
+++ b/web-app/src/app/admin/admin-devices/admin-devices.module.ts
@@ -28,14 +28,12 @@ import { AdminDeviceService } from '../services/admin-device.service';
 import { CreateDeviceDialogComponent } from './create-device/create-device.component';
 import { AdminUsersModule } from '../admin-users/admin-users.module';
 import { DeviceDetailsComponent } from './device-details/device-details.component';
-import { DeleteDeviceComponent } from './delete-device/delete-device.component';
 import { LoginsModule } from '../admin-logins/admin-logins.module';
 
 @NgModule({
     declarations: [
         DeviceDashboardComponent,
         DeviceDetailsComponent,
-        DeleteDeviceComponent,
         CreateDeviceDialogComponent,
     ],
     imports: [

--- a/web-app/src/app/admin/admin-devices/delete-device/delete-device.component.ts
+++ b/web-app/src/app/admin/admin-devices/delete-device/delete-device.component.ts
@@ -1,12 +1,21 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { Device } from '../../../entities/device/device';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @Component({
     selector: 'mage-delete-device',
     templateUrl: './delete-device.component.html',
     styleUrls: ['./delete-device.component.scss'],
-    standalone: false
+    standalone: true,
+    imports: [
+        MatDialogModule,
+        MatButtonModule,
+        MatIconModule,
+        A11yModule
+    ]
 })
 export class DeleteDeviceComponent {
     constructor(

--- a/web-app/src/app/admin/admin-event/admin-events.module.ts
+++ b/web-app/src/app/admin/admin-event/admin-events.module.ts
@@ -26,7 +26,6 @@ import { AdminBreadcrumbModule } from '../admin-breadcrumb/admin-breadcrumb.modu
 import { AdminEventFormModule } from './admin-event-form/admin-event-form.module';
 
 import { EventDetailsComponent } from './event-details/event-details.component';
-import { DeleteEventComponent } from './delete-event/delete-event.component';
 import { UploadFormDialogComponent } from './upload-form/upload-form.component';
 import { EventDashboardComponent } from './dashboard/event-dashboard.component';
 import { MatOptionModule as MatOptionModule } from '@angular/material/core';
@@ -38,7 +37,6 @@ import { CreateEventDialogComponent } from './create-event/create-event.componen
         EventDashboardComponent,
         CreateEventDialogComponent,
         EventDetailsComponent,
-        DeleteEventComponent,
         UploadFormDialogComponent
     ],
     imports: [

--- a/web-app/src/app/admin/admin-event/delete-event/delete-event.component.html
+++ b/web-app/src/app/admin/admin-event/delete-event/delete-event.component.html
@@ -16,16 +16,18 @@
         <mat-form-field appearance="fill" class="confirm-field">
             <mat-label>Type "{{ event.name }}" to confirm</mat-label>
             <input matInput type="text" [(ngModel)]="confirm.text" autocomplete="off">
-            <mat-hint *ngIf="confirm.text && event.name !== confirm.text" class="confirm-mismatch">Does not match event name</mat-hint>
+            @if (confirm.text && event.name !== confirm.text) {
+                <mat-hint class="confirm-mismatch">Does not match event name</mat-hint>
+            }
         </mat-form-field>
     </div>
 </mat-dialog-content>
 
 <mat-dialog-actions>
-    <button matButton type="button" (click)="cancel()" [disabled]="deleting" cdkFocusInitial>Cancel</button>
-    <button matButton type="button" class="delete-button" [disabled]="deleting || event.name !== confirm.text"
+    <button matButton type="button" (click)="cancel()" [disabled]="deleting()" cdkFocusInitial>Cancel</button>
+    <button matButton type="button" class="delete-button" [disabled]="deleting() || event.name !== confirm.text"
         (click)="deleteEvent()">
-        <mat-icon fontSet="material-symbols-outlined">{{ deleting ? 'progress_activity' : 'delete' }}</mat-icon>
+        <mat-icon fontSet="material-symbols-outlined">{{ deleting() ? 'progress_activity' : 'delete' }}</mat-icon>
         Delete Event
     </button>
 </mat-dialog-actions>

--- a/web-app/src/app/admin/admin-event/delete-event/delete-event.component.ts
+++ b/web-app/src/app/admin/admin-event/delete-event/delete-event.component.ts
@@ -1,7 +1,13 @@
-import { Component, Inject } from '@angular/core';
-import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Component, Inject, signal } from '@angular/core';
+import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { AdminEventsService } from '../../services/admin-events.service';
 import { MageEvent } from 'mage-web-app/entities/event/entities.event';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { A11yModule } from '@angular/cdk/a11y';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
 
 /**
  * Modal component for confirming event deletion.
@@ -11,11 +17,20 @@ import { MageEvent } from 'mage-web-app/entities/event/entities.event';
     selector: 'mage-delete-event',
     templateUrl: './delete-event.component.html',
     styleUrls: ['./delete-event.component.scss'],
-    standalone: false
+    standalone: true,
+    imports: [
+        MatDialogModule,
+        MatButtonModule,
+        MatIconModule,
+        A11yModule,
+        MatFormFieldModule,
+        MatInputModule,
+        FormsModule
+    ]
 })
 export class DeleteEventComponent {
     event: MageEvent;
-    deleting = false;
+    readonly deleting = signal(false);
     confirm: { text?: string } = {};
 
     /**
@@ -36,7 +51,7 @@ export class DeleteEventComponent {
      * Deletes the event after confirmation.
      */
     deleteEvent(): void {
-        this.deleting = true;
+        this.deleting.set(true);
 
         this.eventsService.deleteEvent(this.event.id.toString()).subscribe({
             next: () => {
@@ -44,7 +59,7 @@ export class DeleteEventComponent {
             },
             error: (error) => {
                 console.error('Error deleting event:', error);
-                this.deleting = false;
+                this.deleting.set(false);
             }
         });
     }

--- a/web-app/src/app/admin/admin-layers/admin-layers.module.ts
+++ b/web-app/src/app/admin/admin-layers/admin-layers.module.ts
@@ -24,7 +24,6 @@ import { CreateLayerDialogComponent } from './create-layer/create-layer.componen
 import { LayersService } from './layers.service';
 import { AdminBreadcrumbModule } from '../admin-breadcrumb/admin-breadcrumb.module';
 import { LayerDetailsComponent } from './layer-details/layer-details.component';
-import { DeleteLayerComponent } from './delete-layer/delete-layer.component';
 import { LayerPreviewComponent } from './layer-preview/layer-preview.component';
 import { ImageryLayerSettingsComponent } from './imagery-layer-settings/imagery-layer-settings.component';
 import { RouterModule } from '@angular/router';
@@ -34,7 +33,6 @@ import { RouterModule } from '@angular/router';
         LayerDashboardComponent,
         CreateLayerDialogComponent,
         LayerDetailsComponent,
-        DeleteLayerComponent,
         LayerPreviewComponent,
         ImageryLayerSettingsComponent,
     ],

--- a/web-app/src/app/admin/admin-layers/delete-layer/delete-layer.component.html
+++ b/web-app/src/app/admin/admin-layers/delete-layer/delete-layer.component.html
@@ -3,16 +3,18 @@
 <mat-dialog-content>
   <p>This layer will be permanently deleted and all associated data will be removed. This action cannot be undone.</p>
 
-  <div class="error-alert" *ngIf="error">
-    <mat-icon fontSet="material-symbols-outlined">error</mat-icon>
-    <span>{{ error }}</span>
-  </div>
+  @if (error()) {
+    <div class="error-alert">
+      <mat-icon fontSet="material-symbols-outlined">error</mat-icon>
+      <span>{{ error() }}</span>
+    </div>
+  }
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <button matButton type="button" (click)="cancel()" [disabled]="deleting" cdkFocusInitial>Cancel</button>
-  <button matButton type="button" class="delete-button" [disabled]="deleting" (click)="deleteLayer()">
-    <mat-icon fontSet="material-symbols-outlined">{{ deleting ? 'progress_activity' : 'delete' }}</mat-icon>
+  <button matButton type="button" (click)="cancel()" [disabled]="deleting()" cdkFocusInitial>Cancel</button>
+  <button matButton type="button" class="delete-button" [disabled]="deleting()" (click)="deleteLayer()">
+    <mat-icon fontSet="material-symbols-outlined">{{ deleting() ? 'progress_activity' : 'delete' }}</mat-icon>
     Delete Layer
   </button>
 </mat-dialog-actions>

--- a/web-app/src/app/admin/admin-layers/delete-layer/delete-layer.component.ts
+++ b/web-app/src/app/admin/admin-layers/delete-layer/delete-layer.component.ts
@@ -1,17 +1,26 @@
-import { Component, Inject } from '@angular/core';
-import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Component, Inject, signal } from '@angular/core';
+import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { LayersService, Layer } from '../layers.service';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @Component({
     selector: 'mage-delete-layer',
     templateUrl: './delete-layer.component.html',
     styleUrls: ['./delete-layer.component.scss'],
-    standalone: false
+    standalone: true,
+    imports: [
+        MatDialogModule,
+        MatIconModule,
+        MatButtonModule,
+        A11yModule,
+    ]
 })
 export class DeleteLayerComponent {
     layer: Layer;
-    deleting = false;
-    error: string | null = null;
+    readonly deleting = signal(false);
+    readonly error = signal<string | null>(null);
 
     constructor(
         public dialogRef: MatDialogRef<DeleteLayerComponent>,
@@ -22,8 +31,8 @@ export class DeleteLayerComponent {
     }
 
     deleteLayer(): void {
-        this.deleting = true;
-        this.error = null;
+        this.deleting.set(true);
+        this.error.set(null);
 
         this.layersService.deleteLayer(this.layer).subscribe({
             next: () => {
@@ -31,16 +40,16 @@ export class DeleteLayerComponent {
             },
             error: (error) => {
                 console.error('Error deleting layer:', error);
-                this.deleting = false;
+                this.deleting.set(false);
 
                 if (error.error?.message) {
-                    this.error = error.error.message;
+                    this.error.set(error.error.message);
                 } else if (error.statusText && error.status) {
-                    this.error = `Error ${error.status}: ${error.statusText}`;
+                    this.error.set(`Error ${error.status}: ${error.statusText}`);
                 } else if (error.message) {
-                    this.error = error.message;
+                    this.error.set(error.message);
                 } else {
-                    this.error = 'Failed to delete layer. Please try again.';
+                    this.error.set('Failed to delete layer. Please try again.');
                 }
             }
         });

--- a/web-app/src/app/admin/admin-teams/admin-teams.module.ts
+++ b/web-app/src/app/admin/admin-teams/admin-teams.module.ts
@@ -19,7 +19,6 @@ import { TeamDashboardComponent } from './dashboard/team-dashboard.component';
 import { CreateTeamDialogComponent } from './create-team/create-team.component';
 import { AdminEventsService } from '../services/admin-events.service';
 import { TeamDetailsComponent } from './team-details/team-details.component';
-import { DeleteTeamComponent } from './delete-team/delete-team.component';
 import { AdminBreadcrumbModule } from '../admin-breadcrumb/admin-breadcrumb.module';
 import { MatTooltipModule as MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
@@ -28,8 +27,7 @@ import { RouterModule } from '@angular/router';
     declarations: [
         TeamDashboardComponent,
         CreateTeamDialogComponent,
-        TeamDetailsComponent,
-        DeleteTeamComponent
+        TeamDetailsComponent
     ],
     imports: [
         CommonModule,

--- a/web-app/src/app/admin/admin-teams/delete-team/delete-team.component.html
+++ b/web-app/src/app/admin/admin-teams/delete-team/delete-team.component.html
@@ -7,29 +7,33 @@
         Delete all users that are part of this team
     </mat-checkbox>
 
-    <div class="danger-zone" *ngIf="deleteAllUsers" data-testid="danger-zone">
-        <h3 class="danger-zone-title">
-            <mat-icon fontSet="material-symbols-outlined">warning</mat-icon>
-            Are you absolutely sure?
-        </h3>
-        <p class="danger-zone-description">
-            This will delete <strong>all users</strong> that are part of this team, regardless of whether they are
-            in other teams. This action <strong>cannot</strong> be undone.
-        </p>
-    </div>
+    @if (deleteAllUsers) {
+        <div class="danger-zone" data-testid="danger-zone">
+            <h3 class="danger-zone-title">
+                <mat-icon fontSet="material-symbols-outlined">warning</mat-icon>
+                Are you absolutely sure?
+            </h3>
+            <p class="danger-zone-description">
+                This will delete <strong>all users</strong> that are part of this team, regardless of whether they are
+                in other teams. This action <strong>cannot</strong> be undone.
+            </p>
+        </div>
+    }
 
-    <div class="error-alert" *ngIf="error">
-        <mat-icon fontSet="material-symbols-outlined">error</mat-icon>
-        <span>{{ error }}</span>
-    </div>
+    @if (error()) {
+        <div class="error-alert">
+            <mat-icon fontSet="material-symbols-outlined">error</mat-icon>
+            <span>{{ error() }}</span>
+        </div>
+    }
 </mat-dialog-content>
 
 <mat-dialog-actions>
-    <button matButton type="button" (click)="cancel()" [disabled]="deleting" cdkFocusInitial
+    <button matButton type="button" (click)="cancel()" [disabled]="deleting()" cdkFocusInitial
         data-testid="cancel-button">Cancel</button>
-    <button matButton type="button" class="delete-button" [disabled]="deleting" (click)="deleteTeam()"
+    <button matButton type="button" class="delete-button" [disabled]="deleting()" (click)="deleteTeam()"
         data-testid="delete-button">
-        <mat-icon fontSet="material-symbols-outlined">{{ deleting ? 'progress_activity' : 'delete' }}</mat-icon>
+        <mat-icon fontSet="material-symbols-outlined">{{ deleting() ? 'progress_activity' : 'delete' }}</mat-icon>
         {{ deleteAllUsers ? 'Delete Team and Users' : 'Delete Team' }}
     </button>
 </mat-dialog-actions>

--- a/web-app/src/app/admin/admin-teams/delete-team/delete-team.component.spec.ts
+++ b/web-app/src/app/admin/admin-teams/delete-team/delete-team.component.spec.ts
@@ -36,8 +36,8 @@ describe('DeleteTeamComponent', () => {
     mockUserService = jasmine.createSpyObj('UserService', ['deleteUser']);
 
     await TestBed.configureTestingModule({
-      declarations: [DeleteTeamComponent],
       imports: [
+        DeleteTeamComponent,
         FormsModule,
         MatIconModule,
         MatButtonModule,
@@ -66,8 +66,8 @@ describe('DeleteTeamComponent', () => {
   it('should initialize with correct team data', () => {
     expect(component.team).toEqual(mockTeam);
     expect(component.deleteAllUsers).toBe(false);
-    expect(component.deleting).toBe(false);
-    expect(component.error).toBeNull();
+    expect(component.deleting()).toBe(false);
+    expect(component.error()).toBeNull();
   });
 
   it('should display team name in the title', () => {
@@ -108,7 +108,7 @@ describe('DeleteTeamComponent', () => {
   });
 
   it('should disable delete button when deleting is in progress', () => {
-    component.deleting = true;
+    component.deleting.set(true);
     component.deleteAllUsers = true;
     fixture.detectChanges();
 
@@ -130,7 +130,7 @@ describe('DeleteTeamComponent', () => {
 
     it('should set deleting to true when starting deletion', () => {
       component.deleteTeam();
-      expect(component.deleting).toBe(true);
+      expect(component.deleting()).toBe(true);
     });
 
     it('should call teamsService.deleteTeam with correct team id', () => {
@@ -161,8 +161,8 @@ describe('DeleteTeamComponent', () => {
 
       component.deleteTeam();
 
-      expect(component.deleting).toBe(false);
-      expect(component.error).toBe('Delete failed');
+      expect(component.deleting()).toBe(false);
+      expect(component.error()).toBe('Delete failed');
       expect(console.error).toHaveBeenCalledWith('Error deleting team:', error);
     });
   });
@@ -229,12 +229,6 @@ describe('DeleteTeamComponent', () => {
     });
   });
 
-  describe('ngOnInit', () => {
-    it('should be defined and not throw error', () => {
-      expect(() => component.ngOnInit()).not.toThrow();
-    });
-  });
-
   describe('Template Integration', () => {
     it('should call cancel when cancel button is clicked', () => {
       spyOn(component, 'cancel');
@@ -264,7 +258,7 @@ describe('DeleteTeamComponent', () => {
     });
 
     it('should show progress icon when deleting', () => {
-      component.deleting = true;
+      component.deleting.set(true);
       component.deleteAllUsers = true;
       fixture.detectChanges();
 
@@ -273,7 +267,7 @@ describe('DeleteTeamComponent', () => {
     });
 
     it('should show delete icon when not deleting', () => {
-      component.deleting = false;
+      component.deleting.set(false);
       component.deleteAllUsers = true;
       fixture.detectChanges();
 

--- a/web-app/src/app/admin/admin-teams/delete-team/delete-team.component.ts
+++ b/web-app/src/app/admin/admin-teams/delete-team/delete-team.component.ts
@@ -1,8 +1,13 @@
-import { Component, OnInit, Inject } from '@angular/core';
-import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Component, Inject, signal } from '@angular/core';
+import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { Team, TeamService } from '@ngageoint/mage.web-core-lib/team'
 import { Observable, forkJoin } from 'rxjs';
 import { UserService } from '../../../user/user.service';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { A11yModule } from '@angular/cdk/a11y';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { FormsModule } from '@angular/forms';
 
 /**
  * Modal component for confirming team deletion.
@@ -12,13 +17,21 @@ import { UserService } from '../../../user/user.service';
     selector: 'mage-delete-team',
     templateUrl: './delete-team.component.html',
     styleUrls: ['./delete-team.component.scss'],
-    standalone: false
+    standalone: true,
+    imports: [
+      MatDialogModule,
+      MatButtonModule,
+      MatIconModule,
+      A11yModule,
+      MatCheckboxModule,
+      FormsModule
+    ]
 })
-export class DeleteTeamComponent implements OnInit {
+export class DeleteTeamComponent {
   team: Team;
   deleteAllUsers = false;
-  deleting = false;
-  error: string | null = null;
+  readonly deleting = signal(false);
+  readonly error = signal<string | null>(null);
 
   /**
    * Constructor - initializes the component with injected services and team data.
@@ -36,14 +49,12 @@ export class DeleteTeamComponent implements OnInit {
     this.team = data.team;
   }
 
-  ngOnInit(): void {}
-
   /**
    * Deletes the team and optionally its users if the option is selected.
    */
   deleteTeam(): void {
-    this.deleting = true;
-    this.error = null;
+    this.deleting.set(true);
+    this.error.set(null);
 
     this.teamsService.deleteTeam(this.team.id.toString()).subscribe({
       next: () => {
@@ -55,16 +66,16 @@ export class DeleteTeamComponent implements OnInit {
       },
       error: (error) => {
         console.error('Error deleting team:', error);
-        this.deleting = false;
+        this.deleting.set(false);
 
         if (error.error?.message) {
-          this.error = error.error.message;
+          this.error.set(error.error.message);
         } else if (error.statusText && error.status) {
-          this.error = `Error ${error.status}: ${error.statusText}`;
+          this.error.set(`Error ${error.status}: ${error.statusText}`);
         } else if (error.message) {
-          this.error = error.message;
+          this.error.set(error.message);
         } else {
-          this.error = 'Failed to delete team. Please try again.';
+          this.error.set('Failed to delete team. Please try again.');
         }
       }
     });

--- a/web-app/src/app/admin/admin-users/admin-users.module.ts
+++ b/web-app/src/app/admin/admin-users/admin-users.module.ts
@@ -14,7 +14,6 @@ import { MatProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/m
 import { UserDetailsComponent } from './user-details/user-details.component';
 import { UserDetailsViewComponent } from './user-details/user-details-view/user-details-view.component';
 import { UserDetailsEditComponent } from './user-details/user-details-edit/user-details-edit.component';
-import { DeleteUserComponent } from './delete-user/delete-user.component';
 import { ChangePasswordComponent } from './change-password/change-password.component';
 import { LoginsModule } from '../admin-logins/admin-logins.module';
 import { UserDashboardComponent } from './dashboard/user-dashboard.component';
@@ -68,7 +67,6 @@ import { RouterModule } from '@angular/router';
     UserDetailsComponent,
     UserDetailsViewComponent,
     UserDetailsEditComponent,
-    DeleteUserComponent,
     ChangePasswordComponent,
     CreateUserModalComponent,
     BulkUserComponent,

--- a/web-app/src/app/admin/admin-users/delete-user/delete-user.component.ts
+++ b/web-app/src/app/admin/admin-users/delete-user/delete-user.component.ts
@@ -1,12 +1,21 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { User } from '../user';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @Component({
     selector: 'mage-delete-user',
     templateUrl: './delete-user.component.html',
     styleUrls: ['./delete-user.component.scss'],
-    standalone: false
+    standalone: true,
+    imports: [
+        MatDialogModule,
+        MatButtonModule,
+        MatIconModule,
+        A11yModule
+    ]
 })
 export class DeleteUserComponent {
     constructor(


### PR DESCRIPTION
**Summary**
Continues the Angular 21 migration (standalone components, new @if/@for control flow, signals) started in PR #501. This PR covers the "delete confirmation" dialog family: DeleteDeviceComponent, DeleteUserComponent, DeleteLayerComponent, DeleteEventComponent, DeleteTeamComponent.  Final piece of the admin modernization.

**Testing**
- [x] npm run build --prefix web-app — clean
- [x] Manual verification in the Admin panel for all five dialogs:
  - Devices/Users: dialog renders, Cancel/Delete both work, Cancel is focused by default
  - Layers: error banner on failed delete, buttons disable + spinner icon while in-flight
  - Events: typed-confirmation mismatch hint shows/hides correctly, gates the Delete button
  - Teams: "delete all users" checkbox toggles the danger-zone warning, error banner on failure, spinner/disable behavior while in-flight